### PR TITLE
update the CHECK_FILE

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -442,7 +442,7 @@ class UnionTechProbe(Probe):
     Simple probe for UnionTech systems in general
     """
 
-    CHECK_FILE = '/etc/UnionTech-release'
+    CHECK_FILE = '/etc/os-version'
     CHECK_FILE_CONTAINS = 'uos release'
     CHECK_FILE_DISTRO_NAME = 'uos'
     CHECK_VERSION_REGEX = re.compile(r'uos release (\d+)\.(\d+).*')


### PR DESCRIPTION
Fixed an issue where "/etc/uniontech-release" was not generic.
There are multiple distributions of UOS, and there are multiple
branches. "/etc/uniontech-release" is not universal, so it needs
to be changed.

Signed-off-by: shilei <shileib@uniontech.com>