### PR TITLE
Dependency graph [BP004]  [v2]

### DIFF
--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from avocado.core.nrunner import RUNNERS_REGISTRY_PYTHON_CLASS, Task
 from avocado.core.requirements.resolver import RequirementsResolver
 from avocado.core.test_id import TestID
@@ -33,6 +35,7 @@ class RuntimeTask:
         self.spawner_handle = None
         #: The result of the spawning of a Task
         self.spawning_result = None
+        self.dependencies = []
 
     def __repr__(self):
         if self.status is None:
@@ -98,14 +101,12 @@ class RuntimeTask:
         return cls(task)
 
     @classmethod
-    def get_requirements_form_runnable(cls, runnable, test_suite_name,
-                                       status_server_uri=None, job_id=None):
+    def get_requirements_form_runnable(cls, runnable, status_server_uri=None,
+                                       job_id=None):
         """Creates runtime tasks for requirements from runnable
 
         :param runnable: the "description" of what the task should run.
         :type runnable: :class:`avocado.core.nrunner.Runnable`
-        :param test_suite_name: test suite name which this test is related to
-        :type test_suite_name: str
         :param status_server_uri: the URIs for the status servers that this
                                   task should send updates to.
         :type status_server_uri: list
@@ -126,7 +127,7 @@ class RuntimeTask:
         for requirement_runnable in requirements_runnables:
             name = '%s-%s' % (requirement_runnable.kind,
                               requirement_runnable.kwargs.get('name'))
-            prefix = '%s-%s' % (test_suite_name, name)
+            prefix = 0
             # the human UI works with TestID objects, so we need to
             # use it to name Task
             task_id = TestID(prefix, name)
@@ -142,3 +143,77 @@ class RuntimeTask:
             requirements_runtime_tasks.append(cls(requirement_task))
 
         return requirements_runtime_tasks
+
+
+class RuntimeTaskGraph:
+    """Graph representing dependencies between runtime tasks."""
+
+    def __init__(self, tests, test_suite_name, status_server_uri, job_id):
+        """Instantiates a new RuntimeTaskGraph.
+
+        From the list of tests, it will create runtime tasks and connects them
+        inside the graph by its dependencies.
+
+        :param tests: variants of runnables from test suite
+        :type tests: list
+        :param test_suite_name: test suite name which this test is related to
+        :type test_suite_name: str
+        :param status_server_uri: the URIs for the status servers that this
+                                  task should send updates to.
+        :type status_server_uri: list
+        :param job_id: the ID of the job, for authenticating messages that get
+                       sent to the destination job's status server and will
+                       make into the job's results.
+        :type job_id: str
+        """
+        self.graph = {}
+        # create graph
+        no_digits = len(str(len(tests)))
+        for index, (runnable, variant) in enumerate(tests, start=1):
+            runnable = deepcopy(runnable)
+            runtime_test = RuntimeTask.get_test_from_runnable(
+                runnable,
+                no_digits,
+                index,
+                variant,
+                test_suite_name,
+                status_server_uri,
+                job_id)
+            self.graph[runtime_test] = runtime_test
+
+            requirements_tasks = RuntimeTask.get_requirements_form_runnable(
+                runnable,
+                status_server_uri,
+                job_id)
+            self._connect_requirements_with_test(requirements_tasks,
+                                                 runtime_test)
+
+    def _connect_requirements_with_test(self, requirements, runtime_test):
+        for requirement_task in requirements:
+            if requirement_task in self.graph:
+                requirement_task = self.graph.get(requirement_task)
+            else:
+                self.graph[requirement_task] = requirement_task
+            runtime_test.task.dependencies.add(requirement_task.task)
+            runtime_test.dependencies.append(requirement_task)
+
+    def get_tasks_in_topological_order(self):
+        """Computes the topological order of runtime tasks in graph
+
+        :returns: runtime tasks in topological order
+        :rtype: list
+        """
+        def topological_order_util(vertex, visited, topological_order):
+            visited[vertex] = True
+            for v in vertex.dependencies:
+                if not visited[v]:
+                    topological_order_util(v, visited, topological_order)
+            topological_order.append(vertex)
+
+        visited = dict.fromkeys(self.graph, False)
+        topological_order = []
+
+        for vertex in self.graph.values():
+            if not visited[vertex]:
+                topological_order_util(vertex, visited, topological_order)
+        return topological_order

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -31,15 +31,11 @@ from avocado.core.messages import MessageHandler
 from avocado.core.output import LOG_JOB
 from avocado.core.plugin_interfaces import CLI, Init
 from avocado.core.plugin_interfaces import Runner as RunnerInterface
-from avocado.core.requirements.resolver import RequirementsResolver
 from avocado.core.settings import settings
 from avocado.core.status.repo import StatusRepo
 from avocado.core.status.server import StatusServer
 from avocado.core.task.runtime import RuntimeTask
 from avocado.core.task.statemachine import TaskStateMachine, Worker
-from avocado.core.test_id import TestID
-from avocado.core.tree import TreeNode
-from avocado.core.varianter import dump_variant
 
 
 class RunnerInit(Init):
@@ -174,117 +170,32 @@ class Runner(RunnerInterface):
     name = 'nrunner'
     description = 'nrunner based implementation of job compliant runner'
 
-    def _get_requirements_runtime_tasks(self, runnable, prefix, job_id):
-        if runnable.requirements is None:
-            return
+    def _get_all_runtime_tasks(self, tests, test_suite_name, job_id,
+                               status_server_uri):
+        no_digits = len(str(len(tests)))
 
-        # creates the runnables for the requirements
-        requirements_runnables = RequirementsResolver.resolve(runnable)
-        requirements_runtime_tasks = []
-        # creates the tasks and runtime tasks for the requirements
-        for requirement_runnable in requirements_runnables:
-            name = '%s-%s' % (requirement_runnable.kind,
-                              requirement_runnable.kwargs.get('name'))
-            # the human UI works with TestID objects, so we need to
-            # use it to name other tasks
-            task_id = TestID(prefix,
-                             name,
-                             None)
-            # with --dry-run we don't want to run requirement
-            if runnable.kind == 'dry-run':
-                requirement_runnable.kind = 'noop'
-            # creates the requirement task
-            requirement_task = nrunner.Task(requirement_runnable,
-                                            identifier=task_id,
-                                            status_uris=[self.status_server.uri],
-                                            category='requirement',
-                                            job_id=job_id)
-            # make sure we track the dependencies of a task
-            # runtime_task.task.dependencies.add(requirement_task)
-            # created the requirement runtime task
-            requirements_runtime_tasks.append(RuntimeTask(requirement_task))
-
-        return requirements_runtime_tasks
-
-    def _create_runtime_tasks_for_test(self, test_suite, runnable, no_digits,
-                                       index, variant, job_id):
-        """Creates runtime tasks for both tests, and for its requirements."""
-        result = []
-
-        # test related operations
-        # create test ID
-        if test_suite.name:
-            prefix = "{}-{}".format(test_suite.name, index)
-        else:
-            prefix = index
-        test_id = TestID(prefix,
-                         runnable.identifier,
-                         variant,
-                         no_digits)
-        # inject variant on runnable
-        runnable.variant = dump_variant(variant)
-
-        # handles the test task
-        task = nrunner.Task(runnable,
-                            identifier=test_id,
-                            known_runners=nrunner.RUNNERS_REGISTRY_PYTHON_CLASS,
-                            status_uris=[self.status_server.uri],
-                            job_id=job_id)
-        runtime_task = RuntimeTask(task)
-        result.append(runtime_task)
-
-        # handles the requirements
-        requirements_runtime_tasks = (
-            self._get_requirements_runtime_tasks(runnable,
-                                                 prefix,
-                                                 job_id))
-        # extend the list of tasks with the requirements runtime tasks
-        if requirements_runtime_tasks is not None:
-            for requirement_runtime_task in requirements_runtime_tasks:
-                # make sure we track the dependencies of a task
-                runtime_task.task.dependencies.add(
-                    requirement_runtime_task.task)
-            result.extend(requirements_runtime_tasks)
-
-        return result
-
-    def _get_all_runtime_tasks(self, test_suite, job_id):
         runtime_tasks = []
-        test_result_total = test_suite.variants.get_number_of_tests(test_suite.tests)
-        no_digits = len(str(test_result_total))
-        if test_suite.test_parameters:
-            paths = ['/']
-            tree_nodes = TreeNode().get_node(paths[0], True)
-            tree_nodes.value = test_suite.test_parameters
-            variant = {"variant": tree_nodes, "variant_id": None, "paths": paths}
-            test_variant = [(test, variant) for test in test_suite.tests]
-
-        else:
-            # let's use variants when parameters are not available
-            # define execution order
-            execution_order = test_suite.config.get('run.execution_order')
-            if execution_order == "variants-per-test":
-                test_variant = [(test, variant) for test in test_suite.tests
-                                for variant in test_suite.variants.itertests()]
-            elif execution_order == "tests-per-variant":
-                test_variant = [(test, variant)
-                                for variant in test_suite.variants.itertests()
-                                for test in test_suite.tests]
-
-        # decide if a copy of the runnable is needed, in case of more
-        # variants than tests
-        copy_runnable = len(test_variant) > len(test_suite.tests)
-        # create runtime tasks
-        for index, (runnable, variant) in enumerate(test_variant, start=1):
-            if copy_runnable:
-                runnable = deepcopy(runnable)
-            runtime_tasks.extend(self._create_runtime_tasks_for_test(
-                test_suite,
+        for index, (runnable, variant) in enumerate(tests, start=1):
+            runnable = deepcopy(runnable)
+            runtime_task = RuntimeTask.get_test_from_runnable(
                 runnable,
                 no_digits,
                 index,
                 variant,
-                job_id))
+                test_suite_name,
+                status_server_uri,
+                job_id)
+            requirements_tasks = RuntimeTask.get_requirements_form_runnable(
+                runnable,
+                test_suite_name,
+                status_server_uri,
+                job_id)
+            dependencies = [requirment.task
+                            for requirment in requirements_tasks]
+            runtime_task.task.dependencies = set(dependencies)
+
+            runtime_tasks.append(runtime_task)
+            runtime_tasks.extend(requirements_tasks)
         # remove duplicates from runtime_tasks
         return list(dict.fromkeys(runtime_tasks))
 
@@ -349,7 +260,11 @@ class Runner(RunnerInterface):
         self._create_status_server(test_suite, job)
 
         # pylint: disable=W0201
-        self.runtime_tasks = self._get_all_runtime_tasks(test_suite, job.unique_id)
+        self.runtime_tasks = self._get_all_runtime_tasks(
+            test_suite.get_test_variants(),
+            test_suite.name,
+            job.unique_id,
+            self.status_server.uri)
 
         # Start the status server
         asyncio.ensure_future(self.status_server.serve_forever())

--- a/selftests/unit/test_task_runtime.py
+++ b/selftests/unit/test_task_runtime.py
@@ -1,7 +1,40 @@
+import os
 from unittest import TestCase
 
 from avocado.core.nrunner import Runnable, Task
-from avocado.core.task.runtime import RuntimeTask
+from avocado.core.suite import TestSuite
+from avocado.core.task.runtime import RuntimeTask, RuntimeTaskGraph
+from avocado.utils import script
+from selftests.utils import TestCaseTmpDir
+
+SINGLE_REQUIREMENT = '''from avocado import Test
+class SuccessTest(Test):
+    def test_a(self):
+       pass
+    def test_b(self):
+        """
+        :avocado: requirement={"type": "package", "name": "hello"}
+        """
+    def test_c(self):
+        """
+        :avocado: requirement={"type": "package", "name": "hello"}
+        """
+'''
+
+MULTIPLE_REQUIREMENT = '''from avocado import Test
+class FailTest(Test):
+    def test_a(self):
+        """
+        :avocado: requirement={"type": "package", "name": "hello"}
+        """
+    def test_b(self):
+        pass
+    def test_c(self):
+        """
+        :avocado: requirement={"type": "package", "name": "hello"}
+        :avocado: requirement={"type": "package", "name": "-foo-bar-"}
+        """
+'''
 
 
 class Runtime(TestCase):
@@ -22,3 +55,44 @@ class Runtime(TestCase):
         self.assertEqual(self.runtime_task.task.runnable.kind, 'noop')
         self.assertEqual(self.runtime_task.task.runnable.uri, 'noop')
         self.assertEqual(self.runtime_task.status, 'LOST CONTACT')
+
+
+class DependencyGraph(TestCaseTmpDir):
+
+    def test_one_requirement(self):
+        with script.Script(os.path.join(self.tmpdir.name,
+                                        'test_single_requirement.py'),
+                           SINGLE_REQUIREMENT) as test:
+            config = {'resolver.references': [test.path]}
+            suite = TestSuite.from_config(config=config)
+            tests = suite.get_test_variants()
+            graph = RuntimeTaskGraph(tests, suite.name, 1, "")
+            runtime_tests = graph.get_tasks_in_topological_order()
+            self.assertTrue(
+                runtime_tests[0].task.identifier.name.endswith("test_a"))
+            self.assertTrue(
+                runtime_tests[1].task.identifier.name.endswith("hello"))
+            self.assertTrue(
+                runtime_tests[2].task.identifier.name.endswith("test_b"))
+            self.assertTrue(
+                runtime_tests[3].task.identifier.name.endswith("test_c"))
+
+    def test_multiple_requirement(self):
+        with script.Script(os.path.join(self.tmpdir.name,
+                                        'test_multiple_requirement.py'),
+                           MULTIPLE_REQUIREMENT) as test:
+            config = {'resolver.references': [test.path]}
+            suite = TestSuite.from_config(config=config)
+            tests = suite.get_test_variants()
+            graph = RuntimeTaskGraph(tests, suite.name, 1, "")
+            runtime_tests = graph.get_tasks_in_topological_order()
+            self.assertTrue(
+                runtime_tests[0].task.identifier.name.endswith("hello"))
+            self.assertTrue(
+                runtime_tests[1].task.identifier.name.endswith("test_a"))
+            self.assertTrue(
+                runtime_tests[2].task.identifier.name.endswith("test_b"))
+            self.assertTrue(
+                runtime_tests[3].task.identifier.name.endswith("-foo-bar-"))
+            self.assertTrue(
+                runtime_tests[4].task.identifier.name.endswith("test_c"))


### PR DESCRIPTION
This PR introduces the dependency graph from BP004. It connects
RuntimeTasks by its dependencies and sorts them by topological order in
the DependencyGraph. The avocado functionality stays the same, but this
topology will make it easier to implement features from BP004 like pre,
post test tasks.

Reference: #5203
Signed-off-by: Jan Richter jarichte@redhat.com