### PR TITLE
optional_plugins/resultsdb: update requires resultsdb

### DIFF
--- a/optional_plugins/resultsdb/setup.py
+++ b/optional_plugins/resultsdb/setup.py
@@ -34,7 +34,7 @@ setup(name='avocado-framework-plugin-resultsdb',
       packages=packages,
       include_package_data=True,
       install_requires=['avocado-framework==%s' % VERSION,
-                        'resultsdb-api==2.1.3'],
+                        'resultsdb-api==2.1.5'],
       entry_points={
           'avocado.plugins.cli': [
               'resultsdb = avocado_resultsdb.resultsdb:ResultsdbCLI',


### PR DESCRIPTION
Bump versioned requires on resultsdb directly to 2.1.5
Version 2.1.4 was broken and made some API changes that
are now reverted.

Fixes: https://github.com/avocado-framework/avocado/issues/5117

