### PR TITLE
utils/test_network: fixed test on ipv6 disabled

### DIFF
--- a/selftests/unit/utils/test_network.py
+++ b/selftests/unit/utils/test_network.py
@@ -83,7 +83,7 @@ class FreePort(unittest.TestCase):
                             good.append("%s, %s, %s" % (family, protocol,
                                                         addr))
                     except Exception as exc:
-                        if getattr(exc, 'errno', None) in (-2, 2, 22, 94):
+                        if getattr(exc, 'errno', None) in (-2, 2, 22, 94, 99):
                             skip.append("%s, %s, %s: Not supported: %s"
                                         % (family, protocol, addr, exc))
                         else:


### PR DESCRIPTION
Currently, this test is failing when IPV6 is disabled on the host
machine. Since we currently lack a proper skipIf decorator here, I'm
using the already defined catch/logic to ignore when IPv6 is not
supported.

Signed-off-by: Beraldo Leal <bleal@redhat.com>