### PR TITLE
Legacy runner warning

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -548,6 +548,15 @@ class Job:
         if self.time_start == -1:
             self.time_start = time.monotonic()
         try:
+            for suite in self.test_suites:
+                if suite.config.get('run.test_runner') == 'runner':
+                    msg = ("The legacy runner was deprecated, and it is "
+                           "possible that it won't be working properly. The "
+                           "'--test-runner=runner' option will be removed "
+                           "soon.")
+                    LOG_UI.warning(msg)
+                    break
+
             self.result.tests_total = self.size
             pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
             output.log_plugin_failures(pre_post_dispatcher.load_failures)


### PR DESCRIPTION
Because we started removing legacy code and legacy tests. We can't
guarantee the stability of legacy runner on the master branch, but the
`--test-runner=runner`  option wasn't removed yet and the users still
can use legacy runner. Let's add a warning message that using legacy
runner on the newest avocado might be problematic and soon will be
removed.

Signed-off-by: Jan Richter <jarichte@redhat.com>