### PR TITLE
Packit: build SRPMs in Copr

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,5 +1,6 @@
 specfile_path: python-avocado.spec
 downstream_package_name: python-avocado
+srpm_build_deps: []
 jobs:
   - job: copr_build
     trigger: pull_request


### PR DESCRIPTION
Add srpm_build_deps key to the Packit configuration to specify the needed dependencies for SRPM build
and indicate to build SRPM in Copr.

If you are interested in the transition to building SRPMs in Copr, you can read more about it [here](https://packit.dev/posts/copr-srpms/).