### PR TITLE
do not use unencrypted git protocol

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -15,7 +15,7 @@ jobs:
       image: fedora:34
     env:
       RUN_BEFORE: 'dnf install -y git ansible'
-      GIT_URL: 'git://github.com/${{github.repository}}'
+      GIT_URL: 'https://github.com/${{github.repository}}'
       INVENTORY: 'selftests/deployment/inventory'
       PLAYBOOK: 'selftests/deployment/deployment.yml'
     strategy:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -86,7 +86,7 @@ jobs:
     container:
       image: fedora:34
     env:
-      GIT_URL: 'git://github.com/avocado-framework/avocado'
+      GIT_URL: 'https://github.com/avocado-framework/avocado'
       INVENTORY: 'selftests/deployment/inventory'
       PLAYBOOK: 'selftests/deployment/deployment.yml'
     steps:


### PR DESCRIPTION
GitHub has stopped supporting unencrypted Git protocol.
More info at https://github.blog/2021-09-01-improving-git-protocol-security-github/

This was breaking the ansible deployment and pre-release github actions.