### PR TITLE
docs/source/releases/94_0.rst: trivial fix for module reference

### DIFF
--- a/docs/source/releases/94_0.rst
+++ b/docs/source/releases/94_0.rst
@@ -42,9 +42,9 @@ Bug Fixes
 Utility APIs
 ============
 
-* mod:`avocado.utils.network` removed deprecated modules and methods.
+* :mod:`avocado.utils.network` removed deprecated modules and methods.
 
-* mod:`avocado.utils.vmimage` now uses https://cloud.debian.org for
+* :mod:`avocado.utils.vmimage` now uses https://cloud.debian.org for
   obtaining Debian Cloud images.
 
 Misc Changes


### PR DESCRIPTION
The reference to the utils module is broken because the Sphinx module
tag is missing a leading colon.

Signed-off-by: Cleber Rosa <crosa@redhat.com>