### PR TITLE
Makefile.gh / bandit: write to the screen only

### DIFF
--- a/Makefile.gh
+++ b/Makefile.gh
@@ -23,7 +23,7 @@ codespell:
 
 bandit:
 	pip install bandit
-	bandit -o bandit-output.txt -r --skip B101,B105,B311,B404,B603 .
+	bandit -r --skip B101,B105,B311,B404,B603 .
 
 
 propagate-version:


### PR DESCRIPTION
First, at least with bandit 1.7.2 and 1.7.3, the current command is
broken and reports:

   INFO    Screen formatter output was not written to file:
           bandit-output.txt, consider '-f txt'

Given that the action will be primary used by CI or interactive users,
the content on the stdout (screen output) is good enough.

Second, writing to the source directory root should be avoided.

Signed-off-by: Cleber Rosa <crosa@redhat.com>