### PR TITLE
Need Rework for CPU online function in utils/cpu.py file

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -262,7 +262,7 @@ def online(cpu):
     if _get_status(cpu) is False:
         with open(f"/sys/devices/system/cpu/cpu{cpu}/online", "wb") as fd:  # pylint: disable=W1514
             fd.write(b'1')
-        if _get_status(cpu):
+        if _get_status(cpu) is False:
             return 0
     return 1
 


### PR DESCRIPTION
In present implementention for CPU online and offline function in utils/cpu.py file below cases are present,
**online function implementation:**

**Case-1:** In case the CPU is already online, it will return 1 if it is.
**Case-2:** Upon checking CPU status if the CPU is offline, we write 1 into the "online" file. Then, after writing into the "online" file, we check if the CPU is online and if it is, we return 0.
Logically when the CPU is online it should return 1
-> Above two different cases we are returning 1 & 0 when our CPU is online

**offline function implementation:**

**Case-1:** Checking whether the CPU is online or not, if the CPU is offline, 0 is returned.
**Case-2:** If the CPU is online, it will write 0 into the "online" file, and check the CPU status - if it is still online, it will return 1; if not(CPU is offline), it will return 0.
Logically In offline case we are always returning 0.
-> Above two different cases we are returning 0 when CPU is offline and 1 if cpu is online

**Note:** _get_status function checks CPU online and offline status
return: 'bool' True if CPU online or False if not.

Signed-off-by: Samir Mulani <samir@linux.vnet.ibm.com>