### PR TITLE
Option --show fix

### DIFF
--- a/avocado/core/runners/utils/messages.py
+++ b/avocado/core/runners/utils/messages.py
@@ -3,6 +3,7 @@ import sys
 import time
 
 from ... import output
+from ...streams import BUILTIN_STREAMS
 
 
 class GenericMessage:
@@ -122,6 +123,11 @@ class WhiteboardMessage(GenericRunningMessage):
     message_type = 'whiteboard'
 
 
+class OutputMessage(GenericRunningMessage):
+    """Creates output message with all necessary information."""
+    message_type = 'output'
+
+
 class FileMessage(GenericRunningMessage):
     """Creates file message with  all necessary information."""
     message_type = 'file'
@@ -135,6 +141,7 @@ _supported_types = {LogMessage.message_type: LogMessage,
                     StdoutMessage.message_type: StdoutMessage,
                     StderrMessage.message_type: StderrMessage,
                     WhiteboardMessage.message_type: WhiteboardMessage,
+                    OutputMessage.message_type: OutputMessage,
                     FileMessage.message_type: FileMessage}
 
 
@@ -215,3 +222,13 @@ def start_logging(config, queue):
 
     sys.stdout = StreamToQueue(queue, "stdout")
     sys.stderr = StreamToQueue(queue, "stderr")
+
+    # output custom test loggers
+    enabled_loggers = config.get('core.show') or set(["app"])
+    output_handler = RunnerLogHandler(queue, 'output')
+    output_handler.setFormatter(logging.Formatter(fmt='%(name)s: %(message)s'))
+    for user_stream in [user_streams for user_streams in enabled_loggers
+                        if user_streams not in BUILTIN_STREAMS]:
+        custom_logger = logging.getLogger(user_stream)
+        custom_logger.addHandler(output_handler)
+        custom_logger.setLevel(log_level)

--- a/docs/source/guides/writer/chapters/logging.rst
+++ b/docs/source/guides/writer/chapters/logging.rst
@@ -46,28 +46,28 @@ Using --show
 Alternatively, you can ask Avocado to show your logging stream, either
 exclusively or in addition to other builtin streams::
 
-    $ avocado --show app,avocado.test.progress run --test-runner='runner' -- logging_streams.py
+    $ avocado --show app,avocado.test.progress run -- examples/tests/logging_streams.py
 
 The outcome should be similar to::
 
     JOB ID     : af786f86db530bff26cd6a92c36e99bedcdca95b
     JOB LOG    : /home/user/avocado/job-results/job-2016-03-18T10.29-af786f8/job.log
-     (1/1) logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 0
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 1
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: preparing soil on row 2
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: letting soil rest before throwing seeds
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 0
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 1
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: throwing seeds on row 2
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: waiting for Avocados to grow
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 0
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 1
-    avocado.test.progress: 1-logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 2
-    PASS (7.01 s)
+    (1/1) examples/tests/logging_streams.py:Plant.test_plant_organic: STARTED
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: preparing soil on row 0
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: preparing soil on row 1
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: preparing soil on row 2
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: letting soil rest before throwing seeds
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: throwing seeds on row 0
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: throwing seeds on row 1
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: throwing seeds on row 2
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: waiting for Avocados to grow
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: harvesting organic avocados on row 0
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: harvesting organic avocados on row 1
+    1-examples/tests/logging_streams.py:Plant.test_plant_organic: avocado.test.progress: 1-Plant.test_plant_organic: harvesting organic avocados on row 2
+     (1/1) examples/tests/logging_streams.py:Plant.test_plant_organic: PASS (3.02 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     JOB TIME   : 7.11 s
     JOB HTML   : /home/user/avocado/job-results/job-2016-03-18T10.29-af786f8/html/results.html
-
 
 Using --store-logging-stream
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -455,6 +455,15 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
         self.assertEqual(result.stdout, b'')
 
+    def test_show_user_stream(self):
+        cmd_line = ('%s --show=app,avocado.test.progress run --disable-sysinfo '
+                    '--job-results-dir %s examples/tests/logging_streams.py' %
+                    (AVOCADO, self.tmpdir.name))
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
+        self.assertIn(b'Plant.test_plant_organic: preparing soil on row 0',
+                      result.stdout)
+
     def test_empty_args_list(self):
         cmd_line = AVOCADO
         result = process.run(cmd_line, ignore_status=True)


### PR DESCRIPTION
This adds the ability for the runners to print user-specific logging
streams to the console when the --show command is used.

It is backport of https://github.com/avocado-framework/avocado/commit/e2652b71668068838ea856bb7e16b262d34a511e and https://github.com/avocado-framework/avocado/commit/ddd143e2e928fa326dcd9ee65a942087207c5748.

Signed-off-by: Jan Richter [jarichte@redhat.com](mailto:jarichte@redhat.com)