### PR TITLE
fixes test.id vs test.name on jsonresult and xunit plugins

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -24,6 +24,7 @@ from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
 from avocado.core.plugin_interfaces import CLI, Init, Result
 from avocado.core.settings import settings
+from avocado.core.test_id import TestID
 from avocado.utils import astring
 
 UNKNOWN = '<unknown>'
@@ -42,7 +43,12 @@ class JSONResult(Result):
             if fail_reason is not None:
                 fail_reason = astring.to_text(fail_reason)
             tags = test.get('tags') or {}
-            tests.append({'id': str(test.get('name', UNKNOWN)),
+            # Actually we are saving the TestID() there.
+            test_id = test.get('name', UNKNOWN)
+            if isinstance(test_id, TestID):
+                name = test_id.name
+            tests.append({'id': str(test_id),
+                          'name': str(name),
                           'start': test.get('time_start', -1),
                           'end': test.get('time_end', -1),
                           'time': test.get('time_elapsed', -1),

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -24,6 +24,7 @@ from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
 from avocado.core.plugin_interfaces import CLI, Init, Result
 from avocado.core.settings import settings
+from avocado.core.test_id import TestID
 from avocado.utils import astring
 from avocado.utils.data_structures import DataSize
 
@@ -56,7 +57,11 @@ class XUnitResult(Result):
     def _create_testcase_element(self, document, state):
         testcase = document.createElement('testcase')
         testcase.setAttribute('classname', self._get_attr(state, 'class_name'))
-        testcase.setAttribute('name', self._get_attr(state, 'name'))
+        name = state.get('name')
+        if isinstance(name, TestID):
+            testcase.setAttribute('name', self._escape_attr(name.name))
+        else:
+            testcase.setAttribute('name', self._get_attr(state, 'name'))
         testcase.setAttribute('time', self._format_time(self._get_attr(state, 'time_elapsed')))
         return testcase
 


### PR DESCRIPTION
According to our documentation, 'name' should be only the 'name' portion
of the test, without the prefix identifier. Besides being consistent
with out documentation, this will help third-party tools and future
plugins to detect flaky tests when the same test is executed in a
different suite. Related to #5116.
    
Signed-off-by: Beraldo Leal <bleal@redhat.com>