### PR TITLE
selftests: switch to Python f-strings

### DIFF
--- a/selftests/check.py
+++ b/selftests/check.py
@@ -116,7 +116,7 @@ class JobAPIFeaturesTest(Test):
 
         # Asserts
         self.check_exit_code(result)
-        archive_path = '%s.zip' % logdir
+        archive_path = f'{logdir}.zip'
         self.check_file_exists(archive_path)
 
     def test_check_category_directory_exists(self):
@@ -237,7 +237,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
     suites = []
 
     def get_ref(method_short_name):
-        return ['%s:JobAPIFeaturesTest.test_%s' % (__file__, method_short_name)]
+        return [f'{__file__}:JobAPIFeaturesTest.test_{method_short_name}']
 
     # ========================================================================
     # Test if the archive file was created
@@ -253,7 +253,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
     }
 
     suites.append(TestSuite.from_config(config_check_archive_file_exists,
-                                        "job-api-%s" % (len(suites) + 1)))
+                                        f"job-api-{len(suites) + 1}"))
 
     # ========================================================================
     # Test if the category directory was created
@@ -269,7 +269,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
     }
 
     suites.append(TestSuite.from_config(config_check_category_directory_exists,
-                                        "job-api-%s" % (len(suites) + 1)))
+                                        f"job-api-{len(suites) + 1}"))
 
     # ========================================================================
     # Test if a directory was created
@@ -291,7 +291,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
     }
 
     suites.append(TestSuite.from_config(config_check_directory_exists,
-                                        "job-api-%s" % (len(suites) + 1)))
+                                        f"job-api-{len(suites) + 1}"))
 
     # ========================================================================
     # Test the content of a file
@@ -372,7 +372,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
     }
 
     suites.append(TestSuite.from_config(config_check_file_content,
-                                        "job-api-%s" % (len(suites) + 1)))
+                                        f"job-api-{len(suites) + 1}"))
 
     # ========================================================================
     # Test if the result file was created
@@ -450,7 +450,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
              'assert': False})
 
     suites.append(TestSuite.from_config(config_check_file_exists,
-                                        "job-api-%s" % (len(suites) + 1)))
+                                        f"job-api-{len(suites) + 1}"))
 
     # ========================================================================
     # Test if a file was created
@@ -483,7 +483,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
              'assert': True})
 
     suites.append(TestSuite.from_config(config_check_output_file,
-                                        "job-api-%s" % (len(suites) + 1)))
+                                        f"job-api-{len(suites) + 1}"))
 
     # ========================================================================
     # Test if the temporary directory was created
@@ -499,7 +499,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
     }
 
     suites.append(TestSuite.from_config(config_check_tmp_directory_exists,
-                                        "job-api-%s" % (len(suites) + 1)))
+                                        f"job-api-{len(suites) + 1}"))
     return suites
 
 
@@ -605,7 +605,7 @@ def create_suites(args):  # pylint: disable=W0621
         for optional_plugin in glob.glob('optional_plugins/*'):
             plugin_name = os.path.basename(optional_plugin)
             if plugin_name not in args.disable_plugin_checks:
-                pattern = '%s/tests/*' % optional_plugin
+                pattern = f'{optional_plugin}/tests/*'
                 config_check_optional['resolver.references'] += glob.glob(pattern)
 
         suites.append(TestSuite.from_config(config_check_optional,
@@ -645,7 +645,7 @@ def main(args):  # pylint: disable=W0621
                     features.append(variants['namespace'])
 
         unique_features = sorted(set(features))
-        print('Features covered (%i):' % len(unique_features))
+        print(f'Features covered ({len(unique_features)}):')
         print('\n'.join(unique_features))
         exit(0)
 

--- a/selftests/functional/plugin/spawners/test_process.py
+++ b/selftests/functional/plugin/spawners/test_process.py
@@ -20,12 +20,11 @@ class ProcessSpawnerTest(TestCaseTmpDir):
         test = script.Script(os.path.join(self.tmpdir.name, "logdir_test.py"),
                              TEST_LOGDIR)
         test.save()
-        result = process.run("%s run --job-results-dir %s --disable-sysinfo "
-                             "--json - -- %s" % (AVOCADO, self.tmpdir.name,
-                                                 test))
+        result = process.run(f"{AVOCADO} run --job-results-dir {self.tmpdir.name}"
+                             f"--disable-sysinfo --json - -- {test}")
         res = json.loads(result.stdout_text)
         logfile = res["tests"][0]["logfile"]
         testdir = res["tests"][0]["logdir"]
         with open(logfile, 'r', encoding='utf-8') as debug_file:
-            expected = "logdir is: %s" % testdir
+            expected = f"logdir is: {testdir}"
             self.assertIn(expected, debug_file.read())

--- a/selftests/functional/plugin/spawners/test_process.py
+++ b/selftests/functional/plugin/spawners/test_process.py
@@ -20,7 +20,8 @@ class ProcessSpawnerTest(TestCaseTmpDir):
         test = script.Script(os.path.join(self.tmpdir.name, "logdir_test.py"),
                              TEST_LOGDIR)
         test.save()
-        result = process.run(f"{AVOCADO} run --job-results-dir {self.tmpdir.name}"
+        result = process.run(f"{AVOCADO} run "
+                             f"--job-results-dir {self.tmpdir.name}"
                              f"--disable-sysinfo --json - -- {test}")
         res = json.loads(result.stdout_text)
         logfile = res["tests"][0]["logfile"]

--- a/selftests/functional/plugin/test_assets.py
+++ b/selftests/functional/plugin/test_assets.py
@@ -75,14 +75,12 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         test_file.write(test_content.encode())
         test_file.close()
 
-        expected_output = "Fetching assets from %s.\n" \
-            "  File hello-2.9.tar.gz fetched or already on cache.\n" \
-            % test_file.name
+        expected_output = (f"Fetching assets from {test_file.name}.\n"
+                           f"  File hello-2.9.tar.gz fetched or already on cache.\n")
         expected_rc = exit_codes.AVOCADO_ALL_OK
 
-        cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
-                                                        self.config_file.name,
-                                                        test_file.name)
+        cmd_line = (f"{AVOCADO} --config {self.config_file.name} "
+                    f"assets fetch {test_file.name} ")
         result = process.run(cmd_line)
         os.remove(test_file.name)
 
@@ -93,9 +91,7 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         """Test register command failure."""
         url = "https://urlnotfound"
         config = self.config_file.name
-        cmd_line = "%s --config %s assets register foo %s" % (AVOCADO,
-                                                              config,
-                                                              url)
+        cmd_line = f"{AVOCADO} --config {config} assets register foo {url}"
         result = process.run(cmd_line, ignore_status=True)
 
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
@@ -107,9 +103,7 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         """Test register command success."""
         url = "/etc/hosts"
         config = self.config_file.name
-        cmd_line = "%s --config %s assets register hosts %s" % (AVOCADO,
-                                                                config,
-                                                                url)
+        cmd_line = f"{AVOCADO} --config {config} assets register hosts {url}"
         result = process.run(cmd_line)
 
         self.assertIn("Now you can reference it by name hosts",
@@ -125,18 +119,15 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         config = self.config_file.name
         url = asset_file.name
         name = "should-be-removed"
-        cmd_line = "%s --config %s assets register %s %s" % (AVOCADO,
-                                                             config,
-                                                             name,
-                                                             url)
+        cmd_line = f"{AVOCADO} --config {config} assets register {name} {url}"
         result = process.run(cmd_line)
-        self.assertIn("Now you can reference it by name {}".format(name),
+        self.assertIn(f"Now you can reference it by name {name}",
                       result.stdout_text)
 
-        cmd_line = "%s --config %s assets purge --by-size-filter '==1'" % (AVOCADO, config)
+        cmd_line = f"{AVOCADO} --config {config} assets purge --by-size-filter '==1'"
         process.run(cmd_line)
 
-        cmd_line = "%s --config %s assets list" % (AVOCADO, config)
+        cmd_line = f"{AVOCADO} --config {config} assets list"
         result = process.run(cmd_line)
         self.assertNotIn(name, result.stdout_text)
 
@@ -146,15 +137,11 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         url = "/etc/hosts"
         config = self.config_file.name
         name = "should-be-part-of-list"
-        cmd_line = "%s --config %s assets register %s %s" % (AVOCADO,
-                                                             config,
-                                                             name,
-                                                             url)
+        cmd_line = f"{AVOCADO} --config {config} assets register {name} {url}"
         result = process.run(cmd_line)
-        self.assertIn("Now you can reference it by name {}".format(name),
+        self.assertIn(f"Now you can reference it by name {name}",
                       result.stdout_text)
-        cmd_line = "%s --config %s assets list" % (AVOCADO,
-                                                   config)
+        cmd_line = f"{AVOCADO} --config {config} assets list"
         result = process.run(cmd_line)
         self.assertIn(name, result.stdout_text)
 
@@ -168,19 +155,15 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         config = self.config_file.name
         url = asset_file.name
         name = "should-be-removed"
-        cmd_line = "%s --config %s assets register %s %s" % (AVOCADO,
-                                                             config,
-                                                             name,
-                                                             url)
+        cmd_line = f"{AVOCADO} --config {config} assets register {name} {url}"
         result = process.run(cmd_line)
-        self.assertIn("Now you can reference it by name {}".format(name),
+        self.assertIn(f"Now you can reference it by name {name}",
                       result.stdout_text)
 
-        cmd_line = "%s --config %s assets purge --by-overall-limit 2" % (AVOCADO,
-                                                                         config)
+        cmd_line = f"{AVOCADO} --config {config} assets purge --by-overall-limit 2"
         process.run(cmd_line)
 
-        cmd_line = "%s --config %s assets list" % (AVOCADO, config)
+        cmd_line = f"{AVOCADO} --config {config} assets list"
         result = process.run(cmd_line)
         self.assertIn(name, result.stdout_text)
 
@@ -215,8 +198,7 @@ class AssetsPlugin(unittest.TestCase):
             " arguments are required: AVOCADO_INSTRUMENTED\n"
         expected_rc = exit_codes.AVOCADO_FAIL
 
-        cmd_line = "%s --config %s assets fetch" % (AVOCADO,
-                                                    self.config_file.name)
+        cmd_line = f"{AVOCADO} --config {self.config_file.name} assets fetch"
         result = process.run(cmd_line, ignore_status=True)
 
         self.assertEqual(expected_rc, result.exit_status)
@@ -237,12 +219,10 @@ class AssetsPlugin(unittest.TestCase):
         test_file.write(test_content.encode())
         test_file.close()
 
-        expected_stdout = "Fetching assets from %s.\n" % test_file.name
+        expected_stdout = f"Fetching assets from {test_file.name}.\n"
         expected_rc = exit_codes.AVOCADO_ALL_OK
 
-        cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
-                                                        self.config_file.name,
-                                                        test_file.name)
+        cmd_line = f"{AVOCADO} --config {self.config_file.name} assets fetch {test_file.name} "
         result = process.run(cmd_line, ignore_status=True)
         os.remove(test_file.name)
 
@@ -264,13 +244,10 @@ class AssetsPlugin(unittest.TestCase):
         test_file.write(test_content.encode())
         test_file.close()
 
-        expected_stderr = "No such file or file not supported: %s\n" \
-            % test_file.name
+        expected_stderr = f"No such file or file not supported: {test_file.name}\n"
         expected_rc = exit_codes.AVOCADO_FAIL
 
-        cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
-                                                        self.config_file.name,
-                                                        test_file.name)
+        cmd_line = f"{AVOCADO} --config {self.config_file.name} assets fetch {test_file.name} "
         result = process.run(cmd_line, ignore_status=True)
         os.remove(test_file.name)
 
@@ -295,9 +272,7 @@ class AssetsPlugin(unittest.TestCase):
         expected_stderr = "Failed to fetch hello-2.9.tar.gz"
         expected_rc = exit_codes.AVOCADO_FAIL
 
-        cmd_line = "%s --config %s assets fetch %s " % (AVOCADO,
-                                                        self.config_file.name,
-                                                        test_file.name)
+        cmd_line = f"{AVOCADO} --config {self.config_file.name} assets fetch {test_file.name} "
         result = process.run(cmd_line, ignore_status=True)
         os.remove(test_file.name)
 
@@ -322,10 +297,8 @@ class AssetsPlugin(unittest.TestCase):
         expected_stderr = "Failed to fetch hello-2.9.tar.gz"
         expected_rc = exit_codes.AVOCADO_ALL_OK
 
-        cmd_line = "%s --config %s assets fetch --ignore-errors %s " % (
-            AVOCADO,
-            self.config_file.name,
-            test_file.name)
+        cmd_line = (f"{AVOCADO} --config {self.config_file.name} "
+                    f"assets fetch --ignore-errors {test_file.name} ")
         result = process.run(cmd_line, ignore_status=True)
         os.remove(test_file.name)
 
@@ -342,23 +315,19 @@ class AssetsPlugin(unittest.TestCase):
         config = self.config_file.name
         url = asset_file.name
         name = "should-be-removed"
-        cmd_line = "%s --config %s assets register %s %s" % (AVOCADO,
-                                                             config,
-                                                             name,
-                                                             url)
+        cmd_line = f"{AVOCADO} --config {config} assets register {name} {url}"
         result = process.run(cmd_line)
-        self.assertIn("Now you can reference it by name {}".format(name),
+        self.assertIn(f"Now you can reference it by name {name}",
                       result.stdout_text)
 
-        cmd_line = "%s --config %s assets list" % (AVOCADO, config)
+        cmd_line = f"{AVOCADO} --config {config} assets list"
         result = process.run(cmd_line)
         self.assertIn(name, result.stdout_text)
 
-        cmd_line = "%s --config %s assets purge --by-days 0" % (AVOCADO,
-                                                                config)
+        cmd_line = f"{AVOCADO} --config {config} assets purge --by-days 0"
         process.run(cmd_line)
 
-        cmd_line = "%s --config %s assets list" % (AVOCADO, config)
+        cmd_line = f"{AVOCADO} --config {config} assets list"
         result = process.run(cmd_line)
         self.assertNotIn(name, result.stdout_text)
 

--- a/selftests/functional/plugin/test_assets.py
+++ b/selftests/functional/plugin/test_assets.py
@@ -76,7 +76,8 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         test_file.close()
 
         expected_output = (f"Fetching assets from {test_file.name}.\n"
-                           f"  File hello-2.9.tar.gz fetched or already on cache.\n")
+                           f"  File hello-2.9.tar.gz fetched or "
+                           f"already on cache.\n")
         expected_rc = exit_codes.AVOCADO_ALL_OK
 
         cmd_line = (f"{AVOCADO} --config {self.config_file.name} "
@@ -124,7 +125,8 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         self.assertIn(f"Now you can reference it by name {name}",
                       result.stdout_text)
 
-        cmd_line = f"{AVOCADO} --config {config} assets purge --by-size-filter '==1'"
+        cmd_line = (f"{AVOCADO} --config {config} assets purge "
+                    f"--by-size-filter '==1'")
         process.run(cmd_line)
 
         cmd_line = f"{AVOCADO} --config {config} assets list"
@@ -160,7 +162,8 @@ class AssetsFetchSuccess(TestCaseTmpDir):
         self.assertIn(f"Now you can reference it by name {name}",
                       result.stdout_text)
 
-        cmd_line = f"{AVOCADO} --config {config} assets purge --by-overall-limit 2"
+        cmd_line = (f"{AVOCADO} --config {config} assets purge "
+                    f"--by-overall-limit 2")
         process.run(cmd_line)
 
         cmd_line = f"{AVOCADO} --config {config} assets list"
@@ -222,7 +225,8 @@ class AssetsPlugin(unittest.TestCase):
         expected_stdout = f"Fetching assets from {test_file.name}.\n"
         expected_rc = exit_codes.AVOCADO_ALL_OK
 
-        cmd_line = f"{AVOCADO} --config {self.config_file.name} assets fetch {test_file.name} "
+        cmd_line = (f"{AVOCADO} --config {self.config_file.name} "
+                    f"assets fetch {test_file.name} ")
         result = process.run(cmd_line, ignore_status=True)
         os.remove(test_file.name)
 
@@ -244,10 +248,12 @@ class AssetsPlugin(unittest.TestCase):
         test_file.write(test_content.encode())
         test_file.close()
 
-        expected_stderr = f"No such file or file not supported: {test_file.name}\n"
+        expected_stderr = (f"No such file or file not supported: "
+                           f"{test_file.name}\n")
         expected_rc = exit_codes.AVOCADO_FAIL
 
-        cmd_line = f"{AVOCADO} --config {self.config_file.name} assets fetch {test_file.name} "
+        cmd_line = (f"{AVOCADO} --config {self.config_file.name} "
+                    f"assets fetch {test_file.name} ")
         result = process.run(cmd_line, ignore_status=True)
         os.remove(test_file.name)
 
@@ -272,7 +278,8 @@ class AssetsPlugin(unittest.TestCase):
         expected_stderr = "Failed to fetch hello-2.9.tar.gz"
         expected_rc = exit_codes.AVOCADO_FAIL
 
-        cmd_line = f"{AVOCADO} --config {self.config_file.name} assets fetch {test_file.name} "
+        cmd_line = (f"{AVOCADO} --config {self.config_file.name} "
+                    f"assets fetch {test_file.name} ")
         result = process.run(cmd_line, ignore_status=True)
         os.remove(test_file.name)
 

--- a/selftests/functional/plugin/test_diff.py
+++ b/selftests/functional/plugin/test_diff.py
@@ -13,14 +13,17 @@ class DiffTests(TestCaseTmpDir):
     def setUp(self):
         super().setUp()
         cmd_line = (f'{AVOCADO} run examples/tests/passtest.py '
-                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo --json -')
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo '
+                    f'--json -')
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))
 
         self.tmpdir2 = tempfile.TemporaryDirectory(prefix=self.tmpdir.name)
         cmd_line = (f'{AVOCADO} run examples/tests/warntest.py '
-                    f'--job-results-dir {self.tmpdir2.name} --disable-sysinfo --json -')
+                    f'--job-results-dir {self.tmpdir2.name} '
+                    f'--disable-sysinfo '
+                    f'--json -')
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir2 = ''.join(glob.glob(os.path.join(self.tmpdir2.name, 'job-*')))
@@ -28,7 +31,8 @@ class DiffTests(TestCaseTmpDir):
     def run_and_check(self, cmd_line, expected_rc):
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Command {cmd_line} did not return rc " "{expected_rc}:\n{result}")
+                         (f"Command {cmd_line} did not return rc "
+                          f"{expected_rc}:\n{result}"))
         return result
 
     @unittest.skipIf(os.environ.get("RUNNING_COVERAGE"), "Running coverage")
@@ -43,7 +47,8 @@ class DiffTests(TestCaseTmpDir):
         self.assertIn(f"+{avocado_in_log} run", result.stdout_text)
 
     def test_diff_nocmdline(self):
-        cmd_line = f'{AVOCADO} diff {self.jobdir} {self.jobdir2} --diff-filter nocmdline'
+        cmd_line = (f'{AVOCADO} diff {self.jobdir} {self.jobdir2} '
+                    f'--diff-filter nocmdline')
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
         self.assertNotIn(b"# COMMAND LINE", result.stdout)

--- a/selftests/functional/plugin/test_diff.py
+++ b/selftests/functional/plugin/test_diff.py
@@ -12,17 +12,15 @@ class DiffTests(TestCaseTmpDir):
 
     def setUp(self):
         super().setUp()
-        cmd_line = ('%s run examples/tests/passtest.py '
-                    '--job-results-dir %s --disable-sysinfo --json -' %
-                    (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run examples/tests/passtest.py '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo --json -')
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))
 
         self.tmpdir2 = tempfile.TemporaryDirectory(prefix=self.tmpdir.name)
-        cmd_line = ('%s run examples/tests/warntest.py '
-                    '--job-results-dir %s --disable-sysinfo --json -' %
-                    (AVOCADO, self.tmpdir2.name))
+        cmd_line = (f'{AVOCADO} run examples/tests/warntest.py '
+                    f'--job-results-dir {self.tmpdir2.name} --disable-sysinfo --json -')
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir2 = ''.join(glob.glob(os.path.join(self.tmpdir2.name, 'job-*')))
@@ -30,25 +28,22 @@ class DiffTests(TestCaseTmpDir):
     def run_and_check(self, cmd_line, expected_rc):
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
-                         "Command %s did not return rc "
-                         "%d:\n%s" % (cmd_line, expected_rc, result))
+                         f"Command {cmd_line} did not return rc " "{expected_rc}:\n{result}")
         return result
 
     @unittest.skipIf(os.environ.get("RUNNING_COVERAGE"), "Running coverage")
     def test_diff(self):
-        cmd_line = ('%s diff %s %s' %
-                    (AVOCADO, self.jobdir, self.jobdir2))
+        cmd_line = f'{AVOCADO} diff {self.jobdir} {self.jobdir2}'
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
         # Avocado will see the main module on the command line
         avocado_in_log = os.path.join(BASEDIR, 'avocado', '__main__.py')
         self.assertIn(b"# COMMAND LINE", result.stdout)
-        self.assertIn("-%s run" % avocado_in_log, result.stdout_text)
-        self.assertIn("+%s run" % avocado_in_log, result.stdout_text)
+        self.assertIn(f"-{avocado_in_log} run", result.stdout_text)
+        self.assertIn(f"+{avocado_in_log} run", result.stdout_text)
 
     def test_diff_nocmdline(self):
-        cmd_line = ('%s diff %s %s --diff-filter nocmdline' %
-                    (AVOCADO, self.jobdir, self.jobdir2))
+        cmd_line = f'{AVOCADO} diff {self.jobdir} {self.jobdir2} --diff-filter nocmdline'
         expected_rc = exit_codes.AVOCADO_ALL_OK
         result = self.run_and_check(cmd_line, expected_rc)
         self.assertNotIn(b"# COMMAND LINE", result.stdout)

--- a/selftests/functional/plugin/test_jobscripts.py
+++ b/selftests/functional/plugin/test_jobscripts.py
@@ -64,7 +64,8 @@ class JobScriptsTest(TestCaseTmpDir):
                                                                self.post_dir))
         with config:
             cmd = (f'{AVOCADO} --config {config} run '
-                   f'--job-results-dir {self.tmpdir.name} --disable-sysinfo {test_check_touch}')
+                   f'--job-results-dir {self.tmpdir.name} '
+                   f'--disable-sysinfo {test_check_touch}')
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -86,7 +87,8 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_NON_ZERO_CFG % self.pre_dir)
         with config:
             cmd = (f'{AVOCADO} --config {config} run '
-                   f'--job-results-dir {self.tmpdir.name} --disable-sysinfo examples/tests/passtest.py')
+                   f'--job-results-dir {self.tmpdir.name} '
+                   f'--disable-sysinfo examples/tests/passtest.py')
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
@@ -108,7 +110,8 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_NON_EXISTING_DIR_CFG % self.pre_dir)
         with config:
             cmd = (f'{AVOCADO} --config {config} run '
-                   f'--job-results-dir {self.tmpdir.name} --disable-sysinfo examples/tests/passtest.py')
+                   f'--job-results-dir {self.tmpdir.name} '
+                   f'--disable-sysinfo examples/tests/passtest.py')
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status

--- a/selftests/functional/plugin/test_jobscripts.py
+++ b/selftests/functional/plugin/test_jobscripts.py
@@ -63,16 +63,15 @@ class JobScriptsTest(TestCaseTmpDir):
                                         SCRIPT_PRE_POST_CFG % (self.pre_dir,
                                                                self.post_dir))
         with config:
-            cmd = ('%s --config %s run --job-results-dir %s '
-                   '--disable-sysinfo %s'
-                   % (AVOCADO, config, self.tmpdir.name, test_check_touch))
+            cmd = (f'{AVOCADO} --config {config} run '
+                   f'--job-results-dir {self.tmpdir.name} --disable-sysinfo {test_check_touch}')
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertNotIn('Pre job script "%s" exited with status "1"' % touch_script,
+        self.assertNotIn(f'Pre job script "{touch_script}" exited with status "1"',
                          result.stderr_text)
-        self.assertNotIn('Post job script "%s" exited with status "1"' % rm_script,
+        self.assertNotIn(f'Post job script "{rm_script}" exited with status "1"',
                          result.stderr_text)
 
     def test_status_non_zero(self):
@@ -86,14 +85,13 @@ class JobScriptsTest(TestCaseTmpDir):
         config = script.TemporaryScript("non_zero.conf",
                                         SCRIPT_NON_ZERO_CFG % self.pre_dir)
         with config:
-            cmd = ('%s --config %s run --job-results-dir %s '
-                   '--disable-sysinfo examples/tests/passtest.py'
-                   % (AVOCADO, config, self.tmpdir.name))
+            cmd = (f'{AVOCADO} --config {config} run '
+                   f'--job-results-dir {self.tmpdir.name} --disable-sysinfo examples/tests/passtest.py')
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertIn('Pre job script "%s" exited with status "1"\n' % non_zero_script,
+        self.assertIn(f'Pre job script "{non_zero_script}" exited with status "1\"\n',
                       result.stderr_text)
 
     def test_non_existing_dir(self):
@@ -109,15 +107,14 @@ class JobScriptsTest(TestCaseTmpDir):
         config = script.TemporaryScript("non_existing_dir.conf",
                                         SCRIPT_NON_EXISTING_DIR_CFG % self.pre_dir)
         with config:
-            cmd = ('%s --config %s run --job-results-dir %s '
-                   '--disable-sysinfo examples/tests/passtest.py'
-                   % (AVOCADO, config, self.tmpdir.name))
+            cmd = (f'{AVOCADO} --config {config} run '
+                   f'--job-results-dir {self.tmpdir.name} --disable-sysinfo examples/tests/passtest.py')
             result = process.run(cmd)
 
         # Pre/Post scripts failures do not (currently?) alter the exit status
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertIn(b'-job scripts has not been found', result.stderr)
-        self.assertNotIn('Pre job script "%s" exited with status "1"' % non_zero_script,
+        self.assertNotIn(f'Pre job script "{non_zero_script}" exited with status "1"',
                          result.stderr_text)
 
 

--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -8,9 +8,8 @@ from selftests.utils import AVOCADO, TestCaseTmpDir
 class JsonResultTest(TestCaseTmpDir):
 
     def test_logfile(self):
-        cmd_line = ('%s run examples/tests/failtest.py '
-                    '--job-results-dir %s --disable-sysinfo ' %
-                    (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run examples/tests/failtest.py '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo')
         process.run(cmd_line, ignore_status=True)
         json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
 
@@ -21,9 +20,8 @@ class JsonResultTest(TestCaseTmpDir):
             self.assertEqual(expected_logfile, test_data['logfile'])
 
     def test_fail_reason(self):
-        cmd_line = ('%s run examples/tests/failtest.py '
-                    '--job-results-dir %s --disable-sysinfo ' %
-                    (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run examples/tests/failtest.py '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo')
         process.run(cmd_line, ignore_status=True)
         json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
         with open(json_path, 'r', encoding='utf-8') as json_file:

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -21,8 +21,7 @@ class TestLogsUI(TestCaseTmpDir):
         cmd_line %= (AVOCADO, os.path.join(self.tmpdir.name, 'config'))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL,
-                         "Avocado did not return rc %d:\n%s"
-                         % (exit_codes.AVOCADO_ALL_OK, result))
+                         f'Avocado did not return rc {exit_codes.AVOCADO_ALL_OK}:\n {result}')
         stdout_lines = result.stdout_text.splitlines()
         self.assertNotIn('Log file "debug.log" content for test "1-examples/tests/passtest.py'
                          ':PassTest.test" (PASS)', stdout_lines)
@@ -44,13 +43,12 @@ class TestLogsFilesUI(TestCaseTmpDir):
 
     def test_simpletest_logfiles(self):
         fail_test = os.path.join(BASEDIR, 'examples', 'tests', 'failtest.sh')
-        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
-                    ' -- %s' % (AVOCADO, self.config_file.path,
-                                self.tmpdir.name, fail_test))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.path} run '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo -- {fail_test}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f'Avocado did not return rc {expected_rc}:\n {result}')
         self.assertNotIn('Log file "debug.log" content', result.stdout_text)
         self.assertIn('Log file "stdout" content', result.stdout_text)
         self.assertIn('Log file "stderr" content', result.stdout_text)
@@ -66,8 +64,7 @@ class TestLogging(TestCaseTmpDir):
 
     def test_job_log(self):
         pass_test = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-        cmd_line = ('%s run --job-results-dir %s %s' %
-                    (AVOCADO, self.tmpdir.name, pass_test))
+        cmd_line = f'{AVOCADO} run --job-results-dir {self.tmpdir.name} {pass_test}'
         process.run(cmd_line)
         log_file = os.path.join(self.tmpdir.name, 'latest', 'job.log')
         with open(log_file, 'r', encoding='utf-8') as fp:

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -17,11 +17,13 @@ class TestLogsUI(TestCaseTmpDir):
 
     def test(self):
         cmd_line = ("%s --config=%s run -- examples/tests/passtest.py "
-                    "examples/tests/failtest.py examples/tests/canceltest.py ")
+                    "examples/tests/failtest.py "
+                    "examples/tests/canceltest.py ")
         cmd_line %= (AVOCADO, os.path.join(self.tmpdir.name, 'config'))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL,
-                         f'Avocado did not return rc {exit_codes.AVOCADO_ALL_OK}:\n {result}')
+                         (f'Avocado did not return rc {exit_codes.AVOCADO_ALL_OK}:'
+                          f'\n {result}'))
         stdout_lines = result.stdout_text.splitlines()
         self.assertNotIn('Log file "debug.log" content for test "1-examples/tests/passtest.py'
                          ':PassTest.test" (PASS)', stdout_lines)
@@ -44,11 +46,13 @@ class TestLogsFilesUI(TestCaseTmpDir):
     def test_simpletest_logfiles(self):
         fail_test = os.path.join(BASEDIR, 'examples', 'tests', 'failtest.sh')
         cmd_line = (f'{AVOCADO} --config {self.config_file.path} run '
-                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo -- {fail_test}')
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo -- {fail_test}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         f'Avocado did not return rc {expected_rc}:\n {result}')
+                         (f'Avocado did not return rc {expected_rc}:'
+                          f'\n {result}'))
         self.assertNotIn('Log file "debug.log" content', result.stdout_text)
         self.assertIn('Log file "stdout" content', result.stdout_text)
         self.assertIn('Log file "stderr" content', result.stdout_text)
@@ -64,7 +68,8 @@ class TestLogging(TestCaseTmpDir):
 
     def test_job_log(self):
         pass_test = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-        cmd_line = f'{AVOCADO} run --job-results-dir {self.tmpdir.name} {pass_test}'
+        cmd_line = (f'{AVOCADO} run --job-results-dir '
+                    f'{self.tmpdir.name} {pass_test}')
         process.run(cmd_line)
         log_file = os.path.join(self.tmpdir.name, 'latest', 'job.log')
         with open(log_file, 'r', encoding='utf-8') as fp:

--- a/selftests/functional/plugin/test_vmimage.py
+++ b/selftests/functional/plugin/test_vmimage.py
@@ -17,7 +17,7 @@ def missing_binary(binary):
 
 def create_metadata_file(image_file, metadata):
     basename = os.path.splitext(image_file)[0]
-    metadata_file = "%s_metadata.json" % basename
+    metadata_file = f"{basename}_metadata.json"
     metadata = json.dumps(metadata)
     with open(metadata_file, "w", encoding='utf-8') as f:
         f.write(metadata)
@@ -38,14 +38,14 @@ class VMImagePlugin(unittest.TestCase):
                                  '89b7a3293bbc1dd73bb143b15fa06f0f9c7188b8')
         os.makedirs(image_dir)
         open(os.path.join(image_dir, expected_output), "w", encoding='utf-8').close()
-        cmd_line = "%s --config %s vmimage get --distro fedora --distro-version " \
-                   "30 --arch x86_64" % (AVOCADO, self.config_file.name)
+        cmd_line = (f"{AVOCADO} --config {self.config_file.name} vmimage "
+                    f"get --distro fedora --distro-version 30 --arch x86_64")
         result = process.run(cmd_line)
         self.assertIn(expected_output, result.stdout_text)
 
     def test_download_image_fail(self):
-        cmd_line = "%s --config %s vmimage get --distro=SHOULD_NEVER_EXIST " \
-                   "999 --arch zzz_64" % (AVOCADO, self.config_file.name)
+        cmd_line = (f"{AVOCADO} --config {self.config_file.name} vmimage "
+                    f"get --distro=SHOULD_NEVER_EXIST 999 --arch zzz_64")
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
 
@@ -59,8 +59,7 @@ class VMImagePlugin(unittest.TestCase):
         expected_file = os.path.join(image_dir, expected_output)
         open(expected_file, "w", encoding='utf-8').close()
         create_metadata_file(expected_file, metadata)
-        cmd_line = "%s --config %s vmimage list" % (AVOCADO,
-                                                    self.config_file.name)
+        cmd_line = f"{AVOCADO} --config {self.config_file.name} vmimage list"
         result = process.run(cmd_line)
         self.assertIn(expected_output, result.stdout_text)
 

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -12,27 +12,27 @@ class ArgumentParsingTest(unittest.TestCase):
 
     def test_unknown_command(self):
         os.chdir(BASEDIR)
-        cmd_line = '%s whacky-command-that-doesnt-exist' % AVOCADO
+        cmd_line = f'{AVOCADO} whacky-command-that-doesnt-exist'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+                         'Avocado did not return rc {expected_rc}:\n{result}')
 
     def test_known_command_bad_choice(self):
         os.chdir(BASEDIR)
-        cmd_line = '%s run --disable-sysinfo=foo passtest' % AVOCADO
+        cmd_line = f'{AVOCADO} run --disable-sysinfo=foo passtest'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+                         'Avocado did not return rc {expected_rc}:\n{result}')
 
     def test_known_command_bad_argument(self):
         os.chdir(BASEDIR)
-        cmd_line = '%s run --disable-sysinfo --whacky-argument passtest' % AVOCADO
+        cmd_line = f'{AVOCADO} run --disable-sysinfo --whacky-argument passtest'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
+                         'Avocado did not return rc {expected_rc}:\n{result}')
         subcommand_error_msg = (b'avocado run: error: unrecognized arguments: '
                                 b'--whacky-argument')
         self.assertIn(subcommand_error_msg, result.stderr)
@@ -54,12 +54,11 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
 
         self.assertIsNotNone(log_dir)
         job = job_id.create_unique_job_id()
-        cmd_line = '%s run --disable-sysinfo --force-job-id=%%s %%s' % AVOCADO
-        cmd_line %= (job, complement_args)
+        cmd_line = f'{AVOCADO} run --disable-sysinfo --force-job-id={job} {complement_args}'
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc, result))
-        path_job_glob = os.path.join(log_dir, "job-*-%s" % job[0:7])
+                         'Avocado did not return rc {expected_rc}:\n{result}')
+        path_job_glob = os.path.join(log_dir, f"job-*-{job[0:7]}")
         self.assertEqual(glob.glob(path_job_glob), [])
 
     def test_whacky_option(self):

--- a/selftests/functional/test_argument_parsing.py
+++ b/selftests/functional/test_argument_parsing.py
@@ -54,7 +54,8 @@ class ArgumentParsingErrorEarlyTest(unittest.TestCase):
 
         self.assertIsNotNone(log_dir)
         job = job_id.create_unique_job_id()
-        cmd_line = f'{AVOCADO} run --disable-sysinfo --force-job-id={job} {complement_args}'
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--force-job-id={job} {complement_args}')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
                          'Avocado did not return rc {expected_rc}:\n{result}')

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -136,7 +136,8 @@ class RunnerOperationTest(TestCaseTmpDir):
         result = process.run(f'{AVOCADO} -v', ignore_status=True)
         self.assertEqual(result.exit_status, 0)
         self.assertTrue(re.match(r"^Avocado \d+\.\d+$", result.stdout_text),
-                        (f"Version string does not match 'Avocado \\d\\.\\d:'\n"
+                        (f"Version string does not match "
+                         f"'Avocado \\d\\.\\d:'\n"
                          f"{result.stdout_text}"))
 
     def test_alternate_config_datadir(self):
@@ -165,21 +166,25 @@ class RunnerOperationTest(TestCaseTmpDir):
         result = process.run(cmd)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         self.assertIn('   base    ' + mapping['base_dir'], result.stdout_text)
         self.assertIn('   data    ' + mapping['data_dir'], result.stdout_text)
         self.assertIn('   logs    ' + mapping['logs_dir'], result.stdout_text)
 
     def test_runner_phases(self):
-        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
                     f'examples/tests/phases.py')
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
 
     def test_runner_all_ok(self):
-        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
                     f'examples/tests/passtest.py examples/tests/passtest.py')
         process.run(cmd_line)
         # Also check whether jobdata contains correct parameter paths
@@ -189,9 +194,11 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertEqual(variants, expected)
 
     def test_runner_failfast(self):
-        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
                     f'examples/tests/passtest.py examples/tests/failtest.py '
-                    f'examples/tests/passtest.py --failfast --nrunner-max-parallel-tasks=1')
+                    f'examples/tests/passtest.py --failfast '
+                    f'--nrunner-max-parallel-tasks=1')
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'Interrupting job (failfast).', result.stdout)
         self.assertIn(b'PASS 1 | ERROR 0 | FAIL 1 | SKIP 1', result.stdout)
@@ -200,8 +207,10 @@ class RunnerOperationTest(TestCaseTmpDir):
                          f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_runner_ignore_missing_references_one_missing(self):
-        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
-                    f'examples/tests/passtest.py badtest.py --ignore-missing-references')
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/passtest.py badtest.py '
+                    f'--ignore-missing-references')
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'PASS 1 | ERROR 0 | FAIL 0 | SKIP 0', result.stdout)
         expected_rc = exit_codes.AVOCADO_ALL_OK
@@ -209,7 +218,8 @@ class RunnerOperationTest(TestCaseTmpDir):
                          f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_runner_ignore_missing_references_all_missing(self):
-        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
                     f'badtest.py badtest2.py --ignore-missing-references')
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'Suite is empty. There is no tests to run.', result.stderr)
@@ -230,20 +240,23 @@ class RunnerOperationTest(TestCaseTmpDir):
                      '    def test(self):\n'
                      '        self.log.info(hello())\n')) as mytest:
                     cmd_line = (f'{AVOCADO} run --disable-sysinfo '
-                                f'--job-results-dir {self.tmpdir.name} {mytest}')
+                                f'--job-results-dir {self.tmpdir.name} '
+                                f'{mytest}')
                     process.run(cmd_line)
 
     def test_unsupported_status(self):
         with script.TemporaryScript("fake_status.py",
                                     UNSUPPORTED_STATUS_TEST_CONTENTS,
                                     "avocado_unsupported_status") as tst:
-            res = process.run((f"{AVOCADO} run --disable-sysinfo --job-results-dir "
-                               f"{self.tmpdir.name} {tst} --test-runner=runner --json -"),
+            res = process.run((f"{AVOCADO} run --disable-sysinfo "
+                               f"--job-results-dir {self.tmpdir.name} {tst} "
+                               f"--test-runner=runner --json -"),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
-                             f"{results['tests'][0]['status']} != {'ERROR'}\n{res}")
+                             (f"{results['tests'][0]['status']} != "
+                              f"{'ERROR'}\n{res}"))
             self.assertIn("Runner error occurred: Test reports unsupported",
                           results["tests"][0]["fail_reason"])
 
@@ -256,13 +269,16 @@ class RunnerOperationTest(TestCaseTmpDir):
         with script.TemporaryScript("report_status_and_hang.py",
                                     REPORTS_STATUS_AND_HANG,
                                     "hanged_test_with_status") as tst:
-            res = process.run((f"{AVOCADO} run --disable-sysinfo --job-results-dir "
-                              f"{self.tmpdir.name} {tst} --test-runner=runner --json - --job-timeout 1"),
+            res = process.run((f"{AVOCADO} run --disable-sysinfo "
+                               f"--job-results-dir {self.tmpdir.name} {tst} "
+                               f"--test-runner=runner --json - "
+                               f"--job-timeout 1"),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
-                             f"{results['tests'][0]['status']} != {'ERROR'}\n{res}")
+                             (f"{results['tests'][0]['status']} != "
+                              f"{'ERROR'}\n{res}"))
             self.assertIn("Test reported status but did not finish",
                           results["tests"][0]["fail_reason"])
             # Currently it should finish up to 1s after the job-timeout
@@ -271,20 +287,22 @@ class RunnerOperationTest(TestCaseTmpDir):
             # > 60s, which is the deadline for force-finishing the test.
             self.assertLess(res.duration, 55,
                             (f"Test execution took too long, "
-                             f"which is likely because the hanged test was not "
-                             f"interrupted. Results:\n{res}"))
+                             f"which is likely because the hanged test was "
+                             f"not interrupted. Results:\n{res}"))
 
     def test_no_status_reported(self):
         with script.TemporaryScript("die_without_reporting_status.py",
                                     DIE_WITHOUT_REPORTING_STATUS,
                                     "no_status_reported") as tst:
-            res = process.run((f"{AVOCADO} run --disable-sysinfo --job-results-dir "
-                               f"{self.tmpdir.name} {tst} --test-runner=runner --json -"),
+            res = process.run((f"{AVOCADO} run --disable-sysinfo "
+                               f"--job-results-dir {self.tmpdir.name} {tst} "
+                               f"--test-runner=runner --json -"),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
-                             f"{results['tests'][0]['status']} != {'ERROR'}\n{res}")
+                             (f"{results['tests'][0]['status']} != "
+                              f"{'ERROR'}\n{res}"))
             self.assertIn("Test died without reporting the status",
                           results["tests"][0]["fail_reason"])
 
@@ -310,7 +328,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_runner_doublefail(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
-                    f'{self.tmpdir.name} --xunit - examples/tests/doublefail.py')
+                    f'{self.tmpdir.name} --xunit - '
+                    f'examples/tests/doublefail.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         unexpected_rc = exit_codes.AVOCADO_FAIL
@@ -321,11 +340,13 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertIn(b"TestError: Failing during tearDown. Yay!", result.stdout,
                       "Cleanup exception not printed to log output")
         self.assertIn(b"TestFail: This test is supposed to fail", result.stdout,
-                      f"Test did not fail with action exception:\n{result.stdout}")
+                      (f"Test did not fail with action exception:"
+                       f"\n{result.stdout}"))
 
     def test_uncaught_exception(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
-                    f'{self.tmpdir.name} --json - examples/tests/uncaught_exception.py')
+                    f'{self.tmpdir.name} --json - '
+                    f'examples/tests/uncaught_exception.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -334,7 +355,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_fail_on_exception(self):
         cmd_line = (f'{AVOCADO}  run --disable-sysinfo --job-results-dir '
-                    f'{self.tmpdir.name} --json - examples/tests/fail_on_exception.py')
+                    f'{self.tmpdir.name} --json - '
+                    f'examples/tests/fail_on_exception.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
@@ -343,7 +365,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_cancel_on_exception(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
-                    f'{self.tmpdir.name} --json - examples/tests/cancel_on_exception.py')
+                    f'{self.tmpdir.name} --json - '
+                    f'examples/tests/cancel_on_exception.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -377,7 +400,8 @@ class RunnerOperationTest(TestCaseTmpDir):
                                RAISE_CUSTOM_PATH_EXCEPTION_CONTENT)
         mytest.save()
         result = process.run(f'{AVOCADO} --show test run --disable-sysinfo '
-                             f'--test-runner=runner --job-results-dir {self.tmpdir.name} {mytest}')
+                             f'--test-runner=runner '
+                             f'--job-results-dir {self.tmpdir.name} {mytest}')
         self.assertIn(b"mytest.py:SharedLibTest.test -> CancelExc: This "
                       b"should not crash on unpickling in runner",
                       result.stdout)
@@ -460,7 +484,8 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertNotIn(b'Unable to resolve reference', result.stdout)
 
     def test_invalid_unique_id(self):
-        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
                     f'--force-job-id foobar examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertNotEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -468,16 +493,18 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertNotIn(b'needs to be a 40 digit hex', result.stdout)
 
     def test_valid_unique_id(self):
-        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} --disable-sysinfo '
-                    f'--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 examples/tests/passtest.py')
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo '
+                    f'--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertNotIn(b'needs to be a 40 digit hex', result.stderr)
         self.assertIn(b'PASS', result.stdout)
 
     def test_automatic_unique_id(self):
-        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} --disable-sysinfo '
-                    f'examples/tests/passtest.py --json -')
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo examples/tests/passtest.py --json -')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         r = json.loads(result.stdout_text)
@@ -491,7 +518,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
                     f'examples/tests/passtest.py')
         avocado_process = process.SubProcess(cmd_line)
         try:
@@ -526,11 +554,14 @@ class RunnerOperationTest(TestCaseTmpDir):
         """
         :avocado: tags=parallel:1
         """
-        cmd = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+        cmd = (f'{AVOCADO} run --disable-sysinfo '
+               f'--job-results-dir {self.tmpdir.name} '
                f'{READ_BINARY}')
         result = process.run(cmd, timeout=10, ignore_status=True)
-        self.assertLess(result.duration, 8, f"Duration longer than expected.\n{result}")
-        self.assertEqual(result.exit_status, 1, f"Expected exit status is 1\n{result}")
+        self.assertLess(result.duration, 8, (f"Duration longer than expected."
+                                             f"\n{result}"))
+        self.assertEqual(result.exit_status, 1, (f"Expected exit status is 1"
+                                                 f"\n{result}"))
 
     def test_runner_test_parameters(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
@@ -562,7 +593,8 @@ class RunnerOperationTest(TestCaseTmpDir):
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
             self.assertEqual(result.exit_status, expected_rc,
-                             f"Avocado did not return rc {expected_rc}:\n{result}")
+                             (f"Avocado did not return rc {expected_rc}:"
+                              f"\n{result}"))
 
             test_log_dir = glob.glob(os.path.join(self.tmpdir.name, 'job-*',
                                                   'test-results', '1-*'))[0]
@@ -735,8 +767,10 @@ class RunnerSimpleTest(TestCaseTmpDir):
         # simplewarning.sh calls "avocado exec-path" which hasn't
         # access to an installed location for the libexec scripts
         os.environ['PATH'] += ":" + os.path.join(BASEDIR, 'libexec')
-        cmd_line = (f'{AVOCADO} --show=test run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo --test-runner=runner examples/tests/simplewarning.sh')
+        cmd_line = (f'{AVOCADO} --show=test run '
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner '
+                    f'examples/tests/simplewarning.sh')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -755,7 +789,8 @@ class RunnerSimpleTest(TestCaseTmpDir):
         os.chdir(test_base_dir)
         test_file_name = os.path.basename(self.pass_script.path)
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo --test-runner=runner "{test_file_name}"')
+                    f'--disable-sysinfo '
+                    f'--test-runner=runner "{test_file_name}"')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -939,7 +974,8 @@ class PluginsTest(TestCaseTmpDir):
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
             self.assertEqual(result.exit_status, expected_rc,
-                             f"Avocado did not return rc {expected_rc}:\n{result}")
+                             (f"Avocado did not return rc {expected_rc}:"
+                              f"\n{result}"))
             self.assertNotIn(b"Collect system information", result.stdout)
 
     def test_plugin_order(self):
@@ -961,7 +997,8 @@ class PluginsTest(TestCaseTmpDir):
             result = process.run(cmd, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
             self.assertEqual(result.exit_status, expected_rc,
-                             f"Avocado did not return rc {expected_rc}:\n{result}")
+                             (f"Avocado did not return rc {expected_rc}:"
+                              f"\n{result}"))
 
         result_plugins = ["json", "xunit", "zip_archive"]
         result_outputs = ["results.json", "results.xml"]
@@ -1030,7 +1067,8 @@ class PluginsXunitTest(TestCaseTmpDir):
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip):
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo --test-runner=runner --xunit - {testname}')
+                    f'--disable-sysinfo --test-runner=runner '
+                    f'--xunit - {testname}')
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
         self.assertEqual(result.exit_status, e_rc,
@@ -1054,19 +1092,23 @@ class PluginsXunitTest(TestCaseTmpDir):
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
         self.assertEqual(n_tests, e_ntests,
-                         f"Unexpected number of executed tests, XML:\n{xml_output}")
+                         (f"Unexpected number of executed tests, XML:\n"
+                          f"{xml_output}"))
 
         n_errors = int(testsuite_tag.attributes['errors'].value)
         self.assertEqual(n_errors, e_nerrors,
-                         f"Unexpected number of test errors, XML:\n{xml_output}")
+                         (f"Unexpected number of test errors, XML:\n"
+                          f"{xml_output}"))
 
         n_failures = int(testsuite_tag.attributes['failures'].value)
         self.assertEqual(n_failures, e_nfailures,
-                         f"Unexpected number of test failures, XML:\n{xml_output}")
+                         (f"Unexpected number of test failures, XML:\n"
+                          f"{xml_output}"))
 
         n_skip = int(testsuite_tag.attributes['skipped'].value)
         self.assertEqual(n_skip, e_nskip,
-                         f"Unexpected number of test skips, XML:\n{xml_output}")
+                         f"Unexpected number of test skips, XML:\n"
+                         f"{xml_output}")
 
     def test_xunit_plugin_passtest(self):
         self.run_and_check('examples/tests/passtest.py',
@@ -1098,7 +1140,8 @@ class PluginsJSONTest(TestCaseTmpDir):
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip, e_ncancel=0):
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo --test-runner=runner --json - --archive {testname}')
+                    f'--disable-sysinfo --test-runner=runner --json - '
+                    f'--archive {testname}')
         result = process.run(cmd_line, ignore_status=True)
         json_output = result.stdout_text
         self.assertEqual(result.exit_status, e_rc,
@@ -1106,7 +1149,8 @@ class PluginsJSONTest(TestCaseTmpDir):
         try:
             json_data = json.loads(json_output)
         except Exception as detail:
-            raise ParseJSONError(f"Failed to parse content: {detail}\n{json_output}")
+            raise ParseJSONError((f"Failed to parse content: {detail}\n"
+                                  f"{json_output}"))
         self.assertTrue(json_data, f"Empty JSON result:\n{json_output}")
         self.assertIsInstance(json_data['tests'], list,
                               "JSON result lacks 'tests' list")

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -121,7 +121,7 @@ CC_BINARY = probe_binary('cc')
 GNU_ECHO_BINARY = probe_binary('echo')
 if GNU_ECHO_BINARY is not None:
     if probe_binary('man') is not None:
-        echo_cmd = 'man %s' % os.path.basename(GNU_ECHO_BINARY)
+        echo_cmd = f'man {os.path.basename(GNU_ECHO_BINARY)}'
         echo_manpage = process.run(echo_cmd, env={'LANG': 'C'},
                                    encoding='ascii').stdout
         if b'-e' not in echo_manpage:
@@ -133,11 +133,11 @@ SLEEP_BINARY = probe_binary('sleep')
 class RunnerOperationTest(TestCaseTmpDir):
 
     def test_show_version(self):
-        result = process.run('%s -v' % AVOCADO, ignore_status=True)
+        result = process.run(f'{AVOCADO} -v', ignore_status=True)
         self.assertEqual(result.exit_status, 0)
         self.assertTrue(re.match(r"^Avocado \d+\.\d+$", result.stdout_text),
-                        "Version string does not match 'Avocado \\d\\.\\d:'\n"
-                        "%r" % (result.stdout_text))
+                        (f"Version string does not match 'Avocado \\d\\.\\d:'\n"
+                         f"{result.stdout_text}"))
 
     def test_alternate_config_datadir(self):
         """
@@ -156,32 +156,31 @@ class RunnerOperationTest(TestCaseTmpDir):
         for key, value in mapping.items():
             if not os.path.isdir(value):
                 os.mkdir(value)
-            config += "%s = %s\n" % (key, value)
+            config += f"{key} = {value}\n"
         fd, config_file = tempfile.mkstemp(dir=self.tmpdir.name)
         os.write(fd, config.encode())
         os.close(fd)
 
-        cmd = '%s --config %s config --datadir' % (AVOCADO, config_file)
+        cmd = f'{AVOCADO} --config {config_file} config --datadir'
         result = process.run(cmd)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn('   base    ' + mapping['base_dir'], result.stdout_text)
         self.assertIn('   data    ' + mapping['data_dir'], result.stdout_text)
         self.assertIn('   logs    ' + mapping['logs_dir'], result.stdout_text)
 
     def test_runner_phases(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/phases.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/phases.py')
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_runner_all_ok(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/passtest.py examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/passtest.py examples/tests/passtest.py')
         process.run(cmd_line)
         # Also check whether jobdata contains correct parameter paths
         variants = open(os.path.join(self.tmpdir.name, "latest", "jobdata",
@@ -190,37 +189,33 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertEqual(variants, expected)
 
     def test_runner_failfast(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/passtest.py examples/tests/failtest.py '
-                    'examples/tests/passtest.py --failfast '
-                    '--nrunner-max-parallel-tasks=1'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/passtest.py examples/tests/failtest.py '
+                    f'examples/tests/passtest.py --failfast --nrunner-max-parallel-tasks=1')
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'Interrupting job (failfast).', result.stdout)
         self.assertIn(b'PASS 1 | ERROR 0 | FAIL 1 | SKIP 1', result.stdout)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_runner_ignore_missing_references_one_missing(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/passtest.py badtest.py --ignore-missing-references'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/passtest.py badtest.py --ignore-missing-references')
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'PASS 1 | ERROR 0 | FAIL 0 | SKIP 0', result.stdout)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_runner_ignore_missing_references_all_missing(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'badtest.py badtest2.py --ignore-missing-references'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+                    f'badtest.py badtest2.py --ignore-missing-references')
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'Suite is empty. There is no tests to run.', result.stderr)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_runner_test_with_local_imports(self):
         prefix = temp_dir_prefix(self)
@@ -234,23 +229,21 @@ class RunnerOperationTest(TestCaseTmpDir):
                      'class LocalImportTest(Test):\n'
                      '    def test(self):\n'
                      '        self.log.info(hello())\n')) as mytest:
-                    cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                                "%s" % (AVOCADO, self.tmpdir.name, mytest))
+                    cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                                f'--job-results-dir {self.tmpdir.name} {mytest}')
                     process.run(cmd_line)
 
     def test_unsupported_status(self):
         with script.TemporaryScript("fake_status.py",
                                     UNSUPPORTED_STATUS_TEST_CONTENTS,
                                     "avocado_unsupported_status") as tst:
-            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s"
-                              " --test-runner=runner"
-                              " --json -" % (AVOCADO, self.tmpdir.name, tst),
+            res = process.run((f"{AVOCADO} run --disable-sysinfo --job-results-dir "
+                               f"{self.tmpdir.name} {tst} --test-runner=runner --json -"),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
-                             "%s != %s\n%s" % (results["tests"][0]["status"],
-                                               "ERROR", res))
+                             f"{results['tests'][0]['status']} != {'ERROR'}\n{res}")
             self.assertIn("Runner error occurred: Test reports unsupported",
                           results["tests"][0]["fail_reason"])
 
@@ -263,120 +256,111 @@ class RunnerOperationTest(TestCaseTmpDir):
         with script.TemporaryScript("report_status_and_hang.py",
                                     REPORTS_STATUS_AND_HANG,
                                     "hanged_test_with_status") as tst:
-            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s "
-                              "--test-runner=runner "
-                              "--json - --job-timeout 1" % (AVOCADO, self.tmpdir.name, tst),
+            res = process.run((f"{AVOCADO} run --disable-sysinfo --job-results-dir "
+                              f"{self.tmpdir.name} {tst} --test-runner=runner --json - --job-timeout 1"),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
-                             "%s != %s\n%s" % (results["tests"][0]["status"],
-                                               "ERROR", res))
+                             f"{results['tests'][0]['status']} != {'ERROR'}\n{res}")
             self.assertIn("Test reported status but did not finish",
                           results["tests"][0]["fail_reason"])
             # Currently it should finish up to 1s after the job-timeout
             # but the prep and postprocess could take a bit longer on
             # some environments, so let's just check it does not take
             # > 60s, which is the deadline for force-finishing the test.
-            self.assertLess(res.duration, 55, "Test execution took too long, "
-                            "which is likely because the hanged test was not "
-                            "interrupted. Results:\n%s" % res)
+            self.assertLess(res.duration, 55,
+                            (f"Test execution took too long, "
+                             f"which is likely because the hanged test was not "
+                             f"interrupted. Results:\n{res}"))
 
     def test_no_status_reported(self):
         with script.TemporaryScript("die_without_reporting_status.py",
                                     DIE_WITHOUT_REPORTING_STATUS,
                                     "no_status_reported") as tst:
-            res = process.run("%s run --disable-sysinfo --job-results-dir %s %s "
-                              "--test-runner=runner "
-                              "--json -" % (AVOCADO, self.tmpdir.name, tst),
+            res = process.run((f"{AVOCADO} run --disable-sysinfo --job-results-dir "
+                               f"{self.tmpdir.name} {tst} --test-runner=runner --json -"),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)
             self.assertEqual(results["tests"][0]["status"], "ERROR",
-                             "%s != %s\n%s" % (results["tests"][0]["status"],
-                                               "ERROR", res))
+                             f"{results['tests'][0]['status']} != {'ERROR'}\n{res}")
             self.assertIn("Test died without reporting the status",
                           results["tests"][0]["fail_reason"])
 
     def test_runner_tests_fail(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/passtest.py '
-                    'examples/tests/failtest.py '
-                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} examples/tests/passtest.py '
+                    f'examples/tests/failtest.py examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_runner_nonexistent_test(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir '
-                    '%s bogustest' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} bogustest')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_JOB_FAIL
         unexpected_rc = exit_codes.AVOCADO_FAIL
         self.assertNotEqual(result.exit_status, unexpected_rc,
-                            "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
+                            f"Avocado crashed (rc {unexpected_rc}):\n{result}")
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_runner_doublefail(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s --xunit - '
-                    'examples/tests/doublefail.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} --xunit - examples/tests/doublefail.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         unexpected_rc = exit_codes.AVOCADO_FAIL
         self.assertNotEqual(result.exit_status, unexpected_rc,
-                            "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
+                            f"Avocado crashed (rc {unexpected_rc}):\n{result}")
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(b"TestError: Failing during tearDown. Yay!", result.stdout,
                       "Cleanup exception not printed to log output")
         self.assertIn(b"TestFail: This test is supposed to fail", result.stdout,
-                      "Test did not fail with action exception:\n%s" % result.stdout)
+                      f"Test did not fail with action exception:\n{result.stdout}")
 
     def test_uncaught_exception(self):
-        cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                    "--json - examples/tests/uncaught_exception.py"
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} --json - examples/tests/uncaught_exception.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc,
-                                                                result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(b'"status": "ERROR"', result.stdout)
 
     def test_fail_on_exception(self):
-        cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                    "--json - examples/tests/fail_on_exception.py"
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO}  run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} --json - examples/tests/fail_on_exception.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc,
-                                                                result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(b'"status": "FAIL"', result.stdout)
 
     def test_cancel_on_exception(self):
-        cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                    "--json - examples/tests/cancel_on_exception.py"
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} --json - examples/tests/cancel_on_exception.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc,
-                                                                result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+
         result = json.loads(result.stdout_text)
         for test in result['tests']:
             self.assertEqual(test['status'], 'CANCEL')
 
     def test_assert_raises(self):
-        cmd_line = ("%s run --disable-sysinfo --job-results-dir %s "
-                    "-- examples/tests/assert.py" % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} -- examples/tests/assert.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc,
-                                                                result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+
         self.assertIn(b'Assert.test_assert_raises:  PASS', result.stdout)
         self.assertIn(b'Assert.test_fails_to_raise:  FAIL', result.stdout)
         self.assertIn(b'PASS 1 | ERROR 0 | FAIL 1 ', result.stdout)
@@ -392,19 +376,16 @@ class RunnerOperationTest(TestCaseTmpDir):
         mytest = script.Script(os.path.join(self.tmpdir.name, "mytest.py"),
                                RAISE_CUSTOM_PATH_EXCEPTION_CONTENT)
         mytest.save()
-        result = process.run("%s --show test run --disable-sysinfo "
-                             "--test-runner=runner "
-                             "--job-results-dir %s %s"
-                             % (AVOCADO, self.tmpdir.name, mytest))
+        result = process.run(f'{AVOCADO} --show test run --disable-sysinfo '
+                             f'--test-runner=runner --job-results-dir {self.tmpdir.name} {mytest}')
         self.assertIn(b"mytest.py:SharedLibTest.test -> CancelExc: This "
                       b"should not crash on unpickling in runner",
                       result.stdout)
         self.assertNotIn(b"Failed to read queue", result.stdout)
 
     def test_runner_timeout(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/timeouttest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} examples/tests/timeouttest.py')
         result = process.run(cmd_line, ignore_status=True)
         json_path = os.path.join(self.tmpdir.name, 'latest', 'results.json')
         with open(json_path, encoding='utf-8') as json_file:
@@ -413,9 +394,9 @@ class RunnerOperationTest(TestCaseTmpDir):
         expected_rc = exit_codes.AVOCADO_JOB_INTERRUPTED
         unexpected_rc = exit_codes.AVOCADO_FAIL
         self.assertNotEqual(result.exit_status, unexpected_rc,
-                            "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
+                            f"Avocado crashed (rc {unexpected_rc}):\n{result}")
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn("timeout", result_json["tests"][0]["fail_reason"])
         # Ensure no test aborted error messages show up
         self.assertNotIn(b"TestAbortError: Test aborted unexpectedly", output)
@@ -425,30 +406,31 @@ class RunnerOperationTest(TestCaseTmpDir):
         """
         :avocado: tags=parallel:1
         """
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    '--test-runner=runner '
-                    '--xunit - examples/tests/abort.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} --test-runner=runner '
+                    f'--xunit - examples/tests/abort.py')
         result = process.run(cmd_line, ignore_status=True)
         excerpt = b'Test died without reporting the status.'
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         unexpected_rc = exit_codes.AVOCADO_FAIL
         self.assertNotEqual(result.exit_status, unexpected_rc,
-                            "Avocado crashed (rc %d):\n%s" % (unexpected_rc, result))
+                            f"Avocado crashed (rc {unexpected_rc}):\n{result}")
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(excerpt, result.stdout)
 
     def test_silent_output(self):
-        cmd_line = ('%s --show=none run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} --show=none run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(result.stdout, b'')
 
     def test_show_user_stream(self):
-        cmd_line = ('%s --show=app,avocado.test.progress run --disable-sysinfo '
-                    '--job-results-dir %s examples/tests/logging_streams.py' %
-                    (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} --show=app,avocado.test.progress run '
+                    f'--disable-sysinfo --job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/logging_streams.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertIn(b'Plant.test_plant_organic: preparing soil on row 0',
@@ -462,42 +444,40 @@ class RunnerOperationTest(TestCaseTmpDir):
                       result.stderr)
 
     def test_empty_test_list(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s'
-                    '--test-runner=runner ' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name}--test-runner=runner')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
         self.assertIn(b'No test references provided nor any other arguments '
                       b'resolved into tests', result.stderr)
 
     def test_not_found(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    '--test-runner=runner '
-                    'sbrubles' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} --test-runner=runner sbrubles')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
         self.assertIn(b'Unable to resolve reference', result.stderr)
         self.assertNotIn(b'Unable to resolve reference', result.stdout)
 
     def test_invalid_unique_id(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s --force-job-id '
-                    'foobar examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+                    f'--force-job-id foobar examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertNotEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertIn(b'needs to be a 40 digit hex', result.stderr)
         self.assertNotIn(b'needs to be a 40 digit hex', result.stdout)
 
     def test_valid_unique_id(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 '
-                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} --disable-sysinfo '
+                    f'--force-job-id 975de258ac05ce5e490648dec4753657b7ccc7d1 examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertNotIn(b'needs to be a 40 digit hex', result.stderr)
         self.assertIn(b'PASS', result.stdout)
 
     def test_automatic_unique_id(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    'examples/tests/passtest.py --json -' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} --disable-sysinfo '
+                    f'examples/tests/passtest.py --json -')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         r = json.loads(result.stdout_text)
@@ -511,8 +491,8 @@ class RunnerOperationTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/passtest.py')
         avocado_process = process.SubProcess(cmd_line)
         try:
             avocado_process.start()
@@ -530,16 +510,14 @@ class RunnerOperationTest(TestCaseTmpDir):
     def test_invalid_python(self):
         test = script.make_script(os.path.join(self.tmpdir.name, 'test.py'),
                                   INVALID_PYTHON_TEST)
-        cmd_line = ('%s --show test run --disable-sysinfo '
-                    '--job-results-dir %s '
-                    '--test-runner=runner '
-                    '%s') % (AVOCADO, self.tmpdir.name, test)
+        cmd_line = (f'{AVOCADO} --show test run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'--test-runner=runner {test}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
-        self.assertIn('1-%s:MyTest.test_my_name -> TestError' % test,
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+        self.assertIn(f'1-{test}:MyTest.test_my_name -> TestError',
                       result.stdout_text)
 
     @unittest.skipIf(not READ_BINARY, "read binary not available.")
@@ -548,22 +526,20 @@ class RunnerOperationTest(TestCaseTmpDir):
         """
         :avocado: tags=parallel:1
         """
-        cmd = "%s run --disable-sysinfo --job-results-dir %%s %%s" % AVOCADO
-        cmd %= (self.tmpdir.name, READ_BINARY)
+        cmd = (f'{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} '
+               f'{READ_BINARY}')
         result = process.run(cmd, timeout=10, ignore_status=True)
-        self.assertLess(result.duration, 8, "Duration longer than expected."
-                        "\n%s" % result)
-        self.assertEqual(result.exit_status, 1, "Expected exit status is 1\n%s"
-                         % result)
+        self.assertLess(result.duration, 8, f"Duration longer than expected.\n{result}")
+        self.assertEqual(result.exit_status, 1, f"Expected exit status is 1\n{result}")
 
     def test_runner_test_parameters(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    '-p "sleep_length=0.01" -- examples/tests/sleeptest.py '
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} -p "sleep_length=0.01" -- '
+                    f'examples/tests/sleeptest.py ')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
         json_path = os.path.join(self.tmpdir.name, 'latest', 'results.json')
         with open(json_path, encoding='utf-8') as json_file:
@@ -581,13 +557,12 @@ class RunnerOperationTest(TestCaseTmpDir):
                 TEST_OTHER_LOGGERS_CONTENT,
                 'avocado_functional_test_other_loggers') as mytest:
 
-            cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                        '-- %s' % (AVOCADO, self.tmpdir.name, mytest))
+            cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                        f'--job-results-dir {self.tmpdir.name} -- {mytest}')
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
             self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
+                             f"Avocado did not return rc {expected_rc}:\n{result}")
 
             test_log_dir = glob.glob(os.path.join(self.tmpdir.name, 'job-*',
                                                   'test-results', '1-*'))[0]
@@ -596,10 +571,9 @@ class RunnerOperationTest(TestCaseTmpDir):
                 self.assertNotIn(b'SHOULD NOT BE ON debug.log', test_log.read())
 
     def test_store_logging_stream(self):
-        cmd = ("%s run --job-results-dir %s "
-               "--store-logging-stream=avocado.test.progress "
-               "--disable-sysinfo -- examples/tests/logging_streams.py"
-               % (AVOCADO, self.tmpdir.name))
+        cmd = (f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+               f"--store-logging-stream=avocado.test.progress "
+               f"--disable-sysinfo -- examples/tests/logging_streams.py")
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
 
@@ -622,11 +596,9 @@ class DryRunTest(TestCaseTmpDir):
         passtest = os.path.join(examples_path, 'passtest.py')
         failtest = os.path.join(examples_path, 'failtest.py')
         gendata = os.path.join(examples_path, 'gendata.py')
-        cmd = ("%s run --disable-sysinfo --dry-run "
-               "--dry-run-no-cleanup --json - -- %s %s %s " % (AVOCADO,
-                                                               passtest,
-                                                               failtest,
-                                                               gendata))
+        cmd = (f"{AVOCADO} run --disable-sysinfo --dry-run "
+               f"--dry-run-no-cleanup --json - "
+               f"-- {passtest} {failtest} {gendata}")
         number_of_tests = 3
         result = json.loads(process.run(cmd).stdout_text)
         # Check if all tests were skipped
@@ -640,44 +612,39 @@ class DryRunTest(TestCaseTmpDir):
 class RunnerHumanOutputTest(TestCaseTmpDir):
 
     def test_output_pass(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(b'passtest.py:PassTest.test:  PASS', result.stdout)
 
     def test_output_fail(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/failtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} examples/tests/failtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
-        self.assertIn(b'examples/tests/failtest.py:FailTest.test:  FAIL',
-                      result.stdout)
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+        self.assertIn(b'examples/tests/failtest.py:FailTest.test:  FAIL', result.stdout)
 
     def test_output_error(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/errortest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} examples/tests/errortest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(b'errortest.py:ErrorTest.test:  ERROR', result.stdout)
 
     def test_output_cancel(self):
-        cmd_line = ('%s run --disable-sysinfo --job-results-dir %s '
-                    'examples/tests/cancelonsetup.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
+                    f'{self.tmpdir.name} examples/tests/cancelonsetup.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(b'PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | '
                       b'INTERRUPT 0 | CANCEL 1',
                       result.stdout)
@@ -699,22 +666,20 @@ class RunnerSimpleTest(TestCaseTmpDir):
         self.fail_script.save()
 
     def test_simpletest_pass(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
-                    ' "%s"' % (AVOCADO, self.tmpdir.name, self.pass_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo "{self.pass_script.path}"')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_simpletest_fail(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
-                    ' %s' % (AVOCADO, self.tmpdir.name, self.fail_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.fail_script.path}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     @skipOnLevelsInferiorThan(2)
     def test_runner_onehundred_fail_timing(self):
@@ -728,15 +693,15 @@ class RunnerSimpleTest(TestCaseTmpDir):
         :avocado: tags=parallel:1
         """
         one_hundred = 'examples/tests/failtest.py ' * 100
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
-                    % (AVOCADO, self.tmpdir.name, one_hundred))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {one_hundred}')
         initial_time = time.monotonic()
         result = process.run(cmd_line, ignore_status=True)
         actual_time = time.monotonic() - initial_time
         self.assertLess(actual_time, 60.0)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     @skipOnLevelsInferiorThan(2)
     def test_runner_sleep_fail_sleep_timing(self):
@@ -749,15 +714,15 @@ class RunnerSimpleTest(TestCaseTmpDir):
         sleep_fail_sleep = ('examples/tests/sleeptest.py ' +
                             'examples/tests/failtest.py ' * 100 +
                             'examples/tests/sleeptest.py')
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
-                    % (AVOCADO, self.tmpdir.name, sleep_fail_sleep))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {sleep_fail_sleep}')
         initial_time = time.monotonic()
         result = process.run(cmd_line, ignore_status=True)
         actual_time = time.monotonic() - initial_time
         self.assertLess(actual_time, 63.0)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_simplewarning(self):
         """
@@ -770,15 +735,12 @@ class RunnerSimpleTest(TestCaseTmpDir):
         # simplewarning.sh calls "avocado exec-path" which hasn't
         # access to an installed location for the libexec scripts
         os.environ['PATH'] += ":" + os.path.join(BASEDIR, 'libexec')
-        cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
-                    '--test-runner=runner '
-                    'examples/tests/simplewarning.sh'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} --show=test run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner examples/tests/simplewarning.sh')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %s:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(b'DEBUG| Debug message', result.stdout, result)
         self.assertIn(b'INFO | Info message', result.stdout, result)
         self.assertIn(b'WARN | Warning message (should cause this test to '
@@ -792,15 +754,12 @@ class RunnerSimpleTest(TestCaseTmpDir):
         test_base_dir = os.path.dirname(self.pass_script.path)
         os.chdir(test_base_dir)
         test_file_name = os.path.basename(self.pass_script.path)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
-                    ' --test-runner=runner'
-                    ' "%s"' % (AVOCADO, self.tmpdir.name,
-                               test_file_name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner "{test_file_name}"')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def tearDown(self):
         self.pass_script.remove()
@@ -827,10 +786,9 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                              'avocado_simpletest_'
                                              'functional')
         warn_script.save()
-        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
-                    ' --test-runner=runner'
-                    ' %s --json -' % (AVOCADO, self.config_file.path,
-                                      self.tmpdir.name, warn_script.path))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.path} run '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo '
+                    f'--test-runner=runner {warn_script.path} --json -')
         result = process.run(cmd_line, ignore_status=True)
         json_results = json.loads(result.stdout_text)
         self.assertEqual(json_results['tests'][0]['status'], 'WARN')
@@ -841,10 +799,9 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                              'avocado_simpletest_'
                                              'functional')
         skip_script.save()
-        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
-                    ' --test-runner=runner'
-                    ' %s --json -' % (AVOCADO, self.config_file.path,
-                                      self.tmpdir.name, skip_script.path))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.path} run '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo '
+                    f' --test-runner=runner {skip_script.path} --json -')
         result = process.run(cmd_line, ignore_status=True)
         json_results = json.loads(result.stdout_text)
         self.assertEqual(json_results['tests'][0]['status'], 'SKIP')
@@ -855,10 +812,9 @@ class RunnerSimpleTestStatus(TestCaseTmpDir):
                                               'avocado_simpletest_'
                                               'functional')
         skip2_script.save()
-        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
-                    ' --test-runner=runner'
-                    ' %s --json -' % (AVOCADO, self.config_file.path,
-                                      self.tmpdir.name, skip2_script.path))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.path} run '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo '
+                    f' --test-runner=runner {skip2_script.path} --json -')
         result = process.run(cmd_line, ignore_status=True)
         json_results = json.loads(result.stdout_text)
         self.assertEqual(json_results['tests'][0]['status'], 'PASS')
@@ -880,12 +836,12 @@ class RunnerReferenceFromConfig(TestCaseTmpDir):
 
     @skipUnlessPathExists('/bin/true')
     def test(self):
-        cmd_line = '%s --config %s run --job-results-dir %s --disable-sysinfo'
-        cmd_line %= (AVOCADO, self.config_file.path, self.tmpdir.name)
+        cmd_line = (f'{AVOCADO} --config {self.config_file.path} run '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo ')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def tearDown(self):
         super().tearDown()
@@ -904,14 +860,13 @@ class RunnerSimpleTestFailureFields(TestCaseTmpDir):
 
     def test_simpletest_failure_fields(self):
         fail_test = os.path.join(BASEDIR, 'examples', 'tests', 'failtest.sh')
-        cmd_line = ('%s --config %s run --job-results-dir %s --disable-sysinfo'
-                    ' --test-runner=runner'
-                    ' -- %s' % (AVOCADO, self.config_file.path,
-                                self.tmpdir.name, fail_test))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.path} run '
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner -- {fail_test}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertNotIn("Exited with status: '1'", result.stdout_text)
 
     def tearDown(self):
@@ -922,76 +877,69 @@ class RunnerSimpleTestFailureFields(TestCaseTmpDir):
 class PluginsTest(TestCaseTmpDir):
 
     def test_sysinfo_plugin(self):
-        cmd_line = '%s sysinfo %s' % (AVOCADO, self.tmpdir.name)
+        cmd_line = f'{AVOCADO} sysinfo {self.tmpdir.name}'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         sysinfo_files = os.listdir(self.tmpdir.name)
         self.assertGreater(len(sysinfo_files), 0, "Empty sysinfo files dir")
 
     def test_list_plugin(self):
-        cmd_line = '%s list' % AVOCADO
+        cmd_line = f'{AVOCADO} list'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertNotIn(b'No tests were found on current tests dir',
                          result.stdout)
 
     def test_list_error_output(self):
-        cmd_line = '%s list sbrubles' % AVOCADO
+        cmd_line = f'{AVOCADO} list sbrubles'
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual("", result.stdout_text)
 
     def test_plugin_list(self):
-        cmd_line = '%s plugins' % AVOCADO
+        cmd_line = f'{AVOCADO} plugins'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertNotIn(b'Disabled', result.stdout)
 
     def test_config_plugin(self):
-        cmd_line = '%s config ' % AVOCADO
+        cmd_line = f'{AVOCADO} config '
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertNotIn(b'Disabled', result.stdout)
 
     def test_config_plugin_datadir(self):
-        cmd_line = '%s config --datadir ' % AVOCADO
+        cmd_line = f'{AVOCADO} config --datadir '
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertNotIn(b'Disabled', result.stdout)
 
     def test_disable_plugin(self):
-        cmd_line = '%s plugins' % AVOCADO
+        cmd_line = f'{AVOCADO} plugins'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(b"Collect system information", result.stdout)
 
         config_content = "[plugins]\ndisable=['cli.cmd.sysinfo',]"
         config = script.TemporaryScript("disable_sysinfo_cmd.conf",
                                         config_content)
         with config:
-            cmd_line = '%s --config %s plugins' % (AVOCADO, config)
+            cmd_line = f'{AVOCADO} --config {config} plugins'
             result = process.run(cmd_line, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
             self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
+                             f"Avocado did not return rc {expected_rc}:\n{result}")
             self.assertNotIn(b"Collect system information", result.stdout)
 
     def test_plugin_order(self):
@@ -1006,14 +954,14 @@ class PluginsTest(TestCaseTmpDir):
         json and xunit output files *do* make into the archive.
         """
         def run_config(config_path):
-            cmd = ('%s --config %s run examples/tests/passtest.py --archive '
-                   '--job-results-dir %s --disable-sysinfo'
-                   % (AVOCADO, config_path, self.tmpdir.name))
+            cmd = (f'{AVOCADO} --config {config_path} '
+                   f'run examples/tests/passtest.py --archive '
+                   f'--job-results-dir {self.tmpdir.name} '
+                   f'--disable-sysinfo')
             result = process.run(cmd, ignore_status=True)
             expected_rc = exit_codes.AVOCADO_ALL_OK
             self.assertEqual(result.exit_status, expected_rc,
-                             "Avocado did not return rc %d:\n%s" %
-                             (expected_rc, result))
+                             f"Avocado did not return rc {expected_rc}:\n{result}")
 
         result_plugins = ["json", "xunit", "zip_archive"]
         result_outputs = ["results.json", "results.xml"]
@@ -1021,12 +969,11 @@ class PluginsTest(TestCaseTmpDir):
             result_plugins.append("html")
             result_outputs.append("results.html")
 
-        cmd_line = '%s plugins' % AVOCADO
+        cmd_line = f'{AVOCADO} plugins'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         for result_plugin in result_plugins:
             self.assertIn(result_plugin, result.stdout_text)
 
@@ -1058,12 +1005,11 @@ class PluginsTest(TestCaseTmpDir):
                 self.assertIn(result_output, zip_file_list)
 
     def test_Namespace_object_has_no_attribute(self):
-        cmd_line = '%s plugins' % AVOCADO
+        cmd_line = f'{AVOCADO} plugins'
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertNotIn(b"'Namespace' object has no attribute", result.stderr)
 
 
@@ -1083,19 +1029,16 @@ class PluginsXunitTest(TestCaseTmpDir):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo'
-                    ' --test-runner=runner'
-                    ' --xunit - %s' % (AVOCADO, self.tmpdir.name, testname))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner --xunit - {testname}')
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
         self.assertEqual(result.exit_status, e_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (e_rc, result))
+                         f"Avocado did not return rc {e_rc}:\n{result}")
         try:
             xunit_doc = xml.dom.minidom.parseString(xml_output)
         except Exception as detail:
-            raise ParseXMLError("Failed to parse content: %s\n%s" %
-                                (detail, xml_output))
+            raise ParseXMLError(f"Failed to parse content: {detail}\n{xml_output}")
 
         # pylint: disable=I1101
         xunit_file_output = os.path.join(self.tmpdir.name, 'latest', 'results.xml')
@@ -1106,28 +1049,24 @@ class PluginsXunitTest(TestCaseTmpDir):
 
         testsuite_tag = testsuite_list[0]
         self.assertEqual(len(testsuite_tag.attributes), 7,
-                         'The testsuite tag does not have 7 attributes. '
-                         'XML:\n%s' % xml_output)
+                         (f'The testsuite tag does not have 7 attributes. '
+                          f'XML:\n{xml_output}'))
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
         self.assertEqual(n_tests, e_ntests,
-                         "Unexpected number of executed tests, "
-                         "XML:\n%s" % xml_output)
+                         f"Unexpected number of executed tests, XML:\n{xml_output}")
 
         n_errors = int(testsuite_tag.attributes['errors'].value)
         self.assertEqual(n_errors, e_nerrors,
-                         "Unexpected number of test errors, "
-                         "XML:\n%s" % xml_output)
+                         f"Unexpected number of test errors, XML:\n{xml_output}")
 
         n_failures = int(testsuite_tag.attributes['failures'].value)
         self.assertEqual(n_failures, e_nfailures,
-                         "Unexpected number of test failures, "
-                         "XML:\n%s" % xml_output)
+                         f"Unexpected number of test failures, XML:\n{xml_output}")
 
         n_skip = int(testsuite_tag.attributes['skipped'].value)
         self.assertEqual(n_skip, e_nskip,
-                         "Unexpected number of test skips, "
-                         "XML:\n%s" % xml_output)
+                         f"Unexpected number of test skips, XML:\n{xml_output}")
 
     def test_xunit_plugin_passtest(self):
         self.run_and_check('examples/tests/passtest.py',
@@ -1158,20 +1097,17 @@ class PluginsJSONTest(TestCaseTmpDir):
 
     def run_and_check(self, testname, e_rc, e_ntests, e_nerrors,
                       e_nfailures, e_nskip, e_ncancel=0):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--test-runner=runner '
-                    '--json - --archive %s' % (AVOCADO, self.tmpdir.name, testname))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner --json - --archive {testname}')
         result = process.run(cmd_line, ignore_status=True)
         json_output = result.stdout_text
         self.assertEqual(result.exit_status, e_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (e_rc, result))
+                         f"Avocado did not return rc {e_rc}:\n{result}")
         try:
             json_data = json.loads(json_output)
         except Exception as detail:
-            raise ParseJSONError("Failed to parse content: %s\n%s" %
-                                 (detail, json_output))
-        self.assertTrue(json_data, "Empty JSON result:\n%s" % json_output)
+            raise ParseJSONError(f"Failed to parse content: {detail}\n{json_output}")
+        self.assertTrue(json_data, f"Empty JSON result:\n{json_output}")
         self.assertIsInstance(json_data['tests'], list,
                               "JSON result lacks 'tests' list")
         n_tests = len(json_data['tests'])

--- a/selftests/functional/test_coroutine.py
+++ b/selftests/functional/test_coroutine.py
@@ -10,9 +10,9 @@ class Coroutine(TestCaseTmpDir):
         test_path = os.path.join(BASEDIR,
                                  "examples", "tests", "sleeptest_async.py")
         os.environ['PYTHONASYNCIODEBUG'] = '1'
-        cmd = ("{} --show=test run --disable-sysinfo --job-results-dir {} "
-               "-p sleep_length=0 {}").format(AVOCADO, self.tmpdir.name,
-                                              test_path)
+        cmd = (f'{AVOCADO} --show=test run --disable-sysinfo '
+               f'--job-results-dir {self.tmpdir.name} '
+               f'-p sleep_length=0 {test_path}')
         result = process.run(cmd, ignore_status=True)
         self.assertEqual(result.exit_status, 0)
         self.assertNotIn("RuntimeWarning: coroutine 'AsyncSleepTest.test' "

--- a/selftests/functional/test_export_variables.py
+++ b/selftests/functional/test_export_variables.py
@@ -6,7 +6,7 @@ from avocado.core import exit_codes
 from avocado.utils import process, script
 from selftests.utils import AVOCADO, BASEDIR, TestCaseTmpDir
 
-SCRIPT_CONTENT = """#!/bin/sh
+SCRIPT_CONTENT = (f"""#!/bin/sh
 echo "Avocado Version: $AVOCADO_VERSION"
 echo "Avocado Test basedir: $AVOCADO_TEST_BASEDIR"
 echo "Avocado Test workdir: $AVOCADO_TEST_WORKDIR"
@@ -14,13 +14,13 @@ echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"
 echo "Avocado Test outputdir: $AVOCADO_TEST_OUTPUTDIR"
 
-test "$AVOCADO_VERSION" = "{version}" -a \
+test "$AVOCADO_VERSION" = "{VERSION}" -a \
      -d "$AVOCADO_TEST_BASEDIR" -a \
      -d "$AVOCADO_TEST_WORKDIR" -a \
      -d "$AVOCADO_TEST_LOGDIR" -a \
      -f "$AVOCADO_TEST_LOGFILE" -a \
      -d "$AVOCADO_TEST_OUTPUTDIR"
-""".format(version=VERSION)
+""")
 
 
 class EnvironmentVariablesTest(TestCaseTmpDir):
@@ -35,14 +35,12 @@ class EnvironmentVariablesTest(TestCaseTmpDir):
 
     def test_environment_vars(self):
         os.chdir(BASEDIR)
-        cmd_line = ('%s run --job-results-dir %s %s'
-                    ' --test-runner=runner'
-                    % (AVOCADO, self.tmpdir.name, self.script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'{self.script.path} --test-runner=runner')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         "Avocado did not return rc {expected_rc}:\n{result}")
 
     def tearDown(self):
         super().tearDown()

--- a/selftests/functional/test_fetch_asset.py
+++ b/selftests/functional/test_fetch_asset.py
@@ -47,25 +47,22 @@ class FetchAsset(unittest.TestCase):
         localpath = os.path.join(self.asset_dir, assetname)
         with open(localpath, 'w', encoding='utf-8') as f:
             f.write('Test!')
-        url = 'file://%s' % localpath
-        fetch_content = r"""
+        url = f'file://{localpath}'
+        fetch_content = (fr"""
         foo = self.fetch_asset(
-            '%s',
-            locations='%s',
+            '{assetname}',
+            locations='{url}',
             find_only=True)
         print(foo)
-        """ % (assetname, url)
+        """)
         test_content = TEST_TEMPLATE.format(content=fetch_content)
         test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
         test_file.close()
 
         expected_rc = exit_codes.AVOCADO_ALL_OK
-        cmd_line = ("%s --config %s run "
-                    "--test-runner=runner "
-                    "%s" % (AVOCADO,
-                            self.config_file.name,
-                            test_file.name))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.name} run '
+                    f'--test-runner=runner {test_file.name}')
         result = process.run(cmd_line)
         os.remove(localpath)
         self.assertEqual(expected_rc, result.exit_status)
@@ -77,15 +74,15 @@ class FetchAsset(unittest.TestCase):
         """
         fake_assetname = 'fake_foo.tgz'
         localpath = os.path.join(self.asset_dir, fake_assetname)
-        fake_url = 'file://%s' % localpath
-        fetch_content = r"""
+        fake_url = f'file://{localpath}'
+        fetch_content = (fr"""
         foo = self.fetch_asset(
-            '%s',
-            locations='%s',
+            '{fake_assetname}',
+            locations='{fake_url}',
             find_only=True)
         if foo is None:
             raise OSError('Asset not found')
-        """ % (fake_assetname, fake_url)
+        """)
         test_content = TEST_TEMPLATE.format(content=fetch_content)
         test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
@@ -94,11 +91,8 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         expected_stdout = "not found in the cache"
 
-        cmd_line = ("%s --config %s run "
-                    "--test-runner=runner "
-                    "%s" % (AVOCADO,
-                            self.config_file.name,
-                            test_file.name))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.name} run '
+                    f'--test-runner=runner {test_file.name}')
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)
@@ -111,14 +105,14 @@ class FetchAsset(unittest.TestCase):
         """
         fake_assetname = 'fake_foo.tgz'
         localpath = os.path.join(self.asset_dir, fake_assetname)
-        fake_url = 'file://%s' % localpath
-        fetch_content = r"""
+        fake_url = f'file://{localpath}'
+        fetch_content = (fr"""
         foo = self.fetch_asset(
-            '%s',
-            locations='%s',
+            '{fake_assetname}',
+            locations='{fake_url}',
             find_only=True,
             cancel_on_missing=True)
-        """ % (fake_assetname, fake_url)
+        """)
         test_content = TEST_TEMPLATE.format(content=fetch_content)
         test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
@@ -127,11 +121,8 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_stdout = "Missing asset"
 
-        cmd_line = ("%s --config %s run "
-                    "--test-runner=runner "
-                    "%s" % (AVOCADO,
-                            self.config_file.name,
-                            test_file.name))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.name} run '
+                    f'--test-runner=runner {test_file.name}')
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)
@@ -144,13 +135,13 @@ class FetchAsset(unittest.TestCase):
         """
         fake_assetname = 'fake_foo.tgz'
         localpath = os.path.join(self.asset_dir, fake_assetname)
-        fake_url = 'file://%s' % localpath
-        fetch_content = r"""
+        fake_url = f'file://{localpath}'
+        fetch_content = (fr"""
         foo = self.fetch_asset(
-            '%s',
-            locations='%s',
+            '{fake_assetname}',
+            locations='{fake_url}',
             cancel_on_missing=True)
-        """ % (fake_assetname, fake_url)
+        """)
         test_content = TEST_TEMPLATE.format(content=fetch_content)
         test_file = tempfile.NamedTemporaryFile(suffix=".py", dir=self.base_dir.name, delete=False)
         test_file.write(test_content.encode())
@@ -159,11 +150,8 @@ class FetchAsset(unittest.TestCase):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         expected_stdout = "Missing asset"
 
-        cmd_line = ("%s --config %s run "
-                    "--test-runner=runner "
-                    "%s " % (AVOCADO,
-                             self.config_file.name,
-                             test_file.name))
+        cmd_line = (f'{AVOCADO} --config {self.config_file.name} run '
+                    f'--test-runner=runner {test_file.name} ')
 
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(expected_rc, result.exit_status)

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -104,7 +104,8 @@ class InterruptTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        bad_test_basename = f'wontquit-{data_factory.generate_random_string(5)}'
+        bad_test_basename = \
+            f'wontquit-{data_factory.generate_random_string(5)}'
         bad_test = script.TemporaryScript(bad_test_basename, BAD_TEST,
                                           'avocado_interrupt_test',
                                           mode=DEFAULT_MODE)
@@ -151,7 +152,8 @@ class InterruptTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        bad_test_basename = f'wontquit-{data_factory.generate_random_string(5)}'
+        bad_test_basename = \
+            f'wontquit-{data_factory.generate_random_string(5)}'
         bad_test = script.TemporaryScript(bad_test_basename, BAD_TEST,
                                           'avocado_interrupt_test',
                                           mode=DEFAULT_MODE)
@@ -190,7 +192,8 @@ class InterruptTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        good_test_basename = f'goodtest-{data_factory.generate_random_string(5)}.py'
+        good_test_basename = \
+            f'goodtest-{data_factory.generate_random_string(5)}.py'
         good_test = script.TemporaryScript(good_test_basename, GOOD_TEST,
                                            'avocado_interrupt_test',
                                            mode=DEFAULT_MODE)
@@ -233,7 +236,8 @@ class InterruptTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        good_test_basename = f'goodtest-{data_factory.generate_random_string(5)}.py'
+        good_test_basename = \
+            f'goodtest-{data_factory.generate_random_string(5)}.py'
         good_test = script.TemporaryScript(good_test_basename, GOOD_TEST,
                                            'avocado_interrupt_test',
                                            mode=DEFAULT_MODE)

--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -104,17 +104,15 @@ class InterruptTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        bad_test_basename = ('wontquit-%s' %
-                             data_factory.generate_random_string(5))
+        bad_test_basename = f'wontquit-{data_factory.generate_random_string(5)}'
         bad_test = script.TemporaryScript(bad_test_basename, BAD_TEST,
                                           'avocado_interrupt_test',
                                           mode=DEFAULT_MODE)
         bad_test.save()
         self.test_module = bad_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s '
-               '--test-runner=runner'
-               % (AVOCADO, self.test_module, self.tmpdir.name))
+        cmd = (f'{AVOCADO} run {self.test_module} --disable-sysinfo '
+               f'--job-results-dir {self.tmpdir.name} --test-runner=runner')
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
@@ -153,16 +151,15 @@ class InterruptTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        bad_test_basename = ('wontquit-%s' %
-                             data_factory.generate_random_string(5))
+        bad_test_basename = f'wontquit-{data_factory.generate_random_string(5)}'
         bad_test = script.TemporaryScript(bad_test_basename, BAD_TEST,
                                           'avocado_interrupt_test',
                                           mode=DEFAULT_MODE)
         bad_test.save()
         self.test_module = bad_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s ' %
-               (AVOCADO, self.test_module, self.tmpdir.name))
+        cmd = (f'{AVOCADO} run {self.test_module} --disable-sysinfo '
+               f'--job-results-dir {self.tmpdir.name} ')
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
@@ -193,16 +190,15 @@ class InterruptTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        good_test_basename = ('goodtest-%s.py' %
-                              data_factory.generate_random_string(5))
+        good_test_basename = f'goodtest-{data_factory.generate_random_string(5)}.py'
         good_test = script.TemporaryScript(good_test_basename, GOOD_TEST,
                                            'avocado_interrupt_test',
                                            mode=DEFAULT_MODE)
         good_test.save()
         self.test_module = good_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run --test-runner=runner %s --disable-sysinfo --job-results-dir %s ' %
-               (AVOCADO, self.test_module, self.tmpdir.name))
+        cmd = (f'{AVOCADO} run --test-runner=runner {self.test_module} '
+               f'--disable-sysinfo --job-results-dir {self.tmpdir.name} ')
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
@@ -237,16 +233,15 @@ class InterruptTest(TestCaseTmpDir):
 
         :avocado: tags=parallel:1
         """
-        good_test_basename = ('goodtest-%s.py' %
-                              data_factory.generate_random_string(5))
+        good_test_basename = f'goodtest-{data_factory.generate_random_string(5)}.py'
         good_test = script.TemporaryScript(good_test_basename, GOOD_TEST,
                                            'avocado_interrupt_test',
                                            mode=DEFAULT_MODE)
         good_test.save()
         self.test_module = good_test.path
         os.chdir(BASEDIR)
-        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s ' %
-               (AVOCADO, self.test_module, self.tmpdir.name))
+        cmd = (f'{AVOCADO} run {self.test_module} --disable-sysinfo '
+               f'--job-results-dir {self.tmpdir.name} ')
         proc = subprocess.Popen(cmd.split(),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -55,7 +55,8 @@ class JobTimeOutTest(TestCaseTmpDir):
         try:
             xunit_doc = xml.dom.minidom.parseString(xml_output)
         except Exception as detail:
-            raise ParseXMLError(f"Failed to parse content: {detail}\n{xml_output}")
+            raise ParseXMLError(f"Failed to parse content: {detail}\n"
+                                f"{xml_output}")
 
         testsuite_list = xunit_doc.getElementsByTagName('testsuite')
         self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
@@ -67,19 +68,23 @@ class JobTimeOutTest(TestCaseTmpDir):
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
         self.assertEqual(n_tests, e_ntests,
-                         f"Unexpected number of executed tests, XML:\n{xml_output}")
+                         (f"Unexpected number of executed tests, XML:\n"
+                          f"{xml_output}"))
 
         n_errors = int(testsuite_tag.attributes['errors'].value)
         self.assertEqual(n_errors, e_nerrors,
-                         f"Unexpected number of test errors, XML:\n{xml_output}")
+                         (f"Unexpected number of test errors, XML:\n"
+                          f"{xml_output}"))
 
         n_failures = int(testsuite_tag.attributes['failures'].value)
         self.assertEqual(n_failures, e_nfailures,
-                         f"Unexpected number of test failures, XML:\n{xml_output}")
+                         (f"Unexpected number of test failures, XML:\n"
+                          f"{xml_output}"))
 
         n_skip = int(testsuite_tag.attributes['skipped'].value)
         self.assertEqual(n_skip, e_nskip,
-                         f"Unexpected number of test skips, XML:\n{xml_output}")
+                         (f"Unexpected number of test skips, XML:\n"
+                          f"{xml_output}"))
 
     def _check_timeout_msg(self, idx):
         res_dir = os.path.join(self.tmpdir.name, "latest", "test-results")
@@ -89,20 +94,23 @@ class JobTimeOutTest(TestCaseTmpDir):
                       (f"Runner error occurred: Timeout reached message not "
                        f"in the {idx}st test's debug.log:\n{debug_log}"))
         self.assertIn("Traceback (most recent call last)", debug_log,
-                      f"Traceback not present in the {idx}st test's debug.log:\n{debug_log}")
+                      (f"Traceback not present in the {idx}st test's "
+                       f"debug.log:\n{debug_log}"))
 
     @skipOnLevelsInferiorThan(1)
     def test_sleep_longer_timeout(self):
         """:avocado: tags=parallel:1"""
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
                     f'--disable-sysinfo --test-runner=runner --xunit - '
-                    f'--job-timeout=5 {self.script.path} examples/tests/passtest.py')
+                    f'--job-timeout=5 {self.script.path} '
+                    f'examples/tests/passtest.py')
         self.run_and_check(cmd_line, 0, 2, 0, 0, 0)
 
     def test_sleep_short_timeout(self):
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
                     f'--disable-sysinfo --test-runner=runner --xunit - '
-                    f'--job-timeout=1 {self.script.path} examples/tests/passtest.py')
+                    f'--job-timeout=1 {self.script.path} '
+                    f'examples/tests/passtest.py')
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,
                            2, 1, 0, 1)
         self._check_timeout_msg(1)

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -51,114 +51,103 @@ class JobTimeOutTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         xml_output = result.stdout
         self.assertEqual(result.exit_status, e_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (e_rc, result))
+                         f"Avocado did not return rc {e_rc}:\n{result}")
         try:
             xunit_doc = xml.dom.minidom.parseString(xml_output)
         except Exception as detail:
-            raise ParseXMLError("Failed to parse content: %s\n%s" %
-                                (detail, xml_output))
+            raise ParseXMLError(f"Failed to parse content: {detail}\n{xml_output}")
 
         testsuite_list = xunit_doc.getElementsByTagName('testsuite')
         self.assertEqual(len(testsuite_list), 1, 'More than one testsuite tag')
 
         testsuite_tag = testsuite_list[0]
         self.assertEqual(len(testsuite_tag.attributes), 7,
-                         'The testsuite tag does not have 7 attributes. '
-                         'XML:\n%s' % xml_output)
+                         (f'The testsuite tag does not have 7 attributes. '
+                          f'XML:\n{xml_output}'))
 
         n_tests = int(testsuite_tag.attributes['tests'].value)
         self.assertEqual(n_tests, e_ntests,
-                         "Unexpected number of executed tests, "
-                         "XML:\n%s" % xml_output)
+                         f"Unexpected number of executed tests, XML:\n{xml_output}")
 
         n_errors = int(testsuite_tag.attributes['errors'].value)
         self.assertEqual(n_errors, e_nerrors,
-                         "Unexpected number of test errors, "
-                         "XML:\n%s" % xml_output)
+                         f"Unexpected number of test errors, XML:\n{xml_output}")
 
         n_failures = int(testsuite_tag.attributes['failures'].value)
         self.assertEqual(n_failures, e_nfailures,
-                         "Unexpected number of test failures, "
-                         "XML:\n%s" % xml_output)
+                         f"Unexpected number of test failures, XML:\n{xml_output}")
 
         n_skip = int(testsuite_tag.attributes['skipped'].value)
         self.assertEqual(n_skip, e_nskip,
-                         "Unexpected number of test skips, "
-                         "XML:\n%s" % xml_output)
+                         f"Unexpected number of test skips, XML:\n{xml_output}")
 
     def _check_timeout_msg(self, idx):
         res_dir = os.path.join(self.tmpdir.name, "latest", "test-results")
-        debug_log_paths = glob.glob(os.path.join(res_dir, "%s-*" % idx, "debug.log"))
+        debug_log_paths = glob.glob(os.path.join(res_dir, f"{idx}-*", "debug.log"))
         debug_log = genio.read_file(debug_log_paths[0])
         self.assertIn("Runner error occurred: Timeout reached", debug_log,
-                      "Runner error occurred: Timeout reached message not "
-                      "in the %sst test's debug.log:\n%s"
-                      % (idx, debug_log))
+                      (f"Runner error occurred: Timeout reached message not "
+                       f"in the {idx}st test's debug.log:\n{debug_log}"))
         self.assertIn("Traceback (most recent call last)", debug_log,
-                      "Traceback not present in the %sst test's debug.log:\n%s"
-                      % (idx, debug_log))
+                      f"Traceback not present in the {idx}st test's debug.log:\n{debug_log}")
 
     @skipOnLevelsInferiorThan(1)
     def test_sleep_longer_timeout(self):
         """:avocado: tags=parallel:1"""
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--test-runner=runner '
-                    '--xunit - --job-timeout=5 %s examples/tests/passtest.py' %
-                    (AVOCADO, self.tmpdir.name, self.script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner --xunit - '
+                    f'--job-timeout=5 {self.script.path} examples/tests/passtest.py')
         self.run_and_check(cmd_line, 0, 2, 0, 0, 0)
 
     def test_sleep_short_timeout(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--test-runner=runner '
-                    '--xunit - --job-timeout=1 %s examples/tests/passtest.py' %
-                    (AVOCADO, self.tmpdir.name, self.script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner --xunit - '
+                    f'--job-timeout=1 {self.script.path} examples/tests/passtest.py')
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,
                            2, 1, 0, 1)
         self._check_timeout_msg(1)
 
     def test_sleep_short_timeout_with_test_methods(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--test-runner=runner '
-                    '--xunit - --job-timeout=1 %s' %
-                    (AVOCADO, self.tmpdir.name, self.py.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner --xunit - '
+                    f'--job-timeout=1 {self.py.path}')
         self.run_and_check(cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED,
                            3, 1, 0, 2)
         self._check_timeout_msg(1)
 
     def test_invalid_values(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--job-timeout=1,5 examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --job-timeout=1,5 '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
         self.assertIn(b'invalid time_to_seconds value', result.stderr)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--job-timeout=123x examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --job-timeout=123x '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
         self.assertIn(b'invalid time_to_seconds', result.stderr)
 
     def test_valid_values(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--job-timeout=123 examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --job-timeout=123 '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--job-timeout=123s examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --job-timeout=123s '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--job-timeout=123m examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --job-timeout=123m '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--job-timeout=123h examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --job-timeout=123h '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
 

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -13,7 +13,8 @@ class JournalPluginTests(TestCaseTmpDir):
     def setUp(self):
         super().setUp()
         self.cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                         f'--disable-sysinfo --json - --journal examples/tests/passtest.py')
+                         f'--disable-sysinfo --json - '
+                         f'--journal examples/tests/passtest.py')
         self.result = process.run(self.cmd_line, ignore_status=True)
         data = json.loads(self.result.stdout_text)
         self.job_id = data['job_id']
@@ -23,23 +24,27 @@ class JournalPluginTests(TestCaseTmpDir):
     def test_journal_job_id(self):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(self.result.exit_status, expected_rc,
-                         f"Command '{self.cmd_line}' did not return {expected_rc}")
+                         (f"Command '{self.cmd_line}' did not return "
+                          f"{expected_rc}"))
         cur = self.db.cursor()
         cur.execute('SELECT unique_id FROM job_info;')
         db_job_id = cur.fetchone()[0]
         self.assertEqual(db_job_id, self.job_id,
-                         f"The job ids differs, expected {self.job_id} got {db_job_id}")
+                         (f"The job ids differs, expected {self.job_id} "
+                          f"got {db_job_id}"))
 
     def test_journal_count_entries(self):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(self.result.exit_status, expected_rc,
-                         f"Command '{self.cmd_line}' did not return {expected_rc}")
+                         (f"Command '{self.cmd_line}' did not return "
+                          f"{expected_rc}"))
         cur = self.db.cursor()
         cur.execute('SELECT COUNT(*) FROM test_journal;')
         db_count = cur.fetchone()[0]
         count = 2
         self.assertEqual(db_count, count,
-                         f"The checkup count of test_journal is wrong, expected {count} got {db_count}")
+                         (f"The checkup count of test_journal is wrong, "
+                          f"expected {count} got {db_count}"))
 
     def tearDown(self):
         self.db.close()

--- a/selftests/functional/test_journal.py
+++ b/selftests/functional/test_journal.py
@@ -12,9 +12,8 @@ class JournalPluginTests(TestCaseTmpDir):
 
     def setUp(self):
         super().setUp()
-        self.cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --json - '
-                         '--journal examples/tests/passtest.py'
-                         % (AVOCADO, self.tmpdir.name))
+        self.cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                         f'--disable-sysinfo --json - --journal examples/tests/passtest.py')
         self.result = process.run(self.cmd_line, ignore_status=True)
         data = json.loads(self.result.stdout_text)
         self.job_id = data['job_id']
@@ -24,25 +23,23 @@ class JournalPluginTests(TestCaseTmpDir):
     def test_journal_job_id(self):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(self.result.exit_status, expected_rc,
-                         "Command '%s' did not return %s" % (self.cmd_line,
-                                                             expected_rc))
+                         f"Command '{self.cmd_line}' did not return {expected_rc}")
         cur = self.db.cursor()
         cur.execute('SELECT unique_id FROM job_info;')
         db_job_id = cur.fetchone()[0]
         self.assertEqual(db_job_id, self.job_id,
-                         "The job ids differs, expected %s got %s" % (self.job_id, db_job_id))
+                         f"The job ids differs, expected {self.job_id} got {db_job_id}")
 
     def test_journal_count_entries(self):
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(self.result.exit_status, expected_rc,
-                         "Command '%s' did not return %s" % (self.cmd_line,
-                                                             expected_rc))
+                         f"Command '{self.cmd_line}' did not return {expected_rc}")
         cur = self.db.cursor()
         cur.execute('SELECT COUNT(*) FROM test_journal;')
         db_count = cur.fetchone()[0]
         count = 2
         self.assertEqual(db_count, count,
-                         "The checkup count of test_journal is wrong, expected %d got %d" % (count, db_count))
+                         f"The checkup count of test_journal is wrong, expected {count} got {db_count}")
 
     def tearDown(self):
         self.db.close()

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -13,7 +13,8 @@ class VariantsDumpLoadTests(TestCaseTmpDir):
         self.variants_file = os.path.join(self.tmpdir.name, 'variants.json')
 
     def test_variants_dump(self):
-        cmd_line = f'{AVOCADO} variants --json-variants-dump {self.variants_file}'
+        cmd_line = (f'{AVOCADO} variants '
+                    f'--json-variants-dump {self.variants_file}')
         process.run(cmd_line)
         with open(self.variants_file, 'r', encoding='utf-8') as file_obj:
             file_content = file_obj.read()
@@ -36,7 +37,8 @@ class VariantsDumpLoadTests(TestCaseTmpDir):
                    '  "variant_id": "bar-d06d"}]')
         with open(self.variants_file, 'w', encoding='utf-8') as file_obj:
             file_obj.write(content)
-        cmd_line = (f'{AVOCADO} run examples/tests/passtest.py --json-variants-load {self.variants_file} '
+        cmd_line = (f'{AVOCADO} run examples/tests/passtest.py '
+                    f'--json-variants-load {self.variants_file} '
                     f'--test-runner=runner '
                     f'--job-results-dir {self.tmpdir.name} --json -')
         result = process.run(cmd_line)

--- a/selftests/functional/test_json_variants.py
+++ b/selftests/functional/test_json_variants.py
@@ -13,8 +13,7 @@ class VariantsDumpLoadTests(TestCaseTmpDir):
         self.variants_file = os.path.join(self.tmpdir.name, 'variants.json')
 
     def test_variants_dump(self):
-        cmd_line = ('%s variants --json-variants-dump %s' %
-                    (AVOCADO, self.variants_file))
+        cmd_line = f'{AVOCADO} variants --json-variants-dump {self.variants_file}'
         process.run(cmd_line)
         with open(self.variants_file, 'r', encoding='utf-8') as file_obj:
             file_content = file_obj.read()
@@ -37,10 +36,9 @@ class VariantsDumpLoadTests(TestCaseTmpDir):
                    '  "variant_id": "bar-d06d"}]')
         with open(self.variants_file, 'w', encoding='utf-8') as file_obj:
             file_obj.write(content)
-        cmd_line = ('%s run examples/tests/passtest.py --json-variants-load %s '
-                    '--test-runner=runner '
-                    '--job-results-dir %s --json -' %
-                    (AVOCADO, self.variants_file, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run examples/tests/passtest.py --json-variants-load {self.variants_file} '
+                    f'--test-runner=runner '
+                    f'--job-results-dir {self.tmpdir.name} --json -')
         result = process.run(cmd_line)
         json_result = json.loads(result.stdout_text)
         self.assertEqual(json_result["pass"], 2)

--- a/selftests/functional/test_list.py
+++ b/selftests/functional/test_list.py
@@ -175,7 +175,8 @@ class ListTestFunctional(TestCaseTmpDir):
         cmd_line = f"{AVOCADO} --verbose list -t fast -- {examples_dir}"
         result = process.run(cmd_line)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK,
-                         f"Avocado did not return rc {exit_codes.AVOCADO_ALL_OK}:\n{result}")
+                         (f"Avocado did not return rc "
+                          f"{exit_codes.AVOCADO_ALL_OK}:\n{result}"))
         stdout_lines = result.stdout_text.splitlines()
         self.assertIn("TEST TYPES SUMMARY", stdout_lines)
         self.assertIn("avocado-instrumented: 2", stdout_lines)
@@ -276,17 +277,19 @@ class ListTestFunctional(TestCaseTmpDir):
             for exp in exps:
                 if exp[0] in test["id"]:
                     self.assertEqual(test["status"], exp[1],
-                                     f"Status of {exp} not as expected: {result}")
+                                     (f"Status of {exp} not as expected: "
+                                      f"{result}"))
                     exps.remove(exp)
                     if exp[2] is not None:
                         self.assertEqual(test["fail_reason"], exp[2],
-                                         f'Fail reason "{exp}" not as expected: {result}')
+                                         (f'Fail reason "{exp}" not as '
+                                          f'expected: {result}'))
                     break
             else:
                 self.fail(f"No expected result for {test['id']}\n"
                           f"{result}\n\nexps = {exps}")
-        self.assertFalse(exps, (f"Some expected result not matched to actualresults:\n"
-                                f"{result}\n\nexps = {exps}"))
+        self.assertFalse(exps, (f"Some expected result not matched to actual "
+                                f"results:\n{result}\n\nexps = {exps}"))
 
     def test_list_subtests_filter(self):
         """Check whether the subtests filter works for INSTRUMENTED tests."""

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -88,19 +88,19 @@ class LVUtilsTest(TestCaseTmpDir):
             self.assertFalse(glob.glob(os.path.join(ramdisk_basedir, "*")))
         except BaseException as details:
             try:
-                process.run("mountpoint %s && umount %s"
-                            % (mount_loc, mount_loc), shell=True, sudo=True)
+                process.run(f"mountpoint {mount_loc} && umount {mount_loc}",
+                            shell=True, sudo=True)
             except BaseException as details:
-                print("Fail to unmount LV: %s" % details)
+                print(f"Fail to unmount LV: {details}")
             try:
                 lv_utils.lv_remove(vg_name, lv_name)
             except BaseException as details:
-                print("Fail to cleanup LV: %s" % details)
+                print(f"Fail to cleanup LV: {details}")
             try:
                 lv_utils.vg_ramdisk_cleanup(ramdisk_filename, vg_ramdisk_dir,
                                             vg_name, loop_device)
             except BaseException as details:
-                print("Fail to cleanup vg_ramdisk: %s" % details)
+                print(f"Fail to cleanup vg_ramdisk: {details}")
 
 
 class DiskSpace(unittest.TestCase):
@@ -123,8 +123,7 @@ class DiskSpace(unittest.TestCase):
         pre = glob.glob("/dev/sd*")
         process.system("modprobe scsi_debug", sudo=True)
         disks = set(glob.glob("/dev/sd*")).difference(pre)
-        self.assertEqual(len(disks), 1, "pre: %s\npost: %s"
-                         % (disks, glob.glob("/dev/sd*")))
+        self.assertEqual(len(disks), 1, f"pre: {disks}\npost: {glob.glob('/dev/sd*')}")
         disk = disks.pop()
         self.assertEqual(lv_utils.get_diskspace(disk), "8388608")
 

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -123,7 +123,8 @@ class DiskSpace(unittest.TestCase):
         pre = glob.glob("/dev/sd*")
         process.system("modprobe scsi_debug", sudo=True)
         disks = set(glob.glob("/dev/sd*")).difference(pre)
-        self.assertEqual(len(disks), 1, f"pre: {disks}\npost: {glob.glob('/dev/sd*')}")
+        self.assertEqual(len(disks), 1,
+                         f"pre: {disks}\npost: {glob.glob('/dev/sd*')}")
         disk = disks.pop()
         self.assertEqual(lv_utils.get_diskspace(disk), "8388608")
 

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -7,7 +7,7 @@ from avocado.utils import process
 from selftests.utils import (AVOCADO, BASEDIR, TestCaseTmpDir,
                              skipUnlessPathExists)
 
-RUNNER = "%s -m avocado.core.nrunner" % sys.executable
+RUNNER = f"{sys.executable} -m avocado.core.nrunner"
 
 
 class NRunnerFeatures(unittest.TestCase):
@@ -39,7 +39,7 @@ class NRunnerFeatures(unittest.TestCase):
 class RunnableRun(unittest.TestCase):
 
     def test_noop(self):
-        res = process.run("%s runnable-run -k noop" % RUNNER,
+        res = process.run(f"{RUNNER} runnable-run -k noop",
                           ignore_status=True)
         self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
@@ -49,8 +49,8 @@ class RunnableRun(unittest.TestCase):
     def test_exec_test(self):
         # 'base64:LWM=' becomes '-c' and makes Python execute the
         # commands on the subsequent argument
-        cmd = ("%s runnable-run -k exec-test -u %s -a 'base64:LWM=' -a "
-               "'import sys; sys.exit(99)'" % (RUNNER, sys.executable))
+        cmd = (f"{RUNNER} runnable-run -k exec-test -u {sys.executable} "
+               f"-a 'base64:LWM=' -a 'import sys; sys.exit(99)'")
         res = process.run(cmd, ignore_status=True)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'returncode': 99", res.stdout)
@@ -59,8 +59,8 @@ class RunnableRun(unittest.TestCase):
     @skipUnlessPathExists('/bin/sh')
     def test_exec_test_echo(self):
         # 'base64:LW4=' becomes '-n' and prevents echo from printing a newline
-        cmd = ("%s runnable-run -k exec-test -u /bin/echo -a 'base64:LW4=' -a "
-               "_Avocado_Runner_" % RUNNER)
+        cmd = (f"{RUNNER} runnable-run -k exec-test -u /bin/echo "
+               f"-a 'base64:LW4=' -a _Avocado_Runner_")
         res = process.run(cmd, ignore_status=True)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'log': b'_Avocado_Runner_'", res.stdout)
@@ -72,7 +72,7 @@ class RunnableRun(unittest.TestCase):
     def test_exec_recipe(self):
         recipe = os.path.join(BASEDIR, "examples", "nrunner", "recipes",
                               "runnables", "exec_test_sh_echo_env_var.json")
-        cmd = "%s runnable-run-recipe %s" % (RUNNER, recipe)
+        cmd = f"{RUNNER} runnable-run-recipe {recipe}"
         res = process.run(cmd, ignore_status=True)
         lines = res.stdout_text.splitlines()
         if len(lines) == 1:
@@ -89,19 +89,19 @@ class RunnableRun(unittest.TestCase):
         self.assertEqual(res.exit_status, 0)
 
     def test_noop_valid_kwargs(self):
-        res = process.run("%s runnable-run -k noop foo=bar" % RUNNER,
+        res = process.run(f"{RUNNER} runnable-run -k noop foo=bar",
                           ignore_status=True)
         self.assertEqual(res.exit_status, 0)
 
     def test_noop_invalid_kwargs(self):
-        res = process.run("%s runnable-run -k noop foo" % RUNNER,
+        res = process.run(f"{RUNNER} runnable-run -k noop foo",
                           ignore_status=True)
         self.assertIn(b'Invalid keyword parameter: "foo"', res.stderr)
         self.assertEqual(res.exit_status, 2)
 
     @skipUnlessPathExists('/bin/env')
     def test_exec_test_kwargs(self):
-        cmd = "%s runnable-run -k exec-test -u /bin/env X=Y" % RUNNER
+        cmd = f"{RUNNER} runnable-run -k exec-test -u /bin/env X=Y"
         res = process.run(cmd, ignore_status=True)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"X=Y\\n", res.stdout)
@@ -111,7 +111,7 @@ class RunnableRun(unittest.TestCase):
 class TaskRun(unittest.TestCase):
 
     def test_noop(self):
-        res = process.run("%s task-run -i XXXno-opXXX -k noop" % RUNNER,
+        res = process.run(f"{RUNNER} task-run -i XXXno-opXXX -k noop",
                           ignore_status=True)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'id': 'XXXno-opXXX'", res.stdout)
@@ -121,7 +121,7 @@ class TaskRun(unittest.TestCase):
     def test_recipe_exec_test_1(self):
         recipe = os.path.join(BASEDIR, "examples", "nrunner", "recipes",
                               "tasks", "exec-test", "1-uname.json")
-        cmd = "%s task-run-recipe %s" % (RUNNER, recipe)
+        cmd = f"{RUNNER} task-run-recipe {recipe}"
         res = process.run(cmd, ignore_status=True)
         lines = res.stdout_text.splitlines()
         if len(lines) == 1:
@@ -139,7 +139,7 @@ class TaskRun(unittest.TestCase):
     def test_recipe_exec_test_2(self):
         recipe = os.path.join(BASEDIR, "examples", "nrunner", "recipes",
                               "tasks", "exec-test", "2-echo.json")
-        cmd = "%s task-run-recipe %s" % (RUNNER, recipe)
+        cmd = f"{RUNNER} task-run-recipe {recipe}"
         res = process.run(cmd, ignore_status=True)
         lines = res.stdout_text.splitlines()
         if len(lines) == 1:
@@ -159,7 +159,7 @@ class TaskRun(unittest.TestCase):
     def test_recipe_exec_test_3(self):
         recipe = os.path.join(BASEDIR, "examples", "nrunner", "recipes",
                               "tasks", "exec-test", "3-sleep.json")
-        cmd = "%s task-run-recipe %s" % (RUNNER, recipe)
+        cmd = f"{RUNNER} task-run-recipe {recipe}"
         res = process.run(cmd, ignore_status=True)
         lines = res.stdout_text.splitlines()
         # based on the :data:`avocado.core.nrunner.RUNNER_RUN_STATUS_INTERVAL`

--- a/selftests/functional/test_nrunner_interface.py
+++ b/selftests/functional/test_nrunner_interface.py
@@ -8,7 +8,7 @@ from avocado.utils import process
 class Interface(Test):
 
     def get_runner(self):
-        default_runner = "%s -m avocado.core.nrunner" % sys.executable
+        default_runner = f"{sys.executable} -m avocado.core.nrunner"
         return self.params.get("runner", default=default_runner)
 
     @fail_on(process.CmdError)
@@ -17,28 +17,28 @@ class Interface(Test):
         Makes sure a runner can be called with --help and that the
         basic required commands are present in the help message
         """
-        cmd = "%s --help" % self.get_runner()
+        cmd = f"{self.get_runner()} --help"
         result = process.run(cmd)
         self.assertIn(b"capabilities", result.stdout,
                       "Mention to capabilities command not found")
 
     @fail_on(process.CmdError)
     def test_capabilities(self):
-        cmd = "%s capabilities" % self.get_runner()
+        cmd = f"{self.get_runner()} capabilities"
         result = process.run(cmd)
         capabilities = json.loads(result.stdout_text)
         self.assertIn("runnables", capabilities)
         self.assertIn("commands", capabilities)
 
     def test_runnable_run_no_args(self):
-        cmd = "%s runnable-run" % self.get_runner()
+        cmd = f"{self.get_runner()} runnable-run"
         result = process.run(cmd, ignore_status=True)
         expected = self.params.get('runnable-run-no-args-exit-code',
                                    default=2)
         self.assertEqual(result.exit_status, expected)
 
     def test_runnable_run_uri_only(self):
-        cmd = "%s runnable-run -u some_uri" % self.get_runner()
+        cmd = f"{self.get_runner()} runnable-run -u some_uri"
         result = process.run(cmd, ignore_status=True)
         expected = self.params.get('runnable-run-uri-only-exit-code',
                                    default=2)

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -31,8 +31,8 @@ while ( my $result = $parser->next ) {
 $parser->parse_errors == 0 || die "Parser errors!\n";
 $parser->is_good_plan || die "Plan is not a good plan!\n";
 $parser->plan eq '1..3' || die "Plan does not match what was expected!\n";
-""" % AVOCADO_QUOTED
-
+"""
+PERL_TAP_PARSER_SNIPPET = PERL_TAP_PARSER_SNIPPET % AVOCADO_QUOTED
 
 PERL_TAP_PARSER_FAILFAST_SNIPPET = """#!/bin/env perl
 use TAP::Parser;
@@ -50,8 +50,8 @@ while ( my $result = $parser->next ) {
 $parser->parse_errors == 0 || die "Parser errors!\n";
 $parser->is_good_plan || die "Plan is not a good plan!\n";
 $parser->plan eq '1..3' || die "Plan does not match what was expected!\n";
-""" % AVOCADO_QUOTED
-
+"""
+PERL_TAP_PARSER_FAILFAST_SNIPPET = PERL_TAP_PARSER_FAILFAST_SNIPPET % AVOCADO_QUOTED
 
 OUTPUT_TEST_CONTENT = """#!/bin/env python
 import sys
@@ -165,10 +165,8 @@ class OutputTest(TestCaseTmpDir):
         test = script.Script(os.path.join(self.tmpdir.name, "output_test.py"),
                              OUTPUT_TEST_CONTENT)
         test.save()
-        result = process.run("%s run --job-results-dir %s --disable-sysinfo "
-                             "--json - -- %s" % (AVOCADO,
-                                                 self.tmpdir.name,
-                                                 test))
+        result = process.run(f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+                             f"--disable-sysinfo --json - -- {test}")
         res = json.loads(result.stdout_text)
         logfile = res["tests"][0]["logfile"]
         # Today, process.run() calls are not part of the test stdout or stderr.
@@ -195,20 +193,17 @@ class OutputTest(TestCaseTmpDir):
                     if i == end:
                         break
             exps_text = "\n".join([exp.decode() for exp in exps])
-            error_msg = ("Failed to find message in position %s from\n%s\n"
-                         "\nin the %s. Either it's missing or in wrong "
-                         "order.\n%s" % (i, exps_text, path,
-                                         output_file_content))
+            error_msg = (f"Failed to find message in position {i} "
+                         f"from\n{exps_text}\n\nin the {path}. Either "
+                         f"it's missing or in wrong order.\n{output_file_content}")
             self.assertEqual(i, end, error_msg)
 
     def test_print_to_std(self):
         test = script.Script(os.path.join(self.tmpdir.name, "output_test.py"),
                              OUTPUT_TEST_CONTENT)
         test.save()
-        result = process.run("%s run --job-results-dir %s --disable-sysinfo "
-                             "--json - -- %s" % (AVOCADO,
-                                                 self.tmpdir.name,
-                                                 test))
+        result = process.run(f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+                             f"--disable-sysinfo --json - -- {test}")
         res = json.loads(result.stdout_text)
         logfile = res["tests"][0]["logfile"]
         exps = [b"[stdout] top_print", b"[stdout] top_stdout",
@@ -227,10 +222,8 @@ class OutputTest(TestCaseTmpDir):
             self.assertEqual(expected, stderr_file.read())
 
         # With the nrunner, output combined result are inside job.log
-        result = process.run("%s run --job-results-dir %s --disable-sysinfo "
-                             "--json - -- %s" % (AVOCADO,
-                                                 self.tmpdir.name,
-                                                 test))
+        result = process.run(f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+                             f"--disable-sysinfo --json - -- {test}")
         res = json.loads(result.stdout_text)
         with open(logfile, 'rb') as output_file:  # pylint: disable=W1514
             expected = [b'[stdout] top_print\n',
@@ -258,7 +251,7 @@ class OutputTest(TestCaseTmpDir):
         """
         with script.Script(os.path.join(self.tmpdir.name, "test_show.py"),
                            OUTPUT_SHOW_TEST, script.READ_ONLY_MODE) as test:
-            cmd = "%s run --disable-sysinfo -- %s" % (AVOCADO, test.path)
+            cmd = f"{AVOCADO} run --disable-sysinfo -- {test.path}"
             result = process.run(cmd)
             expected_job_id_number = 1
             expected_bin_true_number = 0
@@ -285,8 +278,8 @@ class OutputPluginTest(TestCaseTmpDir):
             minidom.parse(xunit_output_path)
         except Exception as details:
             xunit_output_content = genio.read_file(xunit_output_path)
-            raise AssertionError("Unable to parse xunit output: %s\n\n%s"
-                                 % (details, xunit_output_content))
+            raise AssertionError((f"Unable to parse xunit output: "
+                                  f"{details}\n\n{xunit_output_content}"))
         tap_output = os.path.join(base_dir, "results.tap")
         self.assertTrue(os.path.isfile(tap_output))
         tap = genio.read_file(tap_output)
@@ -294,46 +287,41 @@ class OutputPluginTest(TestCaseTmpDir):
         self.assertIn("\n# debug.log of ", tap)
 
     def test_output_incompatible_setup(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--xunit - --json - examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --xunit - --json - '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         error_regex = re.compile(r'.*Options ((--xunit --json)|'
                                  '(--json --xunit)) are trying to use stdout '
                                  'simultaneously.', re.MULTILINE | re.DOTALL)
         self.assertIsNotNone(error_regex.match(result.stderr_text),
-                             "Missing error message from output:\n%s" %
-                             result.stderr)
+                             f"Missing error message from output:\n{result.stderr}")
 
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--journal --xunit %s --json - examples/tests/passtest.py' %
-                    (AVOCADO, self.tmpdir.name, tmpfile))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --journal --xunit {tmpfile} '
+                    f'--json - examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         # Check if we are producing valid outputs
         json.loads(result.stdout_text)
         minidom.parse(tmpfile)
 
     def test_output_compatible_setup_2(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--xunit - --json %s --tap-include-logs '
-                    'examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name, tmpfile))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --xunit - --json {tmpfile} '
+                    f'--tap-include-logs examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         # Check if we are producing valid outputs
         with open(tmpfile, 'r', encoding='utf-8') as fp:
             json_results = json.load(fp)
@@ -345,17 +333,15 @@ class OutputPluginTest(TestCaseTmpDir):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         tmpfile2 = tempfile.mktemp(dir=self.tmpdir.name)
         # Verify --show=none can be supplied as app argument
-        cmd_line = ('%s --show=none run --job-results-dir %s '
-                    '--disable-sysinfo --xunit %s --json %s --tap-include-logs '
-                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name,
-                                                    tmpfile, tmpfile2))
+        cmd_line = (f'{AVOCADO} --show=none run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --xunit {tmpfile} --json {tmpfile2} '
+                    f'--tap-include-logs examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertEqual(result.stdout, b"",
-                         "Output is not empty:\n%s" % result.stdout)
+                         f"Output is not empty:\n{result.stdout}")
         # Check if we are producing valid outputs
         with open(tmpfile2, 'r', encoding='utf-8') as fp:
             json_results = json.load(fp)
@@ -364,66 +350,59 @@ class OutputPluginTest(TestCaseTmpDir):
         minidom.parse(tmpfile)
 
     def test_show_test(self):
-        cmd_line = ('%s --show=test run --job-results-dir %s --disable-sysinfo '
-                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} --show=test run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         job_id_list = re.findall('Job ID: (.*)', result.stdout_text,
                                  re.MULTILINE)
-        self.assertTrue(job_id_list, 'No Job ID in stdout:\n%s' %
-                        result.stdout)
+        self.assertTrue(job_id_list, f'No Job ID in stdout:\n{result.stdout}')
         job_id = job_id_list[0]
         self.assertEqual(len(job_id), 40)
 
     def test_silent_trumps_test(self):
         # Also verify --show=none can be supplied as run option
-        cmd_line = ('%s --show=test --show=none run --job-results-dir %s '
-                    '--disable-sysinfo examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} --show=test --show=none run '
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertEqual(result.stdout, b"")
 
     def test_verify_whiteboard_save(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         config = os.path.join(self.tmpdir.name, "conf.ini")
-        content = ("[datadir.paths]\nlogs_dir = %s"
+        content = ("[datadir.paths]\nlogs_dir = %s"  # pylint: disable=C0209
                    % os.path.relpath(self.tmpdir.name, "."))
         script.Script(config, content).save()
-        cmd_line = ('%s --config %s --show all run '
-                    '--job-results-dir %s --disable-sysinfo '
-                    'examples/tests/whiteboard.py '
-                    '--json %s' % (AVOCADO, config, self.tmpdir.name, tmpfile))
+        cmd_line = (f'{AVOCADO} --config {config} --show all run '
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo examples/tests/whiteboard.py --json {tmpfile}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         with open(tmpfile, 'r', encoding='utf-8') as fp:
             json_results = json.load(fp)
             logfile = json_results['tests'][0]['logfile']
             debug_dir = os.path.dirname(logfile)
             whiteboard_path = os.path.join(debug_dir, 'whiteboard')
             self.assertTrue(os.path.exists(whiteboard_path),
-                            'Missing whiteboard file %s' % whiteboard_path)
+                            f'Missing whiteboard file {whiteboard_path}')
 
     def test_gendata(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
-        cmd_line = ("%s run --job-results-dir %s "
-                    "--test-runner=runner "
-                    "--disable-sysinfo examples/tests/gendata.py --json %s" %
-                    (AVOCADO, self.tmpdir.name, tmpfile))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--test-runner=runner --disable-sysinfo '
+                    f'examples/tests/gendata.py --json {tmpfile}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         with open(tmpfile, 'r', encoding='utf-8') as fp:
             json_results = json.load(fp)
             json_dir = None
@@ -435,27 +414,26 @@ class OutputPluginTest(TestCaseTmpDir):
                             "directory")
             json_dir = os.path.join(os.path.dirname(json_dir), "data",
                                     "test.json")
-            self.assertTrue(os.path.exists(json_dir), "File %s produced by"
-                            "test does not exist" % json_dir)
+            self.assertTrue(os.path.exists(json_dir),
+                            (f"File {json_dir} produced by"
+                            f"test does not exist"))
 
     def test_redirect_output(self):
         redirected_output_path = tempfile.mktemp(dir=self.tmpdir.name)
-        cmd_line = ('%s run --job-results-dir %s '
-                    '--disable-sysinfo examples/tests/passtest.py > %s'
-                    % (AVOCADO, self.tmpdir.name, redirected_output_path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo examples/tests/passtest.py > {redirected_output_path}')
         result = process.run(cmd_line, ignore_status=True, shell=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertEqual(result.stdout, b'',
-                         'After redirecting to file, output is not empty: %s' % result.stdout)
+                         f'After redirecting to file, output is not empty: {result.stdout}')
         with open(redirected_output_path, 'r', encoding='utf-8') as redirected_output_file_obj:
             redirected_output = redirected_output_file_obj.read()
             for code in TermSupport.ESCAPE_CODES:
                 self.assertNotIn(code, redirected_output,
-                                 'Found terminal support code %s in redirected output\n%s' %
-                                 (code, redirected_output))
+                                 f'Found terminal support code {code} '
+                                 f'in redirected output\n{redirected_output}')
 
     @unittest.skipIf(perl_tap_parser_uncapable(),
                      "Uncapable of using Perl TAP::Parser library")
@@ -464,7 +442,7 @@ class OutputPluginTest(TestCaseTmpDir):
                 "tap_parser.pl",
                 PERL_TAP_PARSER_SNIPPET % self.tmpdir.name,
                 self.tmpdir.name) as perl_script:
-            process.run("perl %s" % perl_script)
+            process.run(f"perl {perl_script}")
 
     @unittest.skipIf(perl_tap_parser_uncapable(),
                      "Uncapable of using Perl TAP::Parser library")
@@ -473,35 +451,32 @@ class OutputPluginTest(TestCaseTmpDir):
                 "tap_parser.pl",
                 PERL_TAP_PARSER_FAILFAST_SNIPPET % self.tmpdir.name,
                 self.tmpdir.name) as perl_script:
-            process.run("perl %s" % perl_script)
+            process.run(f"perl {perl_script}")
 
     def test_tap_totaltests(self):
-        cmd_line = ("%s run examples/tests/passtest.py "
-                    "examples/tests/passtest.py "
-                    "examples/tests/passtest.py "
-                    "examples/tests/passtest.py "
-                    "--job-results-dir %s --disable-sysinfo "
-                    "--tap -" % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run examples/tests/passtest.py '
+                    f'examples/tests/passtest.py examples/tests/passtest.py '
+                    f'examples/tests/passtest.py --job-results-dir '
+                    f'{self.tmpdir.name} --disable-sysinfo --tap -')
         result = process.run(cmd_line)
         expr = b'1..4'
-        self.assertIn(expr, result.stdout, "'%s' not found in:\n%s"
-                      % (expr, result.stdout))
+        self.assertIn(expr, result.stdout,
+                      f"'{expr}' not found in:\n{result.stdout}")
 
     def test_broken_pipe(self):
-        cmd_line = "(%s run --help | whacky-unknown-command)" % AVOCADO
+        cmd_line = f"({AVOCADO} run --help | whacky-unknown-command)"
         result = process.run(cmd_line, shell=True, ignore_status=True,
                              env={"LC_ALL": "C"})
         expected_rc = 127
         self.assertEqual(result.exit_status, expected_rc,
-                         ("avocado run to broken pipe did not return "
-                          "rc %d:\n%s" % (expected_rc, result)))
+                         (f"avocado run to broken pipe did not return "
+                          f"rc {expected_rc}:\n{result}"))
         self.assertIn(b"whacky-unknown-command", result.stderr)
         self.assertIn(b"not found", result.stderr)
         self.assertNotIn(b"Avocado crashed", result.stderr)
 
     def test_results_plugins_no_tests(self):
-        cmd_line = ("%s run UNEXISTING --job-results-dir %s"
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = f"{AVOCADO} run UNEXISTING --job-results-dir {self.tmpdir.name}"
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
 

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -165,7 +165,8 @@ class OutputTest(TestCaseTmpDir):
         test = script.Script(os.path.join(self.tmpdir.name, "output_test.py"),
                              OUTPUT_TEST_CONTENT)
         test.save()
-        result = process.run(f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+        result = process.run(f"{AVOCADO} run "
+                             f"--job-results-dir {self.tmpdir.name} "
                              f"--disable-sysinfo --json - -- {test}")
         res = json.loads(result.stdout_text)
         logfile = res["tests"][0]["logfile"]
@@ -202,7 +203,8 @@ class OutputTest(TestCaseTmpDir):
         test = script.Script(os.path.join(self.tmpdir.name, "output_test.py"),
                              OUTPUT_TEST_CONTENT)
         test.save()
-        result = process.run(f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+        result = process.run(f"{AVOCADO} run "
+                             f"--job-results-dir {self.tmpdir.name} "
                              f"--disable-sysinfo --json - -- {test}")
         res = json.loads(result.stdout_text)
         logfile = res["tests"][0]["logfile"]
@@ -222,7 +224,8 @@ class OutputTest(TestCaseTmpDir):
             self.assertEqual(expected, stderr_file.read())
 
         # With the nrunner, output combined result are inside job.log
-        result = process.run(f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+        result = process.run(f"{AVOCADO} run "
+                             f"--job-results-dir {self.tmpdir.name} "
                              f"--disable-sysinfo --json - -- {test}")
         res = json.loads(result.stdout_text)
         with open(logfile, 'rb') as output_file:  # pylint: disable=W1514
@@ -293,12 +296,14 @@ class OutputPluginTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         error_regex = re.compile(r'.*Options ((--xunit --json)|'
                                  '(--json --xunit)) are trying to use stdout '
                                  'simultaneously.', re.MULTILINE | re.DOTALL)
         self.assertIsNotNone(error_regex.match(result.stderr_text),
-                             f"Missing error message from output:\n{result.stderr}")
+                             (f"Missing error message from output:\n"
+                              f"{result.stderr}"))
 
     def test_output_compatible_setup(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
@@ -308,7 +313,8 @@ class OutputPluginTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         # Check if we are producing valid outputs
         json.loads(result.stdout_text)
         minidom.parse(tmpfile)
@@ -321,7 +327,8 @@ class OutputPluginTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         # Check if we are producing valid outputs
         with open(tmpfile, 'r', encoding='utf-8') as fp:
             json_results = json.load(fp)
@@ -333,13 +340,15 @@ class OutputPluginTest(TestCaseTmpDir):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
         tmpfile2 = tempfile.mktemp(dir=self.tmpdir.name)
         # Verify --show=none can be supplied as app argument
-        cmd_line = (f'{AVOCADO} --show=none run --job-results-dir {self.tmpdir.name} '
+        cmd_line = (f'{AVOCADO} --show=none run '
+                    f'--job-results-dir {self.tmpdir.name} '
                     f'--disable-sysinfo --xunit {tmpfile} --json {tmpfile2} '
                     f'--tap-include-logs examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         self.assertEqual(result.stdout, b"",
                          f"Output is not empty:\n{result.stdout}")
         # Check if we are producing valid outputs
@@ -350,12 +359,14 @@ class OutputPluginTest(TestCaseTmpDir):
         minidom.parse(tmpfile)
 
     def test_show_test(self):
-        cmd_line = (f'{AVOCADO} --show=test run --job-results-dir {self.tmpdir.name} '
+        cmd_line = (f'{AVOCADO} --show=test run '
+                    f'--job-results-dir {self.tmpdir.name} '
                     f'--disable-sysinfo examples/tests/passtest.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         job_id_list = re.findall('Job ID: (.*)', result.stdout_text,
                                  re.MULTILINE)
         self.assertTrue(job_id_list, f'No Job ID in stdout:\n{result.stdout}')
@@ -370,7 +381,8 @@ class OutputPluginTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         self.assertEqual(result.stdout, b"")
 
     def test_verify_whiteboard_save(self):
@@ -381,11 +393,13 @@ class OutputPluginTest(TestCaseTmpDir):
         script.Script(config, content).save()
         cmd_line = (f'{AVOCADO} --config {config} --show all run '
                     f'--job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo examples/tests/whiteboard.py --json {tmpfile}')
+                    f'--disable-sysinfo examples/tests/whiteboard.py '
+                    f'--json {tmpfile}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         with open(tmpfile, 'r', encoding='utf-8') as fp:
             json_results = json.load(fp)
             logfile = json_results['tests'][0]['logfile']
@@ -402,7 +416,8 @@ class OutputPluginTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Avocado did not return rc {expected_rc}:\n{result}")
+                         (f"Avocado did not return rc {expected_rc}:"
+                          f"\n{result}"))
         with open(tmpfile, 'r', encoding='utf-8') as fp:
             json_results = json.load(fp)
             json_dir = None

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -327,7 +327,8 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT)
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo {simple_test} --output-check-record both '
+                    f'--disable-sysinfo {simple_test} '
+                    f'--output-check-record both '
                     f'--json-variants-load {variants_file}')
         process.run(cmd_line, ignore_status=True)
         self.assertIsNotFile(f"{simple_test}.data/stdout.expected")

--- a/selftests/functional/test_output_check.py
+++ b/selftests/functional/test_output_check.py
@@ -140,31 +140,29 @@ class RunnerSimpleTest(TestCaseTmpDir):
         self.output_script.save()
 
     def _check_output_record_all(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check-record all'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path} '
+                    f'--output-check-record all')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
-        stdout_file = "%s.data/stdout.expected" % self.output_script
-        stderr_file = "%s.data/stderr.expected" % self.output_script
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+        stdout_file = f"{self.output_script}.data/stdout.expected"
+        stderr_file = f"{self.output_script}.data/stderr.expected"
         with open(stdout_file, 'rb') as fd_stdout:  # pylint: disable=W1514
             self.assertEqual(fd_stdout.read(), STDOUT)
         with open(stderr_file, 'rb') as fd_stderr:  # pylint: disable=W1514
             self.assertEqual(fd_stderr.read(), STDERR)
 
     def _check_output_record_combined(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check-record combined'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path} '
+                    f'--output-check-record combined')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
-        output_file = "%s.data/output.expected" % self.output_script
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+        output_file = f"{self.output_script}.data/output.expected"
         with open(output_file, 'rb') as fd_output:  # pylint: disable=W1514
             self.assertEqual(fd_output.read(), STDOUT + STDERR)
 
@@ -178,80 +176,74 @@ class RunnerSimpleTest(TestCaseTmpDir):
         return (simple_test, variants_file)
 
     def test_output_record_none(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check-record none'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path} '
+                    f'--output-check-record none')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
-        self.assertIsNotFile("%s.data/stdout.expected" % self.output_script)
-        self.assertIsNotFile("%s.data/stderr.expected" % self.output_script)
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+        self.assertIsNotFile(f"{self.output_script}.data/stdout.expected")
+        self.assertIsNotFile(f"{self.output_script}.data/stderr.expected")
 
     def test_output_record_stdout(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check-record stdout'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path} '
+                    f'--output-check-record stdout')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
-        stdout_file = "%s.data/stdout.expected" % self.output_script
-        stderr_file = "%s.data/stderr.expected" % self.output_script
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+        stdout_file = f"{self.output_script}.data/stdout.expected"
+        stderr_file = f"{self.output_script}.data/stderr.expected"
         with open(stdout_file, 'rb') as fd_stdout:  # pylint: disable=W1514
             self.assertEqual(fd_stdout.read(), STDOUT)
         self.assertIsNotFile(stderr_file)
 
     def test_output_record_and_check(self):
         self._check_output_record_all()
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_output_record_and_check_combined(self):
         self._check_output_record_combined()
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
     def test_output_tamper_stdout(self):
         self._check_output_record_all()
         tampered_msg = b"I PITY THE FOOL THAT STANDS ON MY WAY!"
-        stdout_file = "%s.data/stdout.expected" % self.output_script.path
+        stdout_file = f"{self.output_script.path}.data/stdout.expected"
         with open(stdout_file, 'wb') as stdout_file_obj:  # pylint: disable=W1514
             stdout_file_obj.write(tampered_msg)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path} --xunit -')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(tampered_msg, result.stdout)
 
     def test_output_tamper_combined(self):
         self._check_output_record_combined()
         tampered_msg = b"I PITY THE FOOL THAT STANDS ON MY WAY!"
-        output_file = "%s.data/output.expected" % self.output_script.path
+        output_file = f"{self.output_script.path}.data/output.expected"
         with open(output_file, 'wb') as output_file_obj:  # pylint: disable=W1514
             output_file_obj.write(tampered_msg)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --xunit -'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path} --xunit -')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertIn(tampered_msg, result.stdout)
 
     def test_output_diff(self):
@@ -259,21 +251,20 @@ class RunnerSimpleTest(TestCaseTmpDir):
         tampered_msg_stdout = b"I PITY THE FOOL THAT STANDS ON STDOUT!"
         tampered_msg_stderr = b"I PITY THE FOOL THAT STANDS ON STDERR!"
 
-        stdout_file = "%s.data/stdout.expected" % self.output_script.path
+        stdout_file = f"{self.output_script.path}.data/stdout.expected"
         with open(stdout_file, 'wb') as stdout_file_obj:  # pylint: disable=W1514
             stdout_file_obj.write(tampered_msg_stdout)
 
-        stderr_file = "%s.data/stderr.expected" % self.output_script.path
+        stderr_file = f"{self.output_script.path}.data/stderr.expected"
         with open(stderr_file, 'wb') as stderr_file_obj:  # pylint: disable=W1514
             stderr_file_obj.write(tampered_msg_stderr)
 
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s --json -'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path} --json -')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
 
         json_result = json.loads(result.stdout_text)
         job_log = json_result['debuglog']
@@ -306,17 +297,16 @@ class RunnerSimpleTest(TestCaseTmpDir):
     def test_disable_output_check(self):
         self._check_output_record_all()
         tampered_msg = b"I PITY THE FOOL THAT STANDS ON MY WAY!"
-        stdout_file = "%s.data/stdout.expected" % self.output_script.path
+        stdout_file = f"{self.output_script.path}.data/stdout.expected"
         with open(stdout_file, 'wb') as stdout_file_obj:  # pylint: disable=W1514
             stdout_file_obj.write(tampered_msg)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--disable-output-check --xunit -'
-                    % (AVOCADO, self.tmpdir.name, self.output_script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {self.output_script.path} '
+                    f'--disable-output-check --xunit -')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertNotIn(tampered_msg, result.stdout)
 
     def test_merge_records_same_output(self):
@@ -326,56 +316,56 @@ class RunnerSimpleTest(TestCaseTmpDir):
         simple_test = os.path.join(self.tmpdir.name, 'simpletest.py')
         with open(simple_test, 'w', encoding='utf-8') as file_obj:
             file_obj.write(TEST_WITH_SAME_EXPECTED_OUTPUT)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check-record both --json-variants-load %s' %
-                    (AVOCADO, self.tmpdir.name, simple_test, variants_file))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {simple_test} --output-check-record '
+                    f'both --json-variants-load {variants_file}')
         process.run(cmd_line, ignore_status=True)
-        self.assertIsFile("%s.data/stdout.expected" % simple_test)
-        self.assertIsFile("%s.data/stderr.expected" % simple_test)
+        self.assertIsFile(f"{simple_test}.data/stdout.expected")
+        self.assertIsFile(f"{simple_test}.data/stderr.expected")
 
     def test_merge_records_different_output(self):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check-record both --json-variants-load %s' %
-                    (AVOCADO, self.tmpdir.name, simple_test, variants_file))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {simple_test} --output-check-record both '
+                    f'--json-variants-load {variants_file}')
         process.run(cmd_line, ignore_status=True)
-        self.assertIsNotFile("%s.data/stdout.expected" % simple_test)
-        self.assertIsNotFile("%s.data/stderr.expected" % simple_test)
-        self.assertIsFile("%s.data/PassTest.test_1/stdout.expected" % simple_test)
-        self.assertIsFile("%s.data/PassTest.test_1/stderr.expected" % simple_test)
-        self.assertIsFile("%s.data/PassTest.test_2/stdout.expected" % simple_test)
-        self.assertIsFile("%s.data/PassTest.test_2/stderr.expected" % simple_test)
+        self.assertIsNotFile(f"{simple_test}.data/stdout.expected")
+        self.assertIsNotFile(f"{simple_test}.data/stderr.expected")
+        self.assertIsFile(f"{simple_test}.data/PassTest.test_1/stdout.expected")
+        self.assertIsFile(f"{simple_test}.data/PassTest.test_1/stderr.expected")
+        self.assertIsFile(f"{simple_test}.data/PassTest.test_2/stdout.expected")
+        self.assertIsFile(f"{simple_test}.data/PassTest.test_2/stderr.expected")
 
     def test_merge_records_different_output_variants(self):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_EXPECTED_OUTPUT_VARIANTS)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check-record both --json-variants-load %s' %
-                    (AVOCADO, self.tmpdir.name, simple_test, variants_file))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {simple_test} --output-check-record both '
+                    f'--json-variants-load {variants_file}')
         process.run(cmd_line, ignore_status=True)
-        self.assertIsNotFile("%s.data/stdout.expected" % simple_test)
-        self.assertIsNotFile("%s.data/stderr.expected" % simple_test)
-        self.assertIsNotFile("%s.data/PassTest.test_1/stdout.expected" % simple_test)
-        self.assertIsNotFile("%s.data/PassTest.test_1/stderr.expected" % simple_test)
-        self.assertIsNotFile("%s.data/PassTest.test_2/stdout.expected" % simple_test)
-        self.assertIsNotFile("%s.data/PassTest.test_2/stderr.expected" % simple_test)
-        self.assertIsFile("%s.data/PassTest.test_2/bar/stderr.expected" % simple_test)
-        self.assertIsFile("%s.data/PassTest.test_2/foo/stderr.expected" % simple_test)
+        self.assertIsNotFile(f"{simple_test}.data/stdout.expected")
+        self.assertIsNotFile(f"{simple_test}.data/stderr.expected")
+        self.assertIsNotFile(f"{simple_test}.data/PassTest.test_1/stdout.expected")
+        self.assertIsNotFile(f"{simple_test}.data/PassTest.test_1/stderr.expected")
+        self.assertIsNotFile(f"{simple_test}.data/PassTest.test_2/stdout.expected")
+        self.assertIsNotFile(f"{simple_test}.data/PassTest.test_2/stderr.expected")
+        self.assertIsFile(f"{simple_test}.data/PassTest.test_2/bar/stderr.expected")
+        self.assertIsFile(f"{simple_test}.data/PassTest.test_2/foo/stderr.expected")
 
     def test_merge_records_different_and_same_output(self):
         simple_test, variants_file = self._setup_simple_test(
             TEST_WITH_DIFFERENT_AND_SAME_EXPECTED_OUTPUT)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo %s '
-                    '--output-check-record both --json-variants-load %s' %
-                    (AVOCADO, self.tmpdir.name, simple_test, variants_file))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo {simple_test} --output-check-record both '
+                    f'--json-variants-load {variants_file}')
         process.run(cmd_line, ignore_status=True)
-        self.assertIsFile("%s.data/stdout.expected" % simple_test)
-        self.assertIsFile("%s.data/stderr.expected" % simple_test)
-        self.assertIsFile("%s.data/PassTest.test_1/stdout.expected" % simple_test)
-        self.assertIsFile("%s.data/PassTest.test_1/stderr.expected" % simple_test)
-        self.assertIsNotFile("%s.data/PassTest.test_2/stdout.expected" % simple_test)
-        self.assertIsNotFile("%s.data/PassTest.test_2/stderr.expected" % simple_test)
+        self.assertIsFile(f"{simple_test}.data/stdout.expected")
+        self.assertIsFile(f"{simple_test}.data/stderr.expected")
+        self.assertIsFile(f"{simple_test}.data/PassTest.test_1/stdout.expected")
+        self.assertIsFile(f"{simple_test}.data/PassTest.test_1/stderr.expected")
+        self.assertIsNotFile(f"{simple_test}.data/PassTest.test_2/stdout.expected")
+        self.assertIsNotFile(f"{simple_test}.data/PassTest.test_2/stderr.expected")
 
     def tearDown(self):
         super().tearDown()

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -11,12 +11,11 @@ class ReplayTests(TestCaseTmpDir):
 
     def setUp(self):
         super().setUp()
-        cmd_line = ('%s run examples/tests/passtest.py '
-                    'examples/tests/passtest.py '
-                    'examples/tests/passtest.py '
-                    'examples/tests/passtest.py '
-                    '--job-results-dir %s --disable-sysinfo --json -'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run examples/tests/passtest.py '
+                    f'examples/tests/passtest.py '
+                    f'examples/tests/passtest.py '
+                    f'examples/tests/passtest.py '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo --json -')
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))
@@ -29,23 +28,20 @@ class ReplayTests(TestCaseTmpDir):
         config_path = os.path.join(self.tmpdir.name, 'config')
         with open(config_path, 'w', encoding='utf-8') as config:
             config.write("[datadir.paths]\n")
-            config.write("logs_dir = %s\n" % self.tmpdir.name)
+            config.write(f"logs_dir = {self.tmpdir.name}\n")
         return config_path
 
     def run_and_check(self, cmd_line, expected_rc):
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
-                         "Command %s did not return rc "
-                         "%d:\n%s" % (cmd_line, expected_rc, result))
+                         f"Command {cmd_line} did not return rc {expected_rc}:\n{result}")
         return result
 
     def test_run_replay_noid(self):
         """
         Runs a replay job with an invalid jobid.
         """
-        cmd_line = '%s --config=%s replay %s' % (AVOCADO,
-                                                 self.config_path,
-                                                 'foo')
+        cmd_line = f"{AVOCADO} --config={self.config_path} replay {'foo'}"
         expected_rc = exit_codes.AVOCADO_FAIL
         self.run_and_check(cmd_line, expected_rc)
 
@@ -53,8 +49,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         Runs a replay job using the 'latest' keyword.
         """
-        cmd_line = '%s --config=%s replay latest' % (AVOCADO,
-                                                     self.config_path)
+        cmd_line = f'{AVOCADO} --config={self.config_path} replay latest'
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 
@@ -72,9 +67,7 @@ class ReplayTests(TestCaseTmpDir):
         """
         Runs a replay job.
         """
-        cmd_line = '%s --config=%s replay %s' % (AVOCADO,
-                                                 self.config_path,
-                                                 self.jobdir)
+        cmd_line = f'{AVOCADO} --config={self.config_path} replay {self.jobdir}'
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 

--- a/selftests/functional/test_replay.py
+++ b/selftests/functional/test_replay.py
@@ -15,7 +15,8 @@ class ReplayTests(TestCaseTmpDir):
                     f'examples/tests/passtest.py '
                     f'examples/tests/passtest.py '
                     f'examples/tests/passtest.py '
-                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo --json -')
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --json -')
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
         self.jobdir = ''.join(glob.glob(os.path.join(self.tmpdir.name, 'job-*')))
@@ -34,7 +35,8 @@ class ReplayTests(TestCaseTmpDir):
     def run_and_check(self, cmd_line, expected_rc):
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Command {cmd_line} did not return rc {expected_rc}:\n{result}")
+                         (f"Command {cmd_line} did not return rc "
+                          f"{expected_rc}:\n{result}"))
         return result
 
     def test_run_replay_noid(self):
@@ -67,7 +69,8 @@ class ReplayTests(TestCaseTmpDir):
         """
         Runs a replay job.
         """
-        cmd_line = f'{AVOCADO} --config={self.config_path} replay {self.jobdir}'
+        cmd_line = (f'{AVOCADO} --config={self.config_path} '
+                    f'replay {self.jobdir}')
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.run_and_check(cmd_line, expected_rc)
 

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -25,7 +25,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'executable-test'
         with script.TemporaryScript(name, EXEC_TEST,
                                     name, self.MODE_0775) as test_file:
-            cmd_line = ('%s --verbose list %s' % (AVOCADO, test_file.path))
+            cmd_line = f'{AVOCADO} --verbose list {test_file.path}'
             result = process.run(cmd_line)
         self.assertIn('exec-test: 1', result.stdout_text)
 
@@ -33,7 +33,7 @@ class ResolverFunctional(unittest.TestCase):
         name = 'executable-test'
         with script.TemporaryScript(name, EXEC_TEST,
                                     name, self.MODE_0664) as test_file:
-            cmd_line = ('%s list %s' % (AVOCADO, test_file.path))
+            cmd_line = f'{AVOCADO} list {test_file.path}'
             result = process.run(cmd_line)
         self.assertNotIn('exec-test ', result.stdout_text)
 
@@ -41,14 +41,14 @@ class ResolverFunctional(unittest.TestCase):
         name = 'passtest.py'
         with script.TemporaryScript(name, AVOCADO_INSTRUMENTED_TEST,
                                     name, self.MODE_0664) as test_file:
-            cmd_line = ('%s --verbose list %s' % (AVOCADO, test_file.path))
+            cmd_line = f'{AVOCADO} --verbose list {test_file.path}'
             result = process.run(cmd_line)
         self.assertIn('passtest.py:PassTest.test', result.stdout_text)
         self.assertIn('avocado-instrumented: 1', result.stdout_text)
 
     def test_property(self):
         test_path = os.path.join(BASEDIR, 'examples', 'tests', 'property.py')
-        cmd_line = ('%s --verbose list %s' % (AVOCADO, test_path))
+        cmd_line = f'{AVOCADO} --verbose list {test_path}'
         result = process.run(cmd_line)
         self.assertIn('examples/tests/property.py:Property.test',
                       result.stdout_text)
@@ -63,9 +63,7 @@ class ResolverFunctional(unittest.TestCase):
         config = "[plugins.resolver]\norder = ['python-unittest',]\n"
         with script.TemporaryScript('config', config) as config_path:
             test_path = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-            cmd_line = ('%s --config %s --verbose list %s' % (AVOCADO,
-                                                              config_path.path,
-                                                              test_path))
+            cmd_line = f'{AVOCADO} --config {config_path.path} --verbose list {test_path}'
             result = process.run(cmd_line)
         self.assertIn('python-unittest: 1', result.stdout_text)
 
@@ -79,9 +77,7 @@ class ResolverFunctional(unittest.TestCase):
                   "'resolver.avocado-instrumented']\n")
         with script.TemporaryScript('config', config) as config_path:
             test_path = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-            cmd_line = ('%s --config %s --verbose list %s' % (AVOCADO,
-                                                              config_path.path,
-                                                              test_path))
+            cmd_line = f'{AVOCADO} --config {config_path.path} --verbose list {test_path}'
             result = process.run(cmd_line)
         lines = result.stdout_text.splitlines()
         self.assertEqual(lines[-2], "TEST TYPES SUMMARY")
@@ -89,7 +85,7 @@ class ResolverFunctional(unittest.TestCase):
 
     def test_recursive_by_default(self):
         test_path = os.path.join(BASEDIR, 'examples', 'tests', 'skip_conditional.py')
-        cmd_line = ('%s --verbose list %s' % (AVOCADO, test_path))
+        cmd_line = f'{AVOCADO} --verbose list {test_path}'
         result = process.run(cmd_line)
         lines = result.stdout_text.splitlines()
         # two random tests that should be among the 10 tests found

--- a/selftests/functional/test_resolver.py
+++ b/selftests/functional/test_resolver.py
@@ -63,7 +63,8 @@ class ResolverFunctional(unittest.TestCase):
         config = "[plugins.resolver]\norder = ['python-unittest',]\n"
         with script.TemporaryScript('config', config) as config_path:
             test_path = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-            cmd_line = f'{AVOCADO} --config {config_path.path} --verbose list {test_path}'
+            cmd_line = (f'{AVOCADO} --config {config_path.path} '
+                        f'--verbose list {test_path}')
             result = process.run(cmd_line)
         self.assertIn('python-unittest: 1', result.stdout_text)
 
@@ -77,7 +78,8 @@ class ResolverFunctional(unittest.TestCase):
                   "'resolver.avocado-instrumented']\n")
         with script.TemporaryScript('config', config) as config_path:
             test_path = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
-            cmd_line = f'{AVOCADO} --config {config_path.path} --verbose list {test_path}'
+            cmd_line = (f'{AVOCADO} --config {config_path.path} '
+                        f'--verbose list {test_path}')
             result = process.run(cmd_line)
         lines = result.stdout_text.splitlines()
         self.assertEqual(lines[-2], "TEST TYPES SUMMARY")

--- a/selftests/functional/test_runner_requirement_asset.py
+++ b/selftests/functional/test_runner_requirement_asset.py
@@ -5,7 +5,7 @@ import unittest
 from avocado.utils import process
 from selftests.utils import BASEDIR
 
-RUNNER = "%s -m avocado.core.runners.requirement_asset" % sys.executable
+RUNNER = f"{sys.executable} -m avocado.core.runners.requirement_asset"
 
 
 class RunnableRun(unittest.TestCase):
@@ -14,7 +14,7 @@ class RunnableRun(unittest.TestCase):
                     'Skipping to run on CI only.')
 
     def test_no_kwargs(self):
-        res = process.run("%s runnable-run -k asset" % RUNNER,
+        res = process.run(f"{RUNNER} runnable-run -k asset",
                           ignore_status=True)
         self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
@@ -26,8 +26,8 @@ class RunnableRun(unittest.TestCase):
     def test_fetch(self):
         name = 'name=gpl-2.0.txt'
         locations = 'locations=https://mirrors.kernel.org/gnu/Licenses/gpl-2.0.txt'
-        res = process.run("%s runnable-run -k asset %s %s"
-                          % (RUNNER, name, locations), ignore_status=True)
+        res = process.run(f"{RUNNER} runnable-run -k asset {name} {locations}",
+                          ignore_status=True)
         self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'time': ", res.stdout)
@@ -40,7 +40,7 @@ class RunnableRun(unittest.TestCase):
         recipe = os.path.join(BASEDIR, "examples", "nrunner",
                               "recipes", "runnables",
                               "requirement_asset.json")
-        cmd = "%s runnable-run-recipe %s" % (RUNNER, recipe)
+        cmd = f"{RUNNER} runnable-run-recipe {recipe}"
         res = process.run(cmd, ignore_status=True)
         self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
@@ -51,8 +51,8 @@ class RunnableRun(unittest.TestCase):
 class TaskRun(unittest.TestCase):
 
     def test_no_kwargs(self):
-        res = process.run("%s task-run -i XXXreq-pacXXX -k asset"
-                          % RUNNER, ignore_status=True)
+        res = process.run(f"{RUNNER} task-run -i XXXreq-pacXXX -k asset",
+                          ignore_status=True)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'result': 'error'", res.stdout)
         self.assertIn(b"'id': 'XXXreq-pacXXX'", res.stdout)

--- a/selftests/functional/test_runner_requirement_package.py
+++ b/selftests/functional/test_runner_requirement_package.py
@@ -5,14 +5,14 @@ import unittest
 from avocado.utils import process
 from selftests.utils import BASEDIR
 
-RUNNER = "%s -m avocado.core.runners.requirement_package" % sys.executable
+RUNNER = f"{sys.executable} -m avocado.core.runners.requirement_package"
 
 
 class RunnableRun(unittest.TestCase):
 
     def test_no_kwargs(self):
-        res = process.run("%s runnable-run -k package" %
-                          RUNNER, ignore_status=True)
+        res = process.run(f"{RUNNER} runnable-run -k package",
+                          ignore_status=True)
         self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'time': ", res.stdout)
@@ -20,8 +20,8 @@ class RunnableRun(unittest.TestCase):
 
     def test_action_check_alone(self):
         action = 'action=check'
-        res = process.run("%s runnable-run -k package %s"
-                          % (RUNNER, action), ignore_status=True)
+        res = process.run(f"{RUNNER} runnable-run -k package {action}",
+                          ignore_status=True)
         self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'time': ", res.stdout)
@@ -36,7 +36,7 @@ class RunnableRun(unittest.TestCase):
         recipe = os.path.join(BASEDIR, "examples", "nrunner",
                               "recipes", "runnables",
                               "requirement_package_check_foo.json")
-        cmd = "%s runnable-run-recipe %s" % (RUNNER, recipe)
+        cmd = f"{RUNNER} runnable-run-recipe {recipe}"
         res = process.run(cmd, ignore_status=True)
         lines = res.stdout_text.splitlines()
         if len(lines) == 1:
@@ -55,9 +55,8 @@ class RunnableRun(unittest.TestCase):
 class TaskRun(unittest.TestCase):
 
     def test_no_kwargs(self):
-        res = process.run("%s task-run -i XXXreq-pacXXX"
-                          " -k package"
-                          % RUNNER, ignore_status=True)
+        res = process.run(f"{RUNNER} task-run -i XXXreq-pacXXX -k package",
+                          ignore_status=True)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'result': 'error'", res.stdout)
         self.assertIn(b"'id': 'XXXreq-pacXXX'", res.stdout)

--- a/selftests/functional/test_skiptests.py
+++ b/selftests/functional/test_skiptests.py
@@ -275,8 +275,8 @@ class Base(TestCaseTmpDir):
                     'run',
                     '--disable-sysinfo',
                     '--job-results-dir',
-                    '%s' % self.tmpdir.name,
-                    '%s' % os.path.join(self.tmpdir.name, self.SCRIPT_TO_EXEC),
+                    f'{self.tmpdir.name}',
+                    f'{os.path.join(self.tmpdir.name, self.SCRIPT_TO_EXEC)}',
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
@@ -380,8 +380,8 @@ class SkipTearDown(Base):
                     'run',
                     '--disable-sysinfo',
                     '--job-results-dir',
-                    '%s' % self.tmpdir.name,
-                    '%s' % os.path.join(self.tmpdir.name, self.SCRIPT_TO_EXEC),
+                    f'{self.tmpdir.name}',
+                    f'{os.path.join(self.tmpdir.name, self.SCRIPT_TO_EXEC)}',
                     '--json -']
         result = process.run(' '.join(cmd_line), ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_TESTS_FAIL)

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -146,9 +146,9 @@ class TestStatuses(TestCaseTmpDir):
                                                  ".data",
                                                  'test_statuses.py'))
 
-        cmd = ('%s run %s --disable-sysinfo --job-results-dir %s --json - '
-               '--test-runner=runner '
-               % (AVOCADO, test_file, self.tmpdir.name))
+        cmd = (f'{AVOCADO} run {test_file} --disable-sysinfo '
+               f'--job-results-dir {self.tmpdir.name} --json - '
+               f'--test-runner=runner ')
 
         results = process.run(cmd, ignore_status=True)
         self.results = json.loads(results.stdout_text)
@@ -168,27 +168,23 @@ class TestStatuses(TestCaseTmpDir):
         # Testing if all class/methods were covered
         missing_msg = ' '.join(missing_tests)
         self.assertEqual(missing_msg, '',
-                         "Expected results not found for class/method: %s" %
-                         missing_msg)
+                         f"Expected results not found for class/method: {missing_msg}")
 
     def _check_test(self, test, expected):
         klass_method = test['id'].split(':')[1]
         self.assertEqual(expected[0], test['status'],
-                         "Status error: '%s' != '%s' (%s)" %
-                         (expected[0], test['status'], klass_method))
+                         f"Status error: '{expected[0]}' != '{test['status']}' ({klass_method})")
         debug_log = genio.read_file(test['logfile'])
         for msg in expected[1]:
             self.assertIn(msg, debug_log,
-                          "Message '%s' should be in the log (%s)."
-                          "\nJSON results:\n%s"
-                          "\nDebug Log:\n%s" %
-                          (msg, klass_method, test, debug_log))
+                          (f"Message '{msg}' should be in the log ({klass_method})."
+                           f"\nJSON results:\n{test}"
+                           f"\nDebug Log:\n{debug_log}"))
         for msg in set(ALL_MESSAGES) - set(expected[1]):
             self.assertNotIn(msg, debug_log,
-                             "Message '%s' should not be in the log (%s)"
-                             "\nJSON results:\n%s"
-                             "\nDebug Log:\n%s" %
-                             (msg, klass_method, test, debug_log))
+                             (f"Message '{msg}' should not be in the log ({klass_method})"
+                              f"\nJSON results:\n{test}"
+                              f"\nDebug Log:\n{debug_log}"))
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_statuses.py
+++ b/selftests/functional/test_statuses.py
@@ -168,21 +168,25 @@ class TestStatuses(TestCaseTmpDir):
         # Testing if all class/methods were covered
         missing_msg = ' '.join(missing_tests)
         self.assertEqual(missing_msg, '',
-                         f"Expected results not found for class/method: {missing_msg}")
+                         (f"Expected results not found for class/method: "
+                          f"{missing_msg}"))
 
     def _check_test(self, test, expected):
         klass_method = test['id'].split(':')[1]
         self.assertEqual(expected[0], test['status'],
-                         f"Status error: '{expected[0]}' != '{test['status']}' ({klass_method})")
+                         (f"Status error: '{expected[0]}' != "
+                          f"'{test['status']}' ({klass_method})"))
         debug_log = genio.read_file(test['logfile'])
         for msg in expected[1]:
             self.assertIn(msg, debug_log,
-                          (f"Message '{msg}' should be in the log ({klass_method})."
+                          (f"Message '{msg}' should be in the log "
+                           f"({klass_method})."
                            f"\nJSON results:\n{test}"
                            f"\nDebug Log:\n{debug_log}"))
         for msg in set(ALL_MESSAGES) - set(expected[1]):
             self.assertNotIn(msg, debug_log,
-                             (f"Message '{msg}' should not be in the log ({klass_method})"
+                             (f"Message '{msg}' should not be in the log "
+                              "({klass_method})"
                               f"\nJSON results:\n{test}"
                               f"\nDebug Log:\n{debug_log}"))
 

--- a/selftests/functional/test_streams.py
+++ b/selftests/functional/test_streams.py
@@ -12,7 +12,7 @@ class StreamsTest(TestCaseTmpDir):
         """
         Checks that the application output (<= level info) goes to stdout
         """
-        result = process.run('%s distro' % AVOCADO)
+        result = process.run(f'{AVOCADO} distro')
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertIn(b'Detected distribution', result.stdout)
 
@@ -20,7 +20,7 @@ class StreamsTest(TestCaseTmpDir):
         """
         Checks that the application error (> level info) goes to stderr
         """
-        result = process.run('%s unknown-whacky-command' % AVOCADO,
+        result = process.run(f'{AVOCADO} unknown-whacky-command',
                              ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
         self.assertIn(b"invalid choice: 'unknown-whacky-command'",
@@ -37,34 +37,34 @@ class StreamsTest(TestCaseTmpDir):
         Also checks the symmetry between `--show early` and the environment
         variable `AVOCADO_LOG_EARLY` being set.
         """
-        cmds = (('%s --show early run --disable-sysinfo '
-                 '--job-results-dir %s examples/tests/passtest.py'
-                 % (AVOCADO, self.tmpdir.name),
-                 {}),
-                ('%s run --disable-sysinfo --job-results-dir'
-                 ' %s examples/tests/passtest.py'
-                 % (AVOCADO, self.tmpdir.name),
-                 {'AVOCADO_LOG_EARLY': 'y'}))
+        cmds = ((f'{AVOCADO} --show early run --disable-sysinfo '
+                 f'--job-results-dir {self.tmpdir.name} '
+                 f'examples/tests/passtest.py', {}),
+                (f'{AVOCADO} run --disable-sysinfo '
+                 f'--job-results-dir {self.tmpdir.name} '
+                 f'examples/tests/passtest.py',
+                 {'AVOCADO_LOG_EARLY': 'y'})
+                )
         for cmd, env in cmds:
             result = process.run(cmd, env=env, shell=True)
             # Avocado will see the main module on the command line
             cmd_in_log = os.path.join(BASEDIR, 'avocado', '__main__.py')
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-            self.assertIn("avocado.test: Command line: %s" % cmd_in_log,
+            self.assertIn(f"avocado.test: Command line: {cmd_in_log}",
                           result.stdout_text)
 
     def test_test(self):
         """
         Checks that the test stream (early in this case) goes to stdout
         """
-        cmd = ('%s --show=test run --disable-sysinfo --job-results-dir %s '
-               '--test-runner=runner '
-               'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd = (f'{AVOCADO} --show=test run --disable-sysinfo '
+               f'--job-results-dir {self.tmpdir.name} '
+               f'--test-runner=runner examples/tests/passtest.py')
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         # Avocado will see the main module on the command line
         cmd_in_log = os.path.join(BASEDIR, 'avocado', '__main__.py')
-        self.assertIn("Command line: %s" % cmd_in_log,
+        self.assertIn(f"Command line: {cmd_in_log}",
                       result.stdout_text)
         self.assertIn(b"\nSTART 1-examples/tests/passtest.py:PassTest.test",
                       result.stdout)
@@ -75,8 +75,9 @@ class StreamsTest(TestCaseTmpDir):
         """
         Checks that only errors are output, and that they go to stderr
         """
-        cmd = ('%s --show none run --disable-sysinfo --job-results-dir %s '
-               'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd = (f'{AVOCADO} --show none run --disable-sysinfo '
+               f'--job-results-dir {self.tmpdir.name} '
+               f'examples/tests/passtest.py')
         result = process.run(cmd)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(b'', result.stdout)
@@ -85,7 +86,7 @@ class StreamsTest(TestCaseTmpDir):
         """
         Checks that only errors are output, and that they go to stderr
         """
-        cmd = '%s --show=none unknown-whacky-command' % AVOCADO
+        cmd = f'{AVOCADO} --show=none unknown-whacky-command'
         result = process.run(cmd, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
         self.assertEqual(b'', result.stdout)
@@ -96,17 +97,18 @@ class StreamsTest(TestCaseTmpDir):
         Checks if "--show stream:level" works for non-built-in-streams
         """
         def run(show, no_lines):
-            result = process.run("%s --show %s config" % (AVOCADO, show))
+            result = process.run(f"{AVOCADO} --show {show} config")
             out = result.stdout.splitlines()
             if no_lines == "more_than_one":
-                self.assertGreater(len(out), 1, "Output of %s should contain "
-                                   "more than 1 line, contains only %s\n%s"
-                                   % (result.command, len(out), result))
+                self.assertGreater(len(out), 1,
+                                   (f"Output of {result.command} should "
+                                    f"contain more than 1 line, contains only "
+                                    f"{len(out)}\n{result}"))
             else:
-                self.assertEqual(len(out), no_lines, "Output of %s should "
-                                 "contain %s lines, contains %s instead\n%s"
-                                 % (result.command, no_lines, len(out),
-                                    result))
+                self.assertEqual(len(out), no_lines,
+                                 (f"Output of {result.command} should "
+                                  f"contain {no_lines} lines, contains "
+                                  f"{len(out)} instead\n{result}"))
         run("avocado.app:dEbUg", "more_than_one")
         run("avocado.app:0", "more_than_one")
         run("avocado.app:InFo", 1)

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -17,13 +17,12 @@ commands = %s
 class SysInfoTest(TestCaseTmpDir):
 
     def test_sysinfo_enabled(self):
-        cmd_line = ('%s run --job-results-dir %s '
-                    'examples/tests/passtest.py' % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/passtest.py')
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc,
-                                                                result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         output = result.stdout_text + result.stderr_text
         sysinfo_dir = None
         for line in output.splitlines():
@@ -33,26 +32,22 @@ class SysInfoTest(TestCaseTmpDir):
         self.assertIsNotNone(sysinfo_dir,
                              ('Could not find sysinfo dir from human output. '
                               'Output produced: "%s" % output'))
-        msg = "Avocado didn't create sysinfo directory %s:\n%s" % (sysinfo_dir,
-                                                                   result)
+        msg = f"Avocado didn't create sysinfo directory {sysinfo_dir}:\n{result}"
         self.assertTrue(os.path.isdir(sysinfo_dir), msg)
-        msg = 'The sysinfo directory is empty:\n%s' % result
+        msg = f'The sysinfo directory is empty:\n{result}'
         self.assertGreater(len(os.listdir(sysinfo_dir)), 0, msg)
         for hook in ('pre', 'post'):
             sysinfo_subdir = os.path.join(sysinfo_dir, hook)
-            msg = 'The sysinfo/%s subdirectory does not exist:\n%s' % (hook,
-                                                                       result)
+            msg = f'The sysinfo/{hook} subdirectory does not exist:\n{result}'
             self.assertTrue(os.path.exists(sysinfo_subdir), msg)
 
     def test_sysinfo_disabled(self):
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    'examples/tests/passtest.py'
-                    % (AVOCADO, self.tmpdir.name))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo examples/tests/passtest.py')
         result = process.run(cmd_line)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s' % (expected_rc,
-                                                                result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         output = result.stdout_text + result.stderr_text
         sysinfo_dir = None
         for line in output.splitlines():
@@ -62,38 +57,36 @@ class SysInfoTest(TestCaseTmpDir):
         self.assertIsNotNone(sysinfo_dir,
                              ('Could not find sysinfo dir from human output. '
                               'Output produced: "%s" % output'))
-        msg = 'Avocado created sysinfo directory %s:\n%s' % (sysinfo_dir,
-                                                             result)
+        msg = f'Avocado created sysinfo directory {sysinfo_dir}:\n{result}'
         self.assertFalse(os.path.isdir(sysinfo_dir), msg)
 
     def run_sysinfo_interrupted(self, sleep, timeout, exp_duration):
         commands_path = os.path.join(self.tmpdir.name, "commands")
-        script.make_script(commands_path, "sleep %s" % sleep)
+        script.make_script(commands_path, f"sleep {sleep}")
         config_path = os.path.join(self.tmpdir.name, "config.conf")
         script.make_script(config_path,
                            COMMANDS_TIMEOUT_CONF % (timeout, commands_path))
-        cmd_line = ("%s --show all --config %s run --job-results-dir %s "
-                    "examples/tests/passtest.py"
-                    % (AVOCADO, config_path, self.tmpdir.name))
+        cmd_line = (f"{AVOCADO} --show all --config {config_path} run "
+                    f"--job-results-dir {self.tmpdir.name} "
+                    f"examples/tests/passtest.py")
         result = process.run(cmd_line)
         if timeout > 0:
-            self.assertLess(result.duration, exp_duration, "Execution took "
-                            "longer than %ss which is likely due to "
-                            "malfunctioning commands_timeout "
-                            "sysinfo.collect feature:\n%s"
-                            % (exp_duration, result))
+            self.assertLess(result.duration, exp_duration,
+                            (f"Execution took "
+                             f"longer than {exp_duration}s which is likely due to "
+                             f"malfunctioning commands_timeout "
+                             f"sysinfo.collect feature:\n{result}"))
         else:
-            self.assertGreater(result.duration, exp_duration, "Execution took "
-                               "less than %ss which is likely due to "
-                               "malfunctioning commands_timeout "
-                               "sysinfo.collect feature:\n%s"
-                               % (exp_duration, result))
+            self.assertGreater(result.duration, exp_duration,
+                               (f"Execution took "
+                                f"less than {exp_duration}s which is likely due to "
+                                f"malfunctioning commands_timeout "
+                                f"sysinfo.collect feature:\n{result}"))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         'Avocado did not return rc %d:\n%s'
-                         % (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         sleep_log = os.path.join(self.tmpdir.name, "latest", "sysinfo", "pre",
-                                 "sleep %s" % sleep)
+                                 f"sleep {sleep}")
         if not os.path.exists(sleep_log):
             path = os.path.abspath(sleep_log)
             while not os.path.exists(path):
@@ -101,9 +94,8 @@ class SysInfoTest(TestCaseTmpDir):
                 if tmp == path:
                     break
                 path = tmp
-            raise AssertionError("Sleep output not recorded in '%s', first "
-                                 "existing location '%s' contains:\n%s"
-                                 % (sleep_log, path, os.listdir(path)))
+            raise AssertionError(f"Sleep output not recorded in '{sleep_log}', first "
+                                 f"existing location '{path}' contains:\n{os.listdir(path)}")
 
     @skipOnLevelsInferiorThan(2)
     def test_sysinfo_interrupted(self):

--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -32,7 +32,8 @@ class SysInfoTest(TestCaseTmpDir):
         self.assertIsNotNone(sysinfo_dir,
                              ('Could not find sysinfo dir from human output. '
                               'Output produced: "%s" % output'))
-        msg = f"Avocado didn't create sysinfo directory {sysinfo_dir}:\n{result}"
+        msg = (f"Avocado didn't create sysinfo directory {sysinfo_dir}:"
+               f"\n{result}")
         self.assertTrue(os.path.isdir(sysinfo_dir), msg)
         msg = f'The sysinfo directory is empty:\n{result}'
         self.assertGreater(len(os.listdir(sysinfo_dir)), 0, msg)
@@ -73,14 +74,14 @@ class SysInfoTest(TestCaseTmpDir):
         if timeout > 0:
             self.assertLess(result.duration, exp_duration,
                             (f"Execution took "
-                             f"longer than {exp_duration}s which is likely due to "
-                             f"malfunctioning commands_timeout "
+                             f"longer than {exp_duration}s which is likely "
+                             f"due to malfunctioning commands_timeout "
                              f"sysinfo.collect feature:\n{result}"))
         else:
             self.assertGreater(result.duration, exp_duration,
                                (f"Execution took "
-                                f"less than {exp_duration}s which is likely due to "
-                                f"malfunctioning commands_timeout "
+                                f"less than {exp_duration}s which is likely "
+                                f"due to malfunctioning commands_timeout "
                                 f"sysinfo.collect feature:\n{result}"))
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -94,8 +95,9 @@ class SysInfoTest(TestCaseTmpDir):
                 if tmp == path:
                     break
                 path = tmp
-            raise AssertionError(f"Sleep output not recorded in '{sleep_log}', first "
-                                 f"existing location '{path}' contains:\n{os.listdir(path)}")
+            raise AssertionError(f"Sleep output not recorded in '{sleep_log}',"
+                                 f"first existing location '{path}' contains:"
+                                 f"\n{os.listdir(path)}")
 
     @skipOnLevelsInferiorThan(2)
     def test_sysinfo_interrupted(self):

--- a/selftests/functional/test_task_statemachine.py
+++ b/selftests/functional/test_task_statemachine.py
@@ -20,7 +20,7 @@ class StateMachine(TestCase):
         number_of_workers = 8
 
         runnable = Runnable("noop", "noop")
-        runtime_tasks = [RuntimeTask(Task(runnable, "%03i" % _))
+        runtime_tasks = [RuntimeTask(Task(runnable, "%03i" % _))  # pylint: disable=C0209
                          for _ in range(1, number_of_tasks + 1)]
         spawner = Spawner()
         status_repo = StatusRepo()

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -44,7 +44,8 @@ class TestsTmpDirTests(TestCaseTmpDir):
     def run_and_check(self, cmd_line, expected_rc, env=None):
         result = process.run(cmd_line, ignore_status=True, env=env)
         self.assertEqual(result.exit_status, expected_rc,
-                         f"Command {cmd_line} did not return rc {expected_rc}:\n{result}")
+                         (f"Command {cmd_line} did not return rc "
+                          f"{expected_rc}:\n{result}"))
         return result
 
     @unittest.skipIf(test.COMMON_TMPDIR_NAME in os.environ,
@@ -54,7 +55,8 @@ class TestsTmpDirTests(TestCaseTmpDir):
         Tests whether automatically created teststmpdir is shared across
         all tests.
         """
-        cmd_line = (f"{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} "
+        cmd_line = (f"{AVOCADO} run --disable-sysinfo "
+                    f"--job-results-dir {self.tmpdir.name} "
                     f"{self.simple_test} {self.instrumented_test}")
         self.run_and_check(cmd_line, exit_codes.AVOCADO_ALL_OK)
 
@@ -64,7 +66,8 @@ class TestsTmpDirTests(TestCaseTmpDir):
         avocado
         """
         with tempfile.TemporaryDirectory(dir=self.tmpdir.name) as shared_tmp:
-            cmd = (f"{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} %s")
+            cmd = (f"{AVOCADO} run --disable-sysinfo "
+                   f"--job-results-dir {self.tmpdir.name} %s")
             self.run_and_check(cmd % self.simple_test, exit_codes.AVOCADO_ALL_OK,
                                {test.COMMON_TMPDIR_NAME: shared_tmp})
             self.run_and_check(cmd % self.instrumented_test,

--- a/selftests/functional/test_thirdparty_bugs.py
+++ b/selftests/functional/test_thirdparty_bugs.py
@@ -47,11 +47,10 @@ class TestThirdPartyBugs(unittest.TestCase):
         except URLError as details:
             raise unittest.SkipTest(details)
         issue = json.loads(content)
-        self.assertEqual(issue['state'], 'open', 'The issue %s is not open '
+        self.assertEqual(issue['state'], 'open', 'The issue {issue_url} is not open '
                          'anymore. Please double check and, if already fixed, '
                          'remove the selftests/unit/test_utils_cpu.py from '
-                         'the exclusion list in selftests/inspekt-indent.sh ' %
-                         'https://github.com/avocado-framework/inspektor/issues/31')
+                         'the exclusion list in selftests/inspekt-indent.sh ')
 
 
 if __name__ == '__main__':

--- a/selftests/functional/test_unittest_compat.py
+++ b/selftests/functional/test_unittest_compat.py
@@ -60,10 +60,9 @@ class UnittestCompat(TestCaseTmpDir):
         super().setUp()
         self.original_pypath = os.environ.get('PYTHONPATH')
         if self.original_pypath is not None:
-            os.environ['PYTHONPATH'] = '%s:%s' % (
-                BASEDIR, self.original_pypath)
+            os.environ['PYTHONPATH'] = f'{BASEDIR}:{self.original_pypath}'
         else:
-            os.environ['PYTHONPATH'] = '%s' % BASEDIR
+            os.environ['PYTHONPATH'] = f'{BASEDIR}'
         self.unittest_script_good = script.TemporaryScript(
             'unittest_good.py',
             UNITTEST_GOOD % self.tmpdir.name,
@@ -81,13 +80,13 @@ class UnittestCompat(TestCaseTmpDir):
         self.unittest_script_error.save()
 
     def test_run_pass(self):
-        cmd_line = '%s %s' % (sys.executable, self.unittest_script_good)
+        cmd_line = f'{sys.executable} {self.unittest_script_good}'
         result = process.run(cmd_line)
         self.assertEqual(0, result.exit_status)
         self.assertIn(b'Ran 1 test in', result.stderr)
 
     def test_run_fail(self):
-        cmd_line = '%s %s' % (sys.executable, self.unittest_script_fail)
+        cmd_line = f'{sys.executable} {self.unittest_script_fail}'
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(1, result.exit_status)
         self.assertIn(b'Ran 1 test in', result.stderr)
@@ -95,7 +94,7 @@ class UnittestCompat(TestCaseTmpDir):
         self.assertIn(b'FAILED (failures=1)', result.stderr)
 
     def test_run_error(self):
-        cmd_line = '%s %s' % (sys.executable, self.unittest_script_error)
+        cmd_line = f'{sys.executable} {self.unittest_script_error}'
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(1, result.exit_status)
         self.assertIn(b'Ran 1 test in', result.stderr)

--- a/selftests/functional/test_utils.py
+++ b/selftests/functional/test_utils.py
@@ -16,7 +16,7 @@ DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
                 stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP |
                 stat.S_IROTH | stat.S_IXOTH)
 
-FAKE_VMSTAT_CONTENTS = """#!{python}
+FAKE_VMSTAT_CONTENTS = (f"""#!{sys.executable}
 import time
 import random
 import signal
@@ -112,13 +112,13 @@ class FakeVMStat:
 if __name__ == '__main__':
     vmstat = FakeVMStat(interval=float(sys.argv[1]), interrupt_delay=float(sys.argv[2]))
     vmstat.start()
-""".format(python=sys.executable)
+""")
 
-FAKE_UPTIME_CONTENTS = """#!{python}
+FAKE_UPTIME_CONTENTS = (f"""#!{sys.executable}
 if __name__ == '__main__':
     print("17:56:34 up  8:06,  7 users,  load average: 0.26, 0.20, 0.21")
 
-""".format(python=sys.executable)
+""")
 
 
 class ProcessTest(TestCaseTmpDir):
@@ -140,13 +140,13 @@ class ProcessTest(TestCaseTmpDir):
         """
         :avocado: tags=parallel:1
         """
-        proc = process.SubProcess('%s 1 0' % self.fake_vmstat)
+        proc = process.SubProcess(f'{self.fake_vmstat} 1 0')
         proc.start()
         time.sleep(3)
         proc.terminate()
         proc.wait(timeout=1)
         stdout = proc.get_stdout().decode()
-        self.assertIn('memory', stdout, 'result: %s' % stdout)
+        self.assertIn('memory', stdout, f'result: {stdout}')
         self.assertRegex(stdout, '[0-9]+')
 
     @skipOnLevelsInferiorThan(2)
@@ -154,7 +154,7 @@ class ProcessTest(TestCaseTmpDir):
         """
         :avocado: tags=parallel:1
         """
-        proc = process.SubProcess('%s 1 3' % self.fake_vmstat)
+        proc = process.SubProcess(f'{self.fake_vmstat} 1 3')
         proc.start()
         time.sleep(3)
         proc.stop(2)
@@ -166,7 +166,7 @@ class ProcessTest(TestCaseTmpDir):
         """
         :avocado: tags=parallel:1
         """
-        proc = process.SubProcess('%s 1 3' % self.fake_vmstat)
+        proc = process.SubProcess(f'{self.fake_vmstat} 1 3')
         proc.start()
         time.sleep(3)
         proc.stop(4)
@@ -176,7 +176,7 @@ class ProcessTest(TestCaseTmpDir):
     def test_process_run(self):
         proc = process.SubProcess(self.fake_uptime)
         result = proc.run()
-        self.assertEqual(result.exit_status, 0, 'result: %s' % result)
+        self.assertEqual(result.exit_status, 0, f'result: {result}')
         self.assertIn(b'load average', result.stdout)
 
 

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -45,56 +45,46 @@ class WrapperTest(TestCaseTmpDir):
                      "C compiler is required by the underlying datadir.py test")
     def test_global_wrapper(self):
         os.chdir(BASEDIR)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --wrapper %s '
-                    '--test-runner=runner '
-                    'examples/tests/datadir.py'
-                    % (AVOCADO, self.tmpdir.name, self.script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --wrapper {self.script.path} '
+                    f'--test-runner=runner examples/tests/datadir.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertTrue(os.path.exists(self.tmpfile),
-                        "Wrapper did not touch the tmp file %s\nStdout: "
-                        "%s\nCmdline: %s" %
-                        (self.tmpfile, result.stdout, cmd_line))
+                        (f"Wrapper did not touch the tmp file {self.tmpfile}\n"
+                         f"Stdout: {result.stdout}\nCmdline: {cmd_line}"))
 
     @unittest.skipIf(missing_binary('cc'),
                      "C compiler is required by the underlying datadir.py test")
     def test_process_wrapper(self):
         os.chdir(BASEDIR)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo '
-                    '--test-runner=runner '
-                    '--wrapper %s:*/datadir examples/tests/datadir.py'
-                    % (AVOCADO, self.tmpdir.name, self.script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --test-runner=runner '
+                    f'--wrapper {self.script.path}:*/datadir examples/tests/datadir.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertTrue(os.path.exists(self.tmpfile),
-                        "Wrapper did not touch the tmp file %s\nStdout: "
-                        "%s\nStdout: %s" %
-                        (self.tmpfile, cmd_line, result.stdout))
+                        (f"Wrapper did not touch the tmp file {self.tmpfile}\n"
+                         f"Stdout: {cmd_line}\nStdout: {result.stdout}"))
 
     @unittest.skipIf(missing_binary('cc'),
                      "C compiler is required by the underlying datadir.py test")
     def test_both_wrappers(self):
         os.chdir(BASEDIR)
-        cmd_line = ('%s run --job-results-dir %s --disable-sysinfo --wrapper %s '
-                    '--test-runner=runner '
-                    '--wrapper %s:*/datadir examples/tests/datadir.py'
-                    % (AVOCADO, self.tmpdir.name, self.dummy.path,
-                       self.script.path))
+        cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
+                    f'--disable-sysinfo --wrapper {self.dummy.path} --test-runner=runner '
+                    f'--wrapper {self.script.path}:*/datadir examples/tests/datadir.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
-                         "Avocado did not return rc %d:\n%s" %
-                         (expected_rc, result))
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
         self.assertTrue(os.path.exists(self.tmpfile),
-                        "Wrapper did not touch the tmp file %s\nStdout: "
-                        "%s\nStdout: %s" %
-                        (self.tmpfile, cmd_line, result.stdout))
+                        (f"Wrapper did not touch the tmp file {self.tmpfile}\n"
+                         f"Stdout: {cmd_line}\nStdout: {result.stdout}"))
 
     def tearDown(self):
         super().tearDown()

--- a/selftests/functional/test_wrapper.py
+++ b/selftests/functional/test_wrapper.py
@@ -61,8 +61,8 @@ class WrapperTest(TestCaseTmpDir):
     def test_process_wrapper(self):
         os.chdir(BASEDIR)
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo --test-runner=runner '
-                    f'--wrapper {self.script.path}:*/datadir examples/tests/datadir.py')
+                    f'--disable-sysinfo --test-runner=runner --wrapper '
+                    f'{self.script.path}:*/datadir examples/tests/datadir.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,
@@ -76,8 +76,10 @@ class WrapperTest(TestCaseTmpDir):
     def test_both_wrappers(self):
         os.chdir(BASEDIR)
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo --wrapper {self.dummy.path} --test-runner=runner '
-                    f'--wrapper {self.script.path}:*/datadir examples/tests/datadir.py')
+                    f'--disable-sysinfo '
+                    f'--wrapper {self.dummy.path} --test-runner=runner '
+                    f'--wrapper '
+                    f'{self.script.path}:*/datadir examples/tests/datadir.py')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/functional/utils/test_asset.py
+++ b/selftests/functional/utils/test_asset.py
@@ -19,7 +19,7 @@ class TestAsset(TestCaseTmpDir):
         self.localpath = os.path.join(self.assetdir, self.assetname)
         with open(self.localpath, 'w', encoding='utf-8') as f:
             f.write('Test!')
-        self.url = 'file://%s' % self.localpath
+        self.url = f'file://{self.localpath}'
         self.cache_dir = tempfile.mkdtemp(dir=self.tmpdir.name)
 
     def test_fetch_url_cache_by_location(self):
@@ -69,7 +69,7 @@ class TestAsset(TestCaseTmpDir):
         new_assetdir = tempfile.mkdtemp(dir=self.tmpdir.name)
         new_localpath = os.path.join(new_assetdir, self.assetname)
         new_hash = '9f1ad57044be4799f288222dc91d5eab152921e9'
-        new_url = 'file://%s' % new_localpath
+        new_url = f'file://{new_localpath}'
         with open(new_localpath, 'w', encoding='utf-8') as f:
             f.write('Changed!')
 
@@ -127,7 +127,7 @@ class TestAsset(TestCaseTmpDir):
         second_asset_content = 'This is not your first asset content!'
         with open(second_asset_local_path, 'w', encoding='utf-8') as f:
             f.write(second_asset_content)
-        second_asset_origin_url = 'file://%s' % second_asset_local_path
+        second_asset_origin_url = f'file://{second_asset_local_path}'
 
         a1 = asset.Asset(self.url, self.assethash, 'sha1', None,
                          [self.cache_dir], None)
@@ -145,7 +145,7 @@ class TestAsset(TestCaseTmpDir):
         third_asset_content = 'Another content!'
         with open(third_asset_local_path, 'w', encoding='utf-8') as f:
             f.write(third_asset_content)
-        third_asset_origin_url = 'file://%s' % third_asset_local_path
+        third_asset_origin_url = f'file://{third_asset_local_path}'
         a3 = asset.Asset(third_asset_origin_url, None, None,
                          None, [self.cache_dir], None)
         a3_path = a3.fetch()
@@ -161,7 +161,7 @@ class TestAsset(TestCaseTmpDir):
                                   cache_dirs=[self.cache_dir],
                                   expire=None,
                                   metadata=expected_metadata).fetch()
-        expected_file = "%s_metadata.json" % os.path.splitext(foo_tarball)[0]
+        expected_file = f"{os.path.splitext(foo_tarball)[0]}_metadata.json"
         self.assertTrue(os.path.exists(expected_file))
 
     def test_get_metadata_file_exists(self):

--- a/selftests/pre_release/tests/readthedocs.py
+++ b/selftests/pre_release/tests/readthedocs.py
@@ -15,7 +15,7 @@ class ReadtheDocs(Test):
                       'via the "token" parameter or the '
                       '"AVOCADO_READTHEDOCS_TOKEN" environment variable')
 
-        headers = {'Authorization': 'Token %s' % token,
+        headers = {'Authorization': f'Token {token}',
                    # readthedocs.org throws a 403 without User-Agent header
                    'User-Agent': ''}
 

--- a/selftests/pre_release/tests/vmimage.py
+++ b/selftests/pre_release/tests/vmimage.py
@@ -32,7 +32,7 @@ class Base(Test):
                                default=self.DEFAULTS.get('arch'))
         # Distros may use slightly different values for their architecture names.
         # For instance, Cirros ppc images are called powerpc, so we look
-        distro_arch_path = '/run/distro/%s/%s/*' % (self.vmimage_name, arch)
+        distro_arch_path = f'/run/distro/{self.vmimage_name}/{arch}/*'
         self.vmimage_arch = self.params.get('arch', path=distro_arch_path, default=arch)
 
 

--- a/selftests/unit/plugin/test_jsonresult.py
+++ b/selftests/unit/plugin/test_jsonresult.py
@@ -55,8 +55,8 @@ class JSONResultTest(TestCaseTmpDir):
             self.test_result.check_test(status)
 
         def check_item(name, value, exp):
-            self.assertEqual(value, exp, "Result%s is %s and not %s\n%s"
-                             % (name, value, exp, res))
+            self.assertEqual(value, exp,
+                             f"Result{name} is {value} and not {exp}\n{res}")
 
         # Set the number of tests to all tests + 3
         self.test_result.tests_total = 13
@@ -89,8 +89,8 @@ class JSONResultTest(TestCaseTmpDir):
 
     def test_negative_status(self):
         def check_item(name, value, exp):
-            self.assertEqual(value, exp, "Result%s is %s and not %s\n%s"
-                             % (name, value, exp, res))
+            self.assertEqual(value, exp,
+                             f"Result{name} is {value} and not {exp}\n{res}")
 
         self.test_result.tests_total = 0
         self.test_result.start_test(self.test1)

--- a/selftests/unit/plugin/test_resolver.py
+++ b/selftests/unit/plugin/test_resolver.py
@@ -75,7 +75,7 @@ class AvocadoInstrumented(unittest.TestCase):
     def test_passtest(self):
         passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
         test = 'PassTest.test'
-        uri = '%s:%s' % (passtest, test)
+        uri = f'{passtest}:{test}'
         res = AvocadoInstrumentedResolver().resolve(passtest)
         self.assertEqual(res.reference, passtest)
         self.assertEqual(res.result, resolver.ReferenceResolutionResult.SUCCESS)
@@ -92,7 +92,7 @@ class AvocadoInstrumented(unittest.TestCase):
     def test_passtest_filter_found(self):
         passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
         test_filter = 'test'
-        reference = '%s:%s' % (passtest, test_filter)
+        reference = f'{passtest}:{test_filter}'
         res = AvocadoInstrumentedResolver().resolve(reference)
         self.assertEqual(res.reference, reference)
         self.assertEqual(res.result, resolver.ReferenceResolutionResult.SUCCESS)
@@ -101,7 +101,7 @@ class AvocadoInstrumented(unittest.TestCase):
     def test_passtest_filter_notfound(self):
         passtest = os.path.join(BASEDIR, 'examples', 'tests', 'passtest.py')
         test_filter = 'test_other'
-        reference = '%s:%s' % (passtest, test_filter)
+        reference = f'{passtest}:{test_filter}'
         res = AvocadoInstrumentedResolver().resolve(reference)
         self.assertEqual(res.reference, reference)
         self.assertEqual(res.result, resolver.ReferenceResolutionResult.NOTFOUND)
@@ -156,7 +156,7 @@ class PythonUnittest(unittest.TestCase):
         resolution = res.resolutions[0]
         self.assertEqual(resolution.kind, 'python-unittest')
         self.assertEqual(resolution.uri,
-                         "%s:%s" % (python_unittest.path, "SampleTest.test"))
+                         f"{python_unittest.path}:{'SampleTest.test'}")
         self.assertEqual(resolution.args, ())
         self.assertEqual(resolution.kwargs, {})
         self.assertEqual(resolution.tags, {"flattag": None, "foo": {"bar"}})
@@ -164,7 +164,7 @@ class PythonUnittest(unittest.TestCase):
     def test_dont_detect_non_avocado(self):
         def _check_resolution(resolution, name):
             self.assertEqual(resolution.kind, 'python-unittest')
-            self.assertEqual(resolution.uri, "%s:%s" % (path, name))
+            self.assertEqual(resolution.uri, f"{path}:{name}")
             self.assertEqual(resolution.args, ())
             self.assertEqual(resolution.kwargs, {})
             self.assertEqual(resolution.tags, {})

--- a/selftests/unit/plugin/test_xunit.py
+++ b/selftests/unit/plugin/test_xunit.py
@@ -80,7 +80,7 @@ class xUnitSucceedTest(unittest.TestCase):
         try:
             dom = minidom.parseString(xml)
         except Exception as details:
-            raise ParseXMLError("Error parsing XML: '%s'.\nXML Contents:\n%s" % (details, xml))
+            raise ParseXMLError(f"Error parsing XML: '{details}'.\nXML Contents:\n{xml}")
         self.assertTrue(dom)
 
         els = dom.getElementsByTagName('testsuite')
@@ -130,9 +130,9 @@ class xUnitSucceedTest(unittest.TestCase):
         with open(xunit_output, 'rb') as fp:
             limited_but_fits = fp.read()
         self.assertLess(len(limited), len(unlimited) - 500,
-                        "Length of xunit limited to 10 chars was greater "
-                        "than (unlimited - 500). Unlimited output:\n%s\n\n"
-                        "Limited output:\n%s" % (unlimited, limited))
+                        (f"Length of xunit limited to 10 chars was greater "
+                         f"than (unlimited - 500). Unlimited output:\n{unlimited}\n\n"
+                         f"Limited output:\n{limited}"))
         unlimited_output = get_system_out(unlimited)
         self.assertIn(log_content, unlimited_output)
         self.assertEqual(unlimited_output, get_system_out(limited_but_fits))

--- a/selftests/unit/plugin/test_xunit.py
+++ b/selftests/unit/plugin/test_xunit.py
@@ -131,7 +131,8 @@ class xUnitSucceedTest(unittest.TestCase):
             limited_but_fits = fp.read()
         self.assertLess(len(limited), len(unlimited) - 500,
                         (f"Length of xunit limited to 10 chars was greater "
-                         f"than (unlimited - 500). Unlimited output:\n{unlimited}\n\n"
+                         f"than (unlimited - 500). "
+                         f"Unlimited output:\n{unlimited}\n\n"
                          f"Limited output:\n{limited}"))
         unlimited_output = get_system_out(unlimited)
         self.assertIn(log_content, unlimited_output)

--- a/selftests/unit/test_datadir.py
+++ b/selftests/unit/test_datadir.py
@@ -58,8 +58,8 @@ class DataDirTest(Base):
         with unittest.mock.patch('avocado.core.data_dir.settings', stg):
             from avocado.core import data_dir
             for key in self.mapping.keys():
-                data_dir_func = getattr(data_dir, 'get_%s' % key)
-                namespace = 'datadir.paths.{}'.format(key)
+                data_dir_func = getattr(data_dir, f'get_{key}')
+                namespace = f'datadir.paths.{key}'
                 self.assertEqual(data_dir_func(), stg.as_dict().get(namespace))
 
     def test_unique_log_dir(self):
@@ -107,7 +107,7 @@ class DataDirTest(Base):
         # Create the id file.
         id_file_path = os.path.join(expected_jrd, 'id')
         with open(id_file_path, 'w', encoding='utf-8') as id_file:
-            id_file.write("%s\n" % unique_id)
+            id_file.write(f"{unique_id}\n")
             id_file.flush()
             os.fsync(id_file)
 
@@ -199,7 +199,7 @@ class AltDataDirTest(Base):
         with unittest.mock.patch('avocado.core.data_dir.settings', stg):
             from avocado.core import data_dir
             for key, value in self.mapping.items():
-                data_dir_func = getattr(data_dir, 'get_%s' % key)
+                data_dir_func = getattr(data_dir, f'get_{key}')
                 self.assertEqual(data_dir_func(), value)
 
         (self.alt_base_dir,  # pylint: disable=W0201
@@ -216,7 +216,7 @@ class AltDataDirTest(Base):
         alt_stg.merge_with_configs()
         with unittest.mock.patch('avocado.core.data_dir.settings', alt_stg):
             for key, value in alt_mapping.items():
-                data_dir_func = getattr(data_dir, 'get_%s' % key)
+                data_dir_func = getattr(data_dir, f'get_{key}')
                 self.assertEqual(data_dir_func(), value)
 
     def tearDown(self):

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -131,9 +131,10 @@ class SampleTest(TestCase):
 class LoaderTest(unittest.TestCase):
 
     def _check_discovery(self, exps, tests):
-        self.assertEqual(len(exps), len(tests), "Total count of tests not "
-                         "as expected (%s != %s)\nexps: %s\ntests: %s"
-                         % (len(exps), len(tests), exps, tests))
+        self.assertEqual(len(exps), len(tests),
+                         (f'Total count of tests not '
+                          f'as expected ({len(exps)} != {len(tests)}) '
+                          f'\nexps: {exps}\ntests: {tests}'))
         try:
             for exp, tst in zip(exps, tests):
                 # Test class
@@ -143,8 +144,7 @@ class LoaderTest(unittest.TestCase):
                 self.assertEqual(os.path.abspath(tst[1]['name']),
                                  os.path.abspath(exp[1]))
         except AssertionError as details:
-            raise AssertionError("%s\nexps: %s\ntests:%s"
-                                 % (details, exps, tests))
+            raise AssertionError(f"{details}\nexps: {exps}\ntests:{tests}")
 
     def setUp(self):
         self.loader = loader.FileLoader(None, {})

--- a/selftests/unit/test_safeloader_imported.py
+++ b/selftests/unit/test_safeloader_imported.py
@@ -51,7 +51,8 @@ class SymbolAndModulePathCommon(unittest.TestCase):
         msg = f'Expected symbol name "{input_symbol}", found "{symbol}"'
         self.assertEqual(symbol, input_symbol, msg)
         module_path = ImportedSymbol.get_module_path_from_statement(statement)
-        msg = f'Expected module path "{input_module_path}", found "{module_path}"'
+        msg = (f'Expected module path "{input_module_path}", '
+               f'found "{module_path}"')
         self.assertEqual(module_path, input_module_path, msg)
         imported_symbol = ImportedSymbol(module_path, symbol)
         self.assertEqual(imported_symbol,

--- a/selftests/unit/test_safeloader_imported.py
+++ b/selftests/unit/test_safeloader_imported.py
@@ -48,12 +48,10 @@ class SymbolAndModulePathCommon(unittest.TestCase):
         """Checks all but to_str(), returning the imported_symbol instance."""
         statement = ast.parse(input_statement).body[0]
         symbol = ImportedSymbol.get_symbol_from_statement(statement)
-        msg = 'Expected symbol name "%s", found "%s"' % (input_symbol,
-                                                         symbol)
+        msg = f'Expected symbol name "{input_symbol}", found "{symbol}"'
         self.assertEqual(symbol, input_symbol, msg)
         module_path = ImportedSymbol.get_module_path_from_statement(statement)
-        msg = 'Expected module path "%s", found "%s"' % (input_module_path,
-                                                         module_path)
+        msg = f'Expected module path "{input_module_path}", found "{module_path}"'
         self.assertEqual(module_path, input_module_path, msg)
         imported_symbol = ImportedSymbol(module_path, symbol)
         self.assertEqual(imported_symbol,

--- a/selftests/unit/test_test_id.py
+++ b/selftests/unit/test_test_id.py
@@ -13,7 +13,7 @@ class Test(unittest.TestCase):
         self.assertEqual(test_id.uid, 1)
         self.assertEqual(test_id.str_uid, '1')
         self.assertEqual(test_id.str_filesystem,
-                         astring.string_to_safe_path('%s-%s' % (uid, name)))
+                         astring.string_to_safe_path(f'{uid}-{name}'))
         self.assertIs(test_id.variant, None)
         self.assertIs(test_id.str_variant, '')
 
@@ -24,7 +24,7 @@ class Test(unittest.TestCase):
         self.assertEqual(test_id.uid, 1)
         self.assertEqual(test_id.str_uid, '01')
         self.assertEqual(test_id.str_filesystem,
-                         astring.string_to_safe_path('%s-%s' % ('01', name)))
+                         astring.string_to_safe_path(f"{'01'}-{name}"))
         self.assertIs(test_id.variant, None)
         self.assertIs(test_id.str_variant, '')
 
@@ -37,8 +37,8 @@ class Test(unittest.TestCase):
         name = 'test'
         test_id = TestID(uid, name, no_digits=255)
         self.assertEqual(test_id.uid, 1)
-        self.assertEqual(test_id.str_uid, '%0255i' % uid)
-        self.assertEqual(test_id.str_filesystem, '%0255i' % uid)
+        self.assertEqual(test_id.str_uid, '%0255i' % uid)  # pylint: disable=C0209
+        self.assertEqual(test_id.str_filesystem, '%0255i' % uid)  # pylint: disable=C0209
         self.assertIs(test_id.variant, None)
         self.assertIs(test_id.str_variant, '')
 
@@ -61,7 +61,7 @@ class Test(unittest.TestCase):
         test_id = TestID(uid, name)
         self.assertEqual(test_id.uid, 1)
         # only 253 can fit for the test name
-        self.assertEqual(test_id.str_filesystem, '%s-%s' % (uid, name[:253]))
+        self.assertEqual(test_id.str_filesystem, f'{uid}-{name[:253]}')
         self.assertIs(test_id.variant, None)
         self.assertIs(test_id.str_variant, "")
 
@@ -77,9 +77,9 @@ class Test(unittest.TestCase):
         variant = {'variant_id': variant_id}
         test_id = TestID(uid, name, variant=variant)
         self.assertEqual(test_id.uid, 1)
-        self.assertEqual(test_id.str_filesystem, '%s_%s' % (uid, variant_id[:253]))
+        self.assertEqual(test_id.str_filesystem, f'{uid}_{variant_id[:253]}')
         self.assertIs(test_id.variant, variant_id)
-        self.assertEqual(test_id.str_variant, ";%s" % variant_id)
+        self.assertEqual(test_id.str_variant, f";{variant_id}")
 
 
 if __name__ == '__main__':

--- a/selftests/unit/utils/test_archive.py
+++ b/selftests/unit/utils/test_archive.py
@@ -148,8 +148,7 @@ class ArchiveTest(unittest.TestCase):
     def test_empty_tbz2(self):
         ret = archive.uncompress(os.path.join(BASEDIR, 'selftests', '.data',
                                               'empty.tar.bz2'), self.decompressdir)
-        self.assertEqual(ret, None, "Empty archive should return None (%s)"
-                         % ret)
+        self.assertEqual(ret, None, f"Empty archive should return None ({ret})")
 
     def test_is_gzip_file(self):
         gz_path = os.path.join(BASEDIR, 'selftests', '.data', 'avocado.gz')

--- a/selftests/unit/utils/test_archive.py
+++ b/selftests/unit/utils/test_archive.py
@@ -148,7 +148,8 @@ class ArchiveTest(unittest.TestCase):
     def test_empty_tbz2(self):
         ret = archive.uncompress(os.path.join(BASEDIR, 'selftests', '.data',
                                               'empty.tar.bz2'), self.decompressdir)
-        self.assertEqual(ret, None, f"Empty archive should return None ({ret})")
+        self.assertEqual(ret, None, (f"Empty archive should return None "
+                                     f"({ret})"))
 
     def test_is_gzip_file(self):
         gz_path = os.path.join(BASEDIR, 'selftests', '.data', 'avocado.gz')

--- a/selftests/unit/utils/test_astring.py
+++ b/selftests/unit/utils/test_astring.py
@@ -100,7 +100,7 @@ class AstringUtilsTest(unittest.TestCase):
         self.assertEqual(len(astring.string_to_safe_path(" " * 300)), 255)
         avocado = '\u0430\u0432\u043e\u043a\u0430\u0434\xff<>'
         self.assertEqual(astring.string_to_safe_path(avocado),
-                         "%s__" % avocado[:-2])
+                         f"{avocado[:-2]}__")
 
     def test_is_bytes(self):
         """

--- a/selftests/unit/utils/test_diff_validator.py
+++ b/selftests/unit/utils/test_diff_validator.py
@@ -47,7 +47,7 @@ class ChangeValidationTest(unittest.TestCase):
         changes = diff_validator.extract_changes(change.get_target_files())
         change_success = diff_validator.assert_change(changes, change.files_dict)
         change_dict = diff_validator.assert_change_dict(changes, change.files_dict)
-        self.assertTrue(change_success, "The change must be valid:\n%s" % diff_validator.create_diff_report(change_dict))
+        self.assertTrue(change_success, f"The change must be valid:\n{diff_validator.create_diff_report(change_dict)}")
 
     def test_change_wrong_no_change(self):
         files = self.files
@@ -64,7 +64,7 @@ class ChangeValidationTest(unittest.TestCase):
         changes = diff_validator.extract_changes(change.get_target_files())
         change_success = diff_validator.assert_change(changes, change.files_dict)
         change_dict = diff_validator.assert_change_dict(changes, change.files_dict)
-        self.assertFalse(change_success, "The change must not be valid:\n%s" % diff_validator.create_diff_report(change_dict))
+        self.assertFalse(change_success, f"The change must not be valid:\n{diff_validator.create_diff_report(change_dict)}")
 
     def test_change_wrong_add(self):
         files = self.files
@@ -83,7 +83,7 @@ class ChangeValidationTest(unittest.TestCase):
         changes = diff_validator.extract_changes(change.get_target_files())
         change_success = diff_validator.assert_change(changes, change.files_dict)
         change_dict = diff_validator.assert_change_dict(changes, change.files_dict)
-        self.assertFalse(change_success, "The change must not be valid:\n%s" % diff_validator.create_diff_report(change_dict))
+        self.assertFalse(change_success, f"The change must not be valid:\n{diff_validator.create_diff_report(change_dict)}")
 
     def test_change_unexpected_remove(self):
         files = self.files
@@ -101,7 +101,7 @@ class ChangeValidationTest(unittest.TestCase):
         changes = diff_validator.extract_changes(change.get_target_files())
         change_success = diff_validator.assert_change(changes, change.files_dict)
         change_dict = diff_validator.assert_change_dict(changes, change.files_dict)
-        self.assertFalse(change_success, "The change must not be valid:\n%s" % diff_validator.create_diff_report(change_dict))
+        self.assertFalse(change_success, f"The change must not be valid:\n{diff_validator.create_diff_report(change_dict)}")
 
     def test_change_unexpected_add(self):
         files = self.files
@@ -119,7 +119,7 @@ class ChangeValidationTest(unittest.TestCase):
         changes = diff_validator.extract_changes(change.get_target_files())
         change_success = diff_validator.assert_change(changes, change.files_dict)
         change_dict = diff_validator.assert_change_dict(changes, change.files_dict)
-        self.assertFalse(change_success, "The change must not be valid:\n%s" % diff_validator.create_diff_report(change_dict))
+        self.assertFalse(change_success, f"The change must not be valid:\n{diff_validator.create_diff_report(change_dict)}")
 
 
 if __name__ == '__main__':

--- a/selftests/unit/utils/test_kernel.py
+++ b/selftests/unit/utils/test_kernel.py
@@ -17,7 +17,7 @@ class TestKernelBuild(unittest.TestCase):
 
     def test_build_overrided_url(self):
         base_url = 'https://mykernel.com/'
-        expected_url = '{}linux-4.4.133.tar.gz'.format(base_url)
+        expected_url = f'{base_url}linux-4.4.133.tar.gz'
         self.assertEqual(self.kernel._build_kernel_url(base_url=base_url), expected_url)
 
     def tearDown(self):

--- a/selftests/unit/utils/test_network.py
+++ b/selftests/unit/utils/test_network.py
@@ -77,18 +77,14 @@ class FreePort(unittest.TestCase):
                         sock = socket.socket(family, protocol)
                         sock.bind((addr, port))
                         if ports.is_port_free(port, "localhost"):
-                            bad.append("%s, %s, %s: reports free"
-                                       % (family, protocol, addr))
+                            bad.append(f"{family}, {protocol}, {addr}: reports free")
                         else:
-                            good.append("%s, %s, %s" % (family, protocol,
-                                                        addr))
+                            good.append(f"{family}, {protocol}, {addr}")
                     except Exception as exc:
                         if getattr(exc, 'errno', None) in (-2, 2, 22, 94):
-                            skip.append("%s, %s, %s: Not supported: %s"
-                                        % (family, protocol, addr, exc))
+                            skip.append(f"{family}, {protocol}, {addr}: Not supported: {exc}")
                         else:
-                            bad.append("%s, %s, %s: Failed to bind: %s"
-                                       % (family, protocol, addr, exc))
+                            bad.append(f"{family}, {protocol}, {addr}: Failed to bind: {exc}")
                     finally:
                         if sock is not None:
                             sock.close()

--- a/selftests/unit/utils/test_network.py
+++ b/selftests/unit/utils/test_network.py
@@ -77,14 +77,17 @@ class FreePort(unittest.TestCase):
                         sock = socket.socket(family, protocol)
                         sock.bind((addr, port))
                         if ports.is_port_free(port, "localhost"):
-                            bad.append(f"{family}, {protocol}, {addr}: reports free")
+                            bad.append(f"{family}, {protocol}, {addr}: "
+                                       f"reports free")
                         else:
                             good.append(f"{family}, {protocol}, {addr}")
                     except Exception as exc:
                         if getattr(exc, 'errno', None) in (-2, 2, 22, 94):
-                            skip.append(f"{family}, {protocol}, {addr}: Not supported: {exc}")
+                            skip.append(f"{family}, {protocol}, {addr}: "
+                                        f"Not supported: {exc}")
                         else:
-                            bad.append(f"{family}, {protocol}, {addr}: Failed to bind: {exc}")
+                            bad.append(f"{family}, {protocol}, {addr}: "
+                                       f"Failed to bind: {exc}")
                     finally:
                         if sock is not None:
                             sock.close()

--- a/selftests/unit/utils/test_partition.py
+++ b/selftests/unit/utils/test_partition.py
@@ -84,9 +84,9 @@ class TestPartitionMkfsMount(Base):
         self.disk.mkfs()
         self.disk.mount()
         self.use_mnt_file = os.path.join(self.mountpoint, 'file')
-        self.use_mnt_cmd = ("%s -c 'import time; f = open(\"%s\", \"w\"); "
-                            "time.sleep(60)'" % (sys.executable,
-                                                 self.use_mnt_file))
+        self.use_mnt_cmd = (f"{sys.executable} -c 'import time; "
+                            f"f = open(\"{self.use_mnt_file}\", \"w\"); "
+                            f"time.sleep(60)'")
 
     def run_process_to_use_mnt(self):
         proc = process.SubProcess(self.use_mnt_cmd, sudo=True)

--- a/selftests/unit/utils/test_path.py
+++ b/selftests/unit/utils/test_path.py
@@ -11,7 +11,7 @@ class Path(unittest.TestCase):
                                  return_value=False) as mocked_exists:
             with self.assertRaises(OSError) as cm:
                 path.check_readable(os.devnull)
-            self.assertEqual('File "%s" does not exist' % os.devnull,
+            self.assertEqual(f'File "{os.devnull}" does not exist',
                              cm.exception.args[0])
             mocked_exists.assert_called_with(os.devnull)
 
@@ -20,7 +20,7 @@ class Path(unittest.TestCase):
                                  return_value=False) as mocked_access:
             with self.assertRaises(OSError) as cm:
                 path.check_readable(os.devnull)
-            self.assertEqual('File "%s" can not be read' % os.devnull,
+            self.assertEqual(f'File "{os.devnull}" can not be read',
                              cm.exception.args[0])
             mocked_access.assert_called_with(os.devnull, os.R_OK)
 

--- a/selftests/unit/utils/test_process.py
+++ b/selftests/unit/utils/test_process.py
@@ -276,7 +276,7 @@ class TestProcessRun(unittest.TestCase):
         encoded_text = b'Avok\xc3\xa1do'
         self.assertEqual(text.encode('utf-8'), encoded_text)
         self.assertEqual(encoded_text.decode('utf-8'), text)
-        cmd = "%s -n %s" % (ECHO_CMD, text)
+        cmd = f"{ECHO_CMD} -n {text}"
         result = process.run(cmd, encoding='utf-8')
         self.assertEqual(result.stdout, encoded_text)
         self.assertEqual(result.stdout_text, text)
@@ -287,15 +287,15 @@ class TestProcessRun(unittest.TestCase):
         :avocado: tags=parallel:1
         """
         with script.TemporaryScript("refuse_to_die", REFUSE_TO_DIE) as exe:
-            cmd = "%s '%s'" % (sys.executable, exe.path)
+            cmd = f"{sys.executable} '{exe.path}'"
             # Wait 1s to set the traps
             res = process.run(cmd, timeout=1, ignore_status=True)
-            self.assertLess(res.duration, 100, "Took longer than expected, "
-                            "process probably not interrupted by Avocado.\n%s"
-                            % res)
-            self.assertNotEqual(res.exit_status, 0, "Command finished without "
-                                "reporting failure but should be killed.\n%s"
-                                % res)
+            self.assertLess(res.duration, 100,
+                            (f"Took longer than expected, process probably "
+                             f"not interrupted by Avocado.\n{res}"))
+            self.assertNotEqual(res.exit_status, 0,
+                                (f"Command finished without reporting "
+                                 f"failure but should be killed.\n{res}"))
 
     @skipOnLevelsInferiorThan(2)
     def test_run_with_negative_timeout_ugly_cmd(self):
@@ -303,19 +303,19 @@ class TestProcessRun(unittest.TestCase):
         :avocado: tags=parallel:1
         """
         with script.TemporaryScript("refuse_to_die", REFUSE_TO_DIE) as exe:
-            cmd = "%s '%s'" % (sys.executable, exe.path)
+            cmd = f"{sys.executable} '{exe.path}'"
             # Wait 1s to set the traps
             proc = process.SubProcess(cmd)
             proc.start()
             time.sleep(1)
             proc.wait(-1)
             res = proc.result
-            self.assertLess(res.duration, 100, "Took longer than expected, "
-                            "process probably not interrupted by Avocado.\n%s"
-                            % res)
-            self.assertNotEqual(res.exit_status, 0, "Command finished without "
-                                "reporting failure but should be killed.\n%s"
-                                % res)
+            self.assertLess(res.duration, 100,
+                            (f"Took longer than expected, process probably "
+                             f"not interrupted by Avocado.\n{res}"))
+            self.assertNotEqual(res.exit_status, 0,
+                                (f"Command finished without reporting "
+                                 f"failure but should be killed.\n{res}"))
 
 
 class MiscProcessTests(unittest.TestCase):
@@ -385,7 +385,7 @@ class MiscProcessTests(unittest.TestCase):
         process_id = 123
         signal = 1
         owner_mocked.return_value = owner_id
-        expected_cmd = 'kill -%d %d' % (signal, process_id)
+        expected_cmd = f'kill -{signal} {process_id}'
 
         killed = process.safe_kill(process_id, signal)
         self.assertTrue(killed)
@@ -398,7 +398,7 @@ class MiscProcessTests(unittest.TestCase):
         process_id = 123
         signal = 1
         owner_mocked.return_value = owner_id
-        expected_cmd = 'kill -%d %d' % (signal, process_id)
+        expected_cmd = f'kill -{signal} {process_id}'
         run_mocked.side_effect = process.CmdError()
 
         killed = process.safe_kill(process_id, signal)
@@ -414,7 +414,7 @@ class MiscProcessTests(unittest.TestCase):
         returned_owner_id = process.get_owner_id(process_id)
 
         self.assertEqual(returned_owner_id, owner_user_id)
-        stat_mock.assert_called_with('/proc/%d/' % process_id)
+        stat_mock.assert_called_with(f'/proc/{process_id}/')
 
     @unittest.mock.patch('avocado.utils.process.os.stat')
     def test_process_get_owner_id_with_pid_not_found(self, stat_mock):
@@ -424,7 +424,7 @@ class MiscProcessTests(unittest.TestCase):
         returned_owner_id = process.get_owner_id(process_id)
 
         self.assertIsNone(returned_owner_id)
-        stat_mock.assert_called_with('/proc/%d/' % process_id)
+        stat_mock.assert_called_with(f'/proc/{process_id}/')
 
     @unittest.mock.patch('avocado.utils.process.time.sleep')
     @unittest.mock.patch('avocado.utils.process.safe_kill')

--- a/selftests/unit/utils/test_service.py
+++ b/selftests/unit/utils/test_service.py
@@ -68,7 +68,8 @@ class TestSystemd(unittest.TestCase):
                                        '--type=service', '--no-pager',
                                        '--full'])
             else:
-                self.assertEqual(ret, ["systemctl", cmd, f"{self.service_name}.service"])
+                self.assertEqual(ret, ["systemctl", cmd,
+                                       f"{self.service_name}.service"])
 
     def test_set_target(self):
         ret = getattr(

--- a/selftests/unit/utils/test_service.py
+++ b/selftests/unit/utils/test_service.py
@@ -68,8 +68,7 @@ class TestSystemd(unittest.TestCase):
                                        '--type=service', '--no-pager',
                                        '--full'])
             else:
-                self.assertEqual(ret, ["systemctl", cmd, "%s.service" %
-                                       self.service_name])
+                self.assertEqual(ret, ["systemctl", cmd, f"{self.service_name}.service"])
 
     def test_set_target(self):
         ret = getattr(
@@ -142,13 +141,13 @@ class TestSpecificServiceManager(unittest.TestCase):
     def test_start(self):
         srv = "lldpad"
         self.service_manager.start()
-        cmd = "service boot.%s start" % srv
+        cmd = f"service boot.{srv} start"
         self.assertEqual(self.run_mock.call_args[0][0], cmd)  # pylint: disable=E1136
 
     def test_stop_with_args(self):
         srv = "lldpad"
         self.service_manager.stop(ignore_status=True)
-        cmd = "service boot.%s stop" % srv
+        cmd = f"service boot.{srv} stop"
         self.assertEqual(self.run_mock.call_args[0][0], cmd)  # pylint: disable=E1136
 
     def test_list_is_not_present_in_SpecifcServiceManager(self):
@@ -181,7 +180,7 @@ class TestSystemdServiceManager(unittest.TestCase):
     def test_start(self):
         srv = "lldpad"
         self.service_manager.start(srv)
-        cmd = ("systemctl start %s.service" % srv)
+        cmd = f"systemctl start {srv}.service"
         self.assertEqual(self.run_mock.call_args[0][0], cmd)  # pylint: disable=E1136
 
     def test_list(self):
@@ -243,7 +242,7 @@ class TestSysVInitServiceManager(unittest.TestCase):
     def test_start(self):
         srv = "lldpad"
         self.service_manager.start(srv)
-        cmd = ("service %s start" % srv)
+        cmd = f"service {srv} start"
         self.assertEqual(self.run_mock.call_args[0][0], cmd)  # pylint: disable=E1136
 
     def test_list(self):

--- a/selftests/unit/utils/test_stacktrace.py
+++ b/selftests/unit/utils/test_stacktrace.py
@@ -67,7 +67,7 @@ class TestUnpickableObject(unittest.TestCase):
             act = stacktrace.str_unpickable_object(obj)
             for exp in exps:
                 if not re.search(exp, act):
-                    self.fail("%r no match in:\n%s" % (exp, act))
+                    self.fail(f"{exp!r} no match in:\n{act}")
         check(["this => .*Unpickable"], Unpickable())
         check([r"this\[0\]\[0\]\[foo\]\.troublemaker => .*Unpickable"],
               [[{"foo": InClassUnpickable()}]])

--- a/selftests/unit/utils/test_vmimage.py
+++ b/selftests/unit/utils/test_vmimage.py
@@ -34,15 +34,15 @@ class VMImageHtmlParser(unittest.TestCase):
 
     def test_handle_starttag_with_a_pattern_match(self):
         version = '12'
-        self.parser.feed('<html><head><title>Test</title></head>'
+        self.parser.feed('<html><head><title>Test</title></head>'  # pylint: disable=C0209
                          '<body><a href="%s/" /></body></html>' % version)
         self.assertTrue(self.parser.items)
         self.assertEqual(self.parser.items[0], version)
 
     def test_handle_starttag_with_a_pattern_match_multiple(self):
         versions = ['12', '13', '14']
-        links = ['<a href="%s/" />' % version for version in versions]
-        html = ('<html><head><title>Test</title></head>'
+        links = [f'<a href="{version}/" />' for version in versions]
+        html = ('<html><head><title>Test</title></head>'  # pylint: disable=C0209
                 '<body>%s</body></html>' % ''.join(links))
         self.parser.feed(html)
         self.assertTrue(self.parser.items)
@@ -54,7 +54,7 @@ class ImageProviderBase(unittest.TestCase):
     @staticmethod
     def get_html_with_versions(versions):
         html = '<html><head><title>Test</title></head><body>%s</body></html>'
-        return html % ''.join(['<a href="%s/" />' % v for v in versions])
+        return html % ''.join([f'<a href="{v}/" />' for v in versions])
 
     @unittest.mock.patch('avocado.utils.vmimage.urlopen')
     def test_get_version(self, urlopen_mock):
@@ -409,6 +409,7 @@ class OpenSUSEImageProvider(unittest.TestCase):
 
     @staticmethod
     def get_html_with_image_link(image_link):
+        # pylint: disable=C0209
         return '''
             <a href="openSUSE-Leap-15.0-OpenStack.x86_64-0.0.4-Buildlp150.12.30.packages"></a>
             <a href="%s"></a>
@@ -509,8 +510,7 @@ class FedoraImageProvider(unittest.TestCase):
         urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         provider = vmimage.FedoraImageProvider(expected_version, expected_build,
                                                expected_arch)
-        image = "Fedora-Cloud-Base-%s-%s.%s.qcow2" % (expected_version, expected_build,
-                                                      expected_arch)
+        image = f"Fedora-Cloud-Base-{expected_version}-{expected_build}.{expected_arch}.qcow2"
         parameters = provider.get_image_parameters(image)
         self.assertEqual(expected_version, parameters['version'])
         self.assertEqual(expected_build, parameters['build'])

--- a/selftests/utils.py
+++ b/selftests/utils.py
@@ -12,7 +12,7 @@ BASEDIR = os.path.abspath(os.path.join(BASEDIR, os.path.pardir))
 
 #: The name of the avocado test runner entry point
 AVOCADO = os.environ.get("UNITTEST_AVOCADO_CMD",
-                         "%s -m avocado" % sys.executable)
+                         f"{sys.executable} -m avocado")
 
 
 def python_module_available(module_name):
@@ -50,7 +50,7 @@ def temp_dir_prefix(klass):
     """
     Returns a standard name for the temp dir prefix used by the tests
     """
-    return 'avocado_%s_' % klass.__class__.__name__
+    return f'avocado_{klass.__class__.__name__}_'
 
 
 def get_temporary_config(klass):
@@ -133,8 +133,8 @@ def skipOnLevelsInferiorThan(level):
 
 def skipUnlessPathExists(path):
     return unittest.skipUnless(os.path.exists(path),
-                               ('File or directory at path "%s" used in test is'
-                                ' not available in the system' % path))
+                               (f'File or directory at path "{path}" '
+                               f'used in test is not available in the system'))
 
 
 class TestCaseTmpDir(unittest.TestCase):


### PR DESCRIPTION
Switching `selftests/ `  to see everything goes fine before I start looking into` avocado/`

References: https://github.com/avocado-framework/avocado/issues/5219

