### PR TITLE
Remove the outdated documentation

### DIFF
--- a/docs/source/guides/user/chapters/logging.rst
+++ b/docs/source/guides/user/chapters/logging.rst
@@ -45,5 +45,3 @@ results directory.
 .. note:: You have to specify separated logging streams. You can't use the
  built-in streams in this function.
 
-.. note:: Currently the custom streams are stored only per job, not per each
- individual test.


### PR DESCRIPTION
After the 496a984e7791db91407992f06ad2012ba7f378ed the
`--store-logging-stream` option stores logging per test. This commit
updates documentation about such behavior.

Signed-off-by: Jan Richter <jarichte@redhat.com>