### PR TITLE
Removal of duplicates between requirements

### DIFF
--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -35,3 +35,14 @@ class RuntimeTask:
             return '<RuntimeTask Task Identifier: "%s" Status: "%s">' % (
                 self.task.identifier,
                 self.status)
+
+    def __hash__(self):
+        if self.task.category == "test":
+            return hash(self.task.identifier)
+        return hash((str(self.task.runnable), self.task.job_id,
+                     self.task.category))
+
+    def __eq__(self, other):
+        if isinstance(other, RuntimeTask):
+            return hash(self) == hash(other)
+        return False

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -285,7 +285,8 @@ class Runner(RunnerInterface):
                 index,
                 variant,
                 job_id))
-        return runtime_tasks
+        # remove duplicates from runtime_tasks
+        return list(dict.fromkeys(runtime_tasks))
 
     def _determine_status_server_uri(self, test_suite):
         # pylint: disable=W0201


### PR DESCRIPTION
This will make `RuntimeTask` comparable. It is used for removal of
requirement duplicates from runtime_tasks list. This is part of
preparations for dependency graph from BP004.

Reference: #5202
Signed-off-by: Jan Richter <jarichte@redhat.com>