### PR TITLE
instrumented_tests: add support to Coverage

### DIFF
--- a/docs/source/guides/writer/chapters/integrating.rst
+++ b/docs/source/guides/writer/chapters/integrating.rst
@@ -42,4 +42,7 @@ coverage measurement.
 
 For other options related to `Coverage.py`_, visit the software documentation.
 
+.. note:: Currently coverage support is limited working only with
+   `ProcessSpawner` (the default spawner).
+
 .. _Coverage.py: https://coverage.readthedocs.io/


### PR DESCRIPTION
nrunner spawn sub-processes to run tests which is not good for Coverage
usage. Currently coverage is not working on nrunner. With this patch, we
bring it back. We detect if we are in coverage mode and using the
Coverage API we start, stop and save the measurements if running in
Coverage mode.

Fixes #4765.

Signed-off-by: Beraldo Leal <bleal@redhat.com>