### PR TITLE
job config rewrites the suite config in job API

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -366,9 +366,9 @@ class TestSuite:
         """
         suite_config = config
         config = settings.as_dict()
-        config.update(suite_config)
         if job_config:
             config.update(job_config)
+        config.update(suite_config)
         runner = config.get('run.test_runner')
         if runner == 'nrunner':
             suite = cls._from_config_with_resolver(config, name)


### PR DESCRIPTION
When you have the same config option in suite config and the job config,
the job config will be used, but it should be the suite option because
it is lower level configuration. This will fix that.

Reference: #5305
Signed-off-by: Jan Richter <jarichte@redhat.com>