### PR TITLE
bandit: fixes empty output file

### DIFF
--- a/Makefile.gh
+++ b/Makefile.gh
@@ -23,7 +23,7 @@ codespell:
 
 bandit:
 	pip install bandit
-	bandit -o bandit-output.txt -r --skip B101,B105,B311,B404,B603 .
+	bandit -f txt -o bandit-output.txt -r --skip B101,B105,B311,B404,B603 .
 
 
 propagate-version:


### PR DESCRIPTION
Currently when running make -f Makefile.gh bandit it is not producing
any data inside output file because of the default format. Bandit
suggests using -f txt for that.

Signed-off-by: Beraldo Leal <bleal@redhat.com>