### PR TITLE
Runnable with default config 

### DIFF
--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -8,6 +8,7 @@ import sys
 import pkg_resources
 
 from avocado.core.nrunner.config import ConfigDecoder, ConfigEncoder
+from avocado.core.settings import settings
 
 #: All known runner commands, capable of being used by a
 #: SpawnMethod.STANDALONE_EXECUTABLE compatible spawners
@@ -63,7 +64,8 @@ class Runnable:
     def __init__(self, kind, uri, *args, config=None, **kwargs):
         self.kind = kind
         self.uri = uri
-        self.config = config or {}
+        self.config = settings.as_dict()
+        self.config.update(config or {})
         self.args = args
         self.tags = kwargs.pop('tags', None)
         self.dependencies = kwargs.pop('dependencies', None)

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -74,7 +74,7 @@ class RunnerInit(Init):
                     'is in another host, or different port')
         settings.register_option(section=section,
                                  key='status_server_uri',
-                                 default='127.0.0.1:8888',
+                                 default=None,
                                  metavar="HOST:PORT",
                                  help_msg=help_msg)
 

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -46,6 +46,18 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'time': ", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
+    def test_instrumented(self):
+        test_uri = os.path.join(BASEDIR, "examples", "tests",
+                                "passtest.py:PassTest.test")
+        res = process.run(f"{RUNNER} runnable-run -k avocado-instrumented -u "
+                          f"{test_uri}",
+                          ignore_status=True)
+        self.assertIn(b"'status': 'started'", res.stdout)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'result': 'pass'", res.stdout)
+        self.assertIn(b"'time': ", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
     def test_exec_test(self):
         # 'base64:LWM=' becomes '-c' and makes Python execute the
         # commands on the subsequent argument


### PR DESCRIPTION
Some runners (like instrumented) need config values for proper working.
When we are running tasks by `avocado run` or Job API the default
configuration is inserted to runners via runnable. The problem starts
when you run test runner with `runnable-run` command even a small test
as `avocado-runner runnable-run -k avocado-instrumented -u
examples/tests/passtest.py:PassTest.test` will fail because of missing
configuration. This commit solves this problem by adding default
configuration to the runnable.

Signed-off-by: Jan Richter <jarichte@redhat.com>