### PR TITLE
Fix is_port_free() on IPv6-less systems

### DIFF
--- a/avocado/utils/network/ports.py
+++ b/avocado/utils/network/ports.py
@@ -60,7 +60,7 @@ def is_port_free(port, address):
                     if localhost:
                         return False
                 sock.close()
-        return True
+                return True
     finally:
         if sock is not None:
             sock.close()


### PR DESCRIPTION
The is_port_free() function currently iterates through all combinations
of address families and protocols, and does not return immediately once
a free port has been found. So it only works on systems where a free
AF_INET6 + SOCK_DGRAM port is available, thus it's failing completely on
systems where IPv6 is not available.
Fix it by returning immediately once a free port has been found.