### PR TITLE
–store-logging-stream for non-avocado loggers fix

### DIFF
--- a/avocado/core/runners/utils/messages.py
+++ b/avocado/core/runners/utils/messages.py
@@ -242,3 +242,8 @@ def start_logging(config, queue):
         output_logger = logging.getLogger(enabled_logger)
         output_logger.addHandler(store_stream_handler)
         output_logger.setLevel(log_level)
+
+        if not enabled_logger.startswith('avocado.'):
+            output_logger.addHandler(log_handler)
+            output_logger.propagate = False
+

--- a/avocado/core/runners/utils/messages.py
+++ b/avocado/core/runners/utils/messages.py
@@ -199,6 +199,11 @@ def start_logging(config, queue):
     :param queue: queue for the runner messages
     :type queue: multiprocessing.SimpleQueue
     """
+    def split_loggers_and_levels(enabled_loggers, default_level):
+        for logger_level_split in map(lambda x: x.split(':'), enabled_loggers):
+            logger_name, *level = logger_level_split
+            yield logger_name, level[0] if len(level) > 0 else default_level
+
     log_level = config.get('job.output.loglevel', logging.DEBUG)
     log_handler = RunnerLogHandler(queue, 'log')
     fmt = ('%(asctime)s %(name)s %(levelname)-5.5s| %(message)s')
@@ -227,23 +232,25 @@ def start_logging(config, queue):
     enabled_loggers = config.get('core.show')
     output_handler = RunnerLogHandler(queue, 'output')
     output_handler.setFormatter(logging.Formatter(fmt='%(name)s: %(message)s'))
-    for user_stream in [user_streams for user_streams in enabled_loggers
-                        if user_streams not in BUILTIN_STREAMS]:
+    user_streams = [user_streams for user_streams in enabled_loggers
+                    if user_streams not in BUILTIN_STREAMS]
+    for user_stream, level in split_loggers_and_levels(user_streams,
+                                                       log_level):
         custom_logger = logging.getLogger(user_stream)
         custom_logger.addHandler(output_handler)
-        custom_logger.setLevel(log_level)
+        custom_logger.setLevel(level)
 
     # store custom test loggers
     enabled_loggers = config.get('job.run.store_logging_stream')
-    for enabled_logger in enabled_loggers:
+    for enabled_logger, level in split_loggers_and_levels(enabled_loggers,
+                                                          log_level):
         store_stream_handler = RunnerLogHandler(queue, 'file',
                                                 {'path': enabled_logger})
         store_stream_handler.setFormatter(formatter)
         output_logger = logging.getLogger(enabled_logger)
         output_logger.addHandler(store_stream_handler)
-        output_logger.setLevel(log_level)
+        output_logger.setLevel(level)
 
         if not enabled_logger.startswith('avocado.'):
             output_logger.addHandler(log_handler)
             output_logger.propagate = False
-

--- a/docs/source/guides/writer/chapters/logging.rst
+++ b/docs/source/guides/writer/chapters/logging.rst
@@ -16,6 +16,10 @@ Currently Avocado will store any log information that is part of the
 'avocado.*' namespaces. You just need to choose a namespace when setting up
 your logger.
 
+.. note:: Sometimes you might want to store logs, which is not part of 
+   `avocado.*` name space. For that, you can use `--store-logging-stream`
+   option.
+
 The result is that, besides all the other log files commonly generated, as part
 of the `debug.log` file at the job results dir, you can get your logging
 information.  During the test run, one could watch the progress with::


### PR DESCRIPTION
This will enable non-avocado logging streams in `debug.log` by usage of
`–store-logging-stream` option.

Reference: #5290
Signed-off-by: Jan Richter <jarichte@redhat.com>