### PR TITLE
contrib,examples: switch to Python f-strings

### DIFF
--- a/contrib/scripts/avocado-get-job-results-dir.py
+++ b/contrib/scripts/avocado-get-job-results-dir.py
@@ -31,8 +31,7 @@ if __name__ == '__main__':
 
     resultsdir = data_dir.get_job_results_dir(sys.argv[1])
     if resultsdir is None:
-        sys.stderr.write("Can't find job results directory for '%s'\n" %
-                         sys.argv[1])
+        sys.stderr.write(f"Can't find job results directory for '{sys.argv[1]}'\n")
         sys.exit(-1)
 
-    sys.stdout.write('%s\n' % resultsdir)
+    sys.stdout.write(f'{resultsdir}\n')

--- a/contrib/scripts/summarize-job-failures.py
+++ b/contrib/scripts/summarize-job-failures.py
@@ -25,8 +25,7 @@ def get_one_job_results(path, results):
             # used as the baseline for the set of tests that should be
             # present on every job
             if test_id not in results:
-                print('Test ID "%s" is not present in a previous job, aborting'
-                      % test_id)
+                print(f'Test ID "{test_id}" is not present in a previous job, aborting')
                 sys.exit(1)
         status = test['status']
         job[test_id] = status
@@ -55,7 +54,7 @@ def main():
             any_failure = True
             print(test)
             for status, count in all_job_results[test].items():
-                print("  - %s: %s" % (status, count))
+                print(f"  - {status}: {count}")
     print('Jobs analyzed:', number_of_jobs, '(all PASSed)' if not any_failure else '')
 
 

--- a/contrib/scripts/vmimage-populate-cache.py
+++ b/contrib/scripts/vmimage-populate-cache.py
@@ -19,7 +19,7 @@ KNOWN_IMAGES = (
 def main():
     for image in KNOWN_IMAGES:
         name, version, arch, checksum, algorithm = image
-        print("%s version %s (%s): " % (name, version, arch), end='')
+        print(f"{name} version {version} ({arch}): ", end='')
         cache_dir = settings.as_dict().get('datadir.paths.cache_dirs')[0]
         download = vmimage.get(name=name, version=version, arch=arch,
                                checksum=checksum, algorithm=algorithm,

--- a/examples/plugins/job-pre-post/mail/avocado_job_mail.py
+++ b/examples/plugins/job-pre-post/mail/avocado_job_mail.py
@@ -47,9 +47,7 @@ class Mail(JobPre, JobPost):
         sender = job.config.get('plugins.job.mail.sender')
         server = job.config.get('plugins.job.mail.server')
         # build proper subject based on job status
-        subject = '%s Job %s - Status: %s' % (header,
-                                              job.unique_id,
-                                              job.status)
+        subject = f'{header} Job {job.unique_id} - Status: {job.status}'
         msg = MIMEText(subject)
         msg['Subject'] = subject
         msg['From'] = sender

--- a/examples/plugins/job-pre-post/mail/setup.py
+++ b/examples/plugins/job-pre-post/mail/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 name = 'avocado_job_mail'
 init_klass = 'MailInit'
 klass = 'Mail'
-entry_point = '%s = %s:%s' % (name, name, klass)
-init_entry_point = '%s = %s:%s' % (name, name, init_klass)
+entry_point = f'{name} = {name}:{klass}'
+init_entry_point = f'{name} = {name}:{init_klass}'
 
 if __name__ == '__main__':
     setup(name=name,

--- a/examples/plugins/job-pre-post/sleep/setup.py
+++ b/examples/plugins/job-pre-post/sleep/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 name = 'avocado_job_sleep'
 init_klass = 'SleepInit'
 klass = 'Sleep'
-entry_point = '%s = %s:%s' % (name, name, klass)
-init_entry_point = '%s = %s:%s' % (name, name, init_klass)
+entry_point = f'{name} = {name}:{klass}'
+init_entry_point = f'{name} = {name}:{init_klass}'
 
 if __name__ == '__main__':
     setup(name=name,

--- a/examples/plugins/tests/magic/avocado_magic/resolver.py
+++ b/examples/plugins/tests/magic/avocado_magic/resolver.py
@@ -35,7 +35,7 @@ class MagicResolver(Resolver):
             return ReferenceResolution(
                 reference,
                 ReferenceResolutionResult.NOTFOUND,
-                info='Word "%s" is not a valid magic word' % (reference))
+                info=f'Word "{reference}" is not a valid magic word')
 
         return ReferenceResolution(reference,
                                    ReferenceResolutionResult.SUCCESS,

--- a/examples/plugins/tests/magic/setup.py
+++ b/examples/plugins/tests/magic/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup
 
 name = 'magic'
 module = 'avocado_magic'
-resolver_ep = '%s = %s.resolver:%s' % (name, module, 'MagicResolver')
-discoverer_ep = '%s = %s.resolver:%s' % (name, module, 'MagicDiscoverer')
-runner_ep = '%s = %s.runner:%s' % (name, module, 'MagicRunner')
-runner_script = 'avocado-runner-%s = %s.runner:main' % (name, module)
+resolver_ep = f"{name} = {module}.resolver:MagicResolver"
+discoverer_ep = f"{name} = {module}.resolver:MagicDiscoverer"
+runner_ep = f"{name} = {module}.runner:MagicRunner"
+runner_script = f'avocado-runner-{name} = {module}.runner:main'
 
 
 if __name__ == '__main__':

--- a/examples/tests/assets.py
+++ b/examples/tests/assets.py
@@ -32,15 +32,13 @@ class Hello(Test):
     @fail_on(process.CmdError)
     def test_gpg_signature(self):
         keyring = os.path.join(self.workdir, "tempring.gpg")
-        gpg_cmd = "gpg --no-default-keyring --keyring %s" % keyring
+        gpg_cmd = f"gpg --no-default-keyring --keyring {keyring}"
         signer_pubkey = self.get_data("gnu_hello_signer.gpg")
-        import_cmd = "%s --import %s" % (gpg_cmd, signer_pubkey)
+        import_cmd = f"{gpg_cmd} --import {signer_pubkey}"
         # gpg will not return 0 when creating a new keyring and
         # importing the public key
         process.run(import_cmd, ignore_status=True)
-        verify_cmd = "%s --verify %s %s" % (gpg_cmd,
-                                            self.hello_sig,
-                                            self.hello)
+        verify_cmd = f"{gpg_cmd} --verify {self.hello_sig} {self.hello}"
         process.run(verify_cmd)
 
     @fail_on(process.CmdError)

--- a/examples/tests/cabort.py
+++ b/examples/tests/cabort.py
@@ -20,7 +20,7 @@ class CAbort(Test):
         source = self.params.get('source', default='abort.c')
         c_file = self.get_data(source)
         if c_file is None:
-            self.cancel('Test is missing data file %s' % source)
+            self.cancel(f'Test is missing data file {source}')
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.workdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/datadir.py
+++ b/examples/tests/datadir.py
@@ -20,7 +20,7 @@ class DataDirTest(Test):
         source = self.params.get('source', default='datadir.c')
         c_file = self.get_data(source)
         if c_file is None:
-            self.cancel('Test is missing data file %s' % source)
+            self.cancel(f'Test is missing data file {source}')
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.workdir, c_file_name)
         shutil.copy(c_file, dest_c_file)

--- a/examples/tests/gdbtest.py
+++ b/examples/tests/gdbtest.py
@@ -30,16 +30,14 @@ class GdbTest(Test):
             return99_source_path = self.get_data('return99.c')
             if return99_source_path is None:
                 self.cancel('Test is missing data file "return99.c"')
-            process.system('gcc -O0 -g %s -o %s' % (return99_source_path,
-                                                    self.return99_binary_path))
+            process.system(f'gcc -O0 -g {return99_source_path} -o {self.return99_binary_path}')
 
         self.segfault_binary_path = os.path.join(self.teststmpdir, 'segfault')
         if not os.path.exists(self.segfault_binary_path):
             segfault_source_path = self.get_data('segfault.c')
             if segfault_source_path is None:
                 self.cancel('Test is missing data file "segfault.c"')
-            process.system('gcc -O0 -g %s -o %s' % (segfault_source_path,
-                                                    self.segfault_binary_path))
+            process.system(f'gcc -O0 -g {segfault_source_path} -o {self.segfault_binary_path}')
 
     @staticmethod
     def is_process_alive(process):  # pylint: disable=W0621
@@ -73,14 +71,14 @@ class GdbTest(Test):
         g = gdb.GDB()
         self.log.info("Testing existing (valid) GDB commands using raw commands")
         for cmd in self.VALID_CMDS:
-            info_cmd = "-info-gdb-mi-command %s" % cmd[1:]
+            info_cmd = f"-info-gdb-mi-command {cmd[1:]}"
             r = g.cmd(info_cmd)
             self.assertEqual(r.result.result.command.exists, 'true')
 
         self.log.info("Testing non-existing (invalid) GDB commands using raw "
                       "commands")
         for cmd in self.INVALID_CMDS:
-            info_cmd = "-info-gdb-mi-command %s" % cmd[1:]
+            info_cmd = f"-info-gdb-mi-command {cmd[1:]}"
             r = g.cmd(info_cmd)
             self.assertEqual(r.result.result.command.exists, 'false')
 
@@ -105,7 +103,7 @@ class GdbTest(Test):
         self.log.info("Testing that GDB loads a file and sets a breakpoint")
         g = gdb.GDB()
 
-        file_cmd = "-file-exec-and-symbols %s" % self.return99_binary_path
+        file_cmd = f"-file-exec-and-symbols {self.return99_binary_path}"
         r = g.cmd(file_cmd)
         self.assertEqual(r.result.class_, 'done')
 
@@ -145,7 +143,7 @@ class GdbTest(Test):
         self.log.info("Testing that a core dump will be generated")
 
         g = gdb.GDB()
-        file_cmd = "-file-exec-and-symbols %s" % self.segfault_binary_path
+        file_cmd = f"-file-exec-and-symbols {self.segfault_binary_path}"
         r = g.cmd(file_cmd)
         self.assertEqual(r.result.class_, 'done')
 
@@ -160,8 +158,8 @@ class GdbTest(Test):
             if (hasattr(parsed_msg, 'class_') and
                 (parsed_msg.class_ == 'stopped') and
                     (parsed_msg.result.signal_name == 'SIGSEGV')):
-                core_path = "%s.core" % self.segfault_binary_path
-                gcore_cmd = 'gcore %s' % core_path
+                core_path = f"{self.segfault_binary_path}.core"
+                gcore_cmd = f'gcore {core_path}'
                 gcore_cmd = gdb.encode_mi_cli(gcore_cmd)
                 r = g.cmd(gcore_cmd)
                 self.assertEqual(r.result.class_, 'done')
@@ -191,14 +189,14 @@ class GdbTest(Test):
 
         # Do 100 cycle of target (kind of connects) and disconnects
         for _ in range(0, 100):
-            cmd = '-target-select extended-remote :%s' % s.port
+            cmd = f'-target-select extended-remote :{s.port}'
             r = g.cmd(cmd)
             self.assertEqual(r.result.class_, 'connected')
             r = g.cmd('-target-disconnect')
             self.assertEqual(r.result.class_, 'done')
 
         # manual server shutdown
-        cmd = '-target-select extended-remote :%s' % s.port
+        cmd = f'-target-select extended-remote :{s.port}'
         r = g.cmd(cmd)
         self.assertEqual(r.result.class_, 'connected')
         r = g.cli_cmd('monitor exit')
@@ -234,15 +232,15 @@ class GdbTest(Test):
         s = gdb.GDBServer()
         g = gdb.GDB()
 
-        cmd = '-file-exec-and-symbols %s' % self.return99_binary_path
+        cmd = f'-file-exec-and-symbols {self.return99_binary_path}'
         r = g.cmd(cmd)
         self.assertEqual(r.result.class_, 'done')
 
-        cmd = 'set remote exec-file %s' % self.return99_binary_path
+        cmd = f'set remote exec-file {self.return99_binary_path}'
         r = g.cmd(cmd)
         self.assertEqual(r.result.class_, 'done')
 
-        cmd = "-break-insert %s" % 'main'
+        cmd = f"-break-insert {'main'}"
         r = g.cmd(cmd)
         self.assertEqual(r.result.class_, 'done')
 
@@ -318,7 +316,7 @@ class GdbTest(Test):
         self.assertTrue(os.path.exists(s.stderr_path))
 
         stderr_lines = genio.read_all_lines(s.stderr_path)
-        listening_line = "Listening on port %s" % s.port
+        listening_line = f"Listening on port {s.port}"
         self.assertIn(listening_line, stderr_lines)
 
     def test_server_stdout(self):

--- a/examples/tests/linuxbuild.py
+++ b/examples/tests/linuxbuild.py
@@ -21,7 +21,7 @@ class LinuxBuildTest(Test):
         if linux_config is not None:
             linux_config = self.get_data(linux_config)
         if linux_config is None:
-            self.cancel('Test is missing data file %s' % linux_config)
+            self.cancel(f'Test is missing data file {linux_config}')
 
         self.linux_build = kernel.KernelBuild(kernel_version,
                                               linux_config,

--- a/examples/tests/modify_variable.py
+++ b/examples/tests/modify_variable.py
@@ -27,7 +27,7 @@ class PrintVariableTest(Test):
         source = self.params.get('source', default='print_variable.c')
         c_file = self.get_data(source)
         if c_file is None:
-            self.cancel('Test is missing data file %s' % source)
+            self.cancel(f'Test is missing data file {source}')
         shutil.copy(c_file, self.workdir)
         self.__binary = source.rsplit('.', 1)[0]
         build.make(self.workdir,

--- a/examples/tests/multiplextest.py
+++ b/examples/tests/multiplextest.py
@@ -61,12 +61,10 @@ class MultiplexTest(Test):
                       self.params.get('sync_tries', default=3))
 
         self.log.info('Executing ping test...')
-        cmdline = ('ping --timeout %s --tries %s'
-                   % (self.params.get('ping_timeout', default=10),
-                      self.params.get('ping_tries', default=5)))
+        cmdline = f"ping --timeout {self.params.get('ping_timeout', default=10)} --tries {self.params.get('ping_tries', default=5)}"
 
         ping_flags = self.params.get('ping_flags')
         if ping_flags:
-            cmdline += ' %s' % ping_flags
+            cmdline += f' {ping_flags}'
 
         self.log.info(cmdline)

--- a/examples/tests/raise.py
+++ b/examples/tests/raise.py
@@ -21,7 +21,7 @@ class Raise(Test):
         source = self.params.get('source', default='raise.c')
         c_file = self.get_data(source)
         if c_file is None:
-            self.cancel('Test is missing data file %s' % source)
+            self.cancel(f'Test is missing data file {source}')
         c_file_name = os.path.basename(c_file)
         dest_c_file = os.path.join(self.workdir, c_file_name)
         shutil.copy(c_file, dest_c_file)
@@ -34,7 +34,7 @@ class Raise(Test):
         Execute 'raise'.
         """
         signum = self.params.get('signal_number', default=15)
-        cmd = os.path.join(self.workdir, 'raise %d' % signum)
+        cmd = os.path.join(self.workdir, f'raise {signum}')
         cmd_result = process.run(cmd, ignore_status=True)
         self.log.info(cmd_result)
         if signum == 0:

--- a/examples/tests/sleeptenmin.py
+++ b/examples/tests/sleeptenmin.py
@@ -29,4 +29,4 @@ class SleepTenMin(Test):
             if method == 'builtin':
                 time.sleep(length)
             elif method == 'shell':
-                os.system("sleep %s" % length)
+                os.system(f"sleep {length}")

--- a/examples/tests/synctest.py
+++ b/examples/tests/synctest.py
@@ -25,7 +25,7 @@ class SyncTest(Test):
         sync_tarball = self.params.get('sync_tarball', '*', 'synctest.tar.bz2')
         tarball_path = self.get_data(sync_tarball)
         if tarball_path is None:
-            self.cancel('Test is missing data file %s' % tarball_path)
+            self.cancel(f'Test is missing data file {tarball_path}')
         archive.extract(tarball_path, self.workdir)
         srcdir = os.path.join(self.workdir, 'synctest')
         os.chdir(srcdir)
@@ -41,8 +41,6 @@ class SyncTest(Test):
         Execute synctest with the appropriate params.
         """
         path = os.path.join(os.getcwd(), 'synctest')
-        cmd = ('%s %s %s' %
-               (path, self.params.get('sync_length', default=100),
-                self.params.get('sync_loop', default=10)))
+        cmd = f"{path} {self.params.get('sync_length', default=100)} {self.params.get('sync_loop', default=10)}"
         process.system(cmd)
         os.chdir(self.cwd)

--- a/examples/tests/test_env.py
+++ b/examples/tests/test_env.py
@@ -12,7 +12,7 @@ class Env(Test):
         Logs information about the environment under which the test is executed
         """
         pid = os.getpid()
-        p_dir = '/proc/%d' % pid
+        p_dir = f'/proc/{pid}'
 
         def get_proc_content(rel_path):
             try:
@@ -42,8 +42,8 @@ class Env(Test):
         log_std_io('stdout', sys.stdout)
         log_std_io('stderr', sys.stdout)
 
-        fd_dir = '/proc/%s/fd' % pid
-        if os.path.isdir('/proc/%s/fd' % pid):
+        fd_dir = f'/proc/{pid}/fd'
+        if os.path.isdir(f'/proc/{pid}/fd'):
             fds = os.listdir(fd_dir)
             self.log.debug('Open file descriptors:')
             for fd in fds:

--- a/examples/tests/vm-cleanup.py
+++ b/examples/tests/vm-cleanup.py
@@ -71,12 +71,12 @@ class VMCleanup(Test):
                '--vm-host=%s')
         cmd %= (self.tmpdir, vm_domain, vm_host)
         if vm_username:
-            cmd += ' --vm-username=%s' % vm_username
+            cmd += f' --vm-username={vm_username}'
         if vm_password:
-            cmd += ' --vm-password=%s' % vm_password
+            cmd += f' --vm-password={vm_password}'
 
-        cmd_clean = '%s %s' % (cmd, self.clean_test_path)
-        cmd_dirty = '%s --vm-cleanup %s' % (cmd, self.dirty_test_path)
+        cmd_clean = f'{cmd} {self.clean_test_path}'
+        cmd_dirty = f'{cmd} --vm-cleanup {self.dirty_test_path}'
 
         process.run(cmd_clean)
         process.run(cmd_dirty)


### PR DESCRIPTION
I made a semi-automatic update to f-strings to all the files under `contrib` and `examples`

References: https://github.com/avocado-framework/avocado/issues/5219

