### PR TITLE
fixing lv_remove() fails by using obsolute path of lv

### DIFF
--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -475,7 +475,7 @@ def lv_remove(vg_name, lv_name):
     if not lv_check(vg_name, lv_name):
         raise LVException("Logical volume could not be found")
 
-    cmd = "lvremove -f %s/%s" % (vg_name, lv_name)
+    cmd = "lvremove -f /dev/%s/%s" % (vg_name, lv_name)
     process.run(cmd, sudo=True)
 
 


### PR DESCRIPTION
current code is failing to remove the lv with just vg/lv name format.
So changed the lv path to its obsolute path like /dev/vg/lv format,
and it worked fine.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>