### PR TITLE
Revert "do not use unencrypted git protocol"

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -15,7 +15,7 @@ jobs:
       image: fedora:34
     env:
       RUN_BEFORE: 'dnf install -y git ansible'
-      GIT_URL: 'https://github.com/${{github.repository}}'
+      GIT_URL: 'git://github.com/${{github.repository}}'
       INVENTORY: 'selftests/deployment/inventory'
       PLAYBOOK: 'selftests/deployment/deployment.yml'
     strategy:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -86,7 +86,7 @@ jobs:
     container:
       image: fedora:34
     env:
-      GIT_URL: 'https://github.com/avocado-framework/avocado'
+      GIT_URL: 'git://github.com/avocado-framework/avocado'
       INVENTORY: 'selftests/deployment/inventory'
       PLAYBOOK: 'selftests/deployment/deployment.yml'
     steps:


### PR DESCRIPTION
When running the release workflow, the following error occurs:

   fatal: Authentication failed for
         'https://github.com/avocado-framework/avocado.git/'

For now, let's revert the change that most likely caused the failure.

This reverts commit 4b1b40933266bb72f2931c340d18c46baa3c8427.

Reference: https://github.com/avocado-framework/avocado/runs/5837720843
Signed-off-by: Cleber Rosa <crosa@redhat.com>