### PR TITLE
Remove distutils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
          fi
          python3 setup.py bdist_egg
          mv dist/avocado_framework-*egg /tmp
-         python3 setup.py clean --all
+         python3 setup.py clean
          python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
          cd /tmp
          python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
@@ -307,7 +307,7 @@ jobs:
          test `python3 -m avocado plugins | grep ^html | wc -l` -eq "3"
          test `python3 -m avocado plugins | grep ^robot | wc -l` -eq "1"
          python3 setup.py develop --user --uninstall
-         python3 setup.py clean --all
+         python3 setup.py clean
          python3 setup.py develop --user --skip-optional-plugins
          python3 -m avocado --version
          test `python3 -m avocado plugins | grep ^html | wc -l` -eq "0"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ pip:
 	$(PYTHON) -m pip --version || $(PYTHON) -m ensurepip $(PYTHON_DEVELOP_ARGS) || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"
 
 clean:
-	$(PYTHON) setup.py clean --all
+	$(PYTHON) setup.py clean
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ import os
 import shutil
 import sys
 from abc import abstractmethod
-from distutils.command.clean import clean
 from pathlib import Path
 from subprocess import CalledProcessError, run
 
@@ -52,7 +51,23 @@ def walk_plugins_setup_py(action, action_name=None,
         run([sys.executable, "setup.py"] + action, cwd=parent_dir, check=True)
 
 
-class Clean(clean):
+class SimpleCommand(Command):
+    """Make Command implementation simpler."""
+
+    user_options = []
+
+    @abstractmethod
+    def run(self):
+        """Run when command is invoked."""
+
+    def initialize_options(self):
+        """Set default values for options."""
+
+    def finalize_options(self):
+        """Post-process options."""
+
+
+class Clean(SimpleCommand):
     """Our custom command to get rid of junk files after build."""
 
     description = "Get rid of scratch, byte files and build stuff."
@@ -165,22 +180,6 @@ class Develop(setuptools.command.develop.develop):
                 self.handle_install()
             elif self.uninstall:
                 self.handle_uninstall()
-
-
-class SimpleCommand(Command):
-    """Make Command implementation simpler."""
-
-    user_options = []
-
-    @abstractmethod
-    def run(self):
-        """Run when command is invoked."""
-
-    def initialize_options(self):
-        """Set default values for options."""
-
-    def finalize_options(self):
-        """Post-process options."""
 
 
 class Linter(SimpleCommand):

--- a/setup.py
+++ b/setup.py
@@ -92,12 +92,6 @@ class Clean(SimpleCommand):
             if os.path.isdir(e):
                 shutil.rmtree(e)
 
-        self.clean_optional_plugins()
-
-    @staticmethod
-    def clean_optional_plugins():
-        walk_plugins_setup_py(["clean", "--all"])
-
 
 class Develop(setuptools.command.develop.develop):
     """Custom develop command."""


### PR DESCRIPTION
Make custom command 'clean' to inherit from SimpleCommand instead of the clean command from distutils.
Everything is already cleaned by the custom command. And because this,  remove the clean call for plugins as well. 
Once distutils is removed from setuptools these calls in the plugins will fail.

