### PR TITLE
display failed tests at the end of a run

### DIFF
--- a/avocado/plugins/testlogs.py
+++ b/avocado/plugins/testlogs.py
@@ -43,6 +43,9 @@ class TestLogsUI(JobPre, JobPost):
         if not statuses:
             return
 
+        if job.config.get('stdout_claimed_by') is not None:
+            return
+
         try:
             with open(os.path.join(job.logdir, 'results.json'), encoding='utf-8') as json_file:
                 results = json.load(json_file)


### PR DESCRIPTION
This will improve the readability when running multiple tests inside a
CI job without the need to run a second command or grep to find failed
tests. This is related to: #5200

Signed-off-by: Beraldo Leal <bleal@redhat.com>