### PR TITLE
packit: add centos stream 8 & 9

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -6,3 +6,5 @@ jobs:
     metadata:
       targets:
       - fedora-all
+      - centos-stream-8
+      - centos-stream-9


### PR DESCRIPTION
Add centos stream 8 and 9 to packit.

References: https://github.com/avocado-framework/avocado/issues/5261
