### PR TITLE
Sysinfo: per-test not working consistenly

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -89,7 +89,8 @@ class ConfigOption:
     def __init__(self, namespace, help_msg, key_type=str, default=None,
                  parser=None, short_arg=None, long_arg=None,
                  positional_arg=False, choices=None, nargs=None,
-                 metavar=None, required=None, action=None, argparse_type=None):
+                 metavar=None, required=None, action=None, argparse_type=None,
+                 argparse_help_msg=None):
         self.namespace = namespace
         self.help_msg = help_msg
         self.key_type = key_type
@@ -105,6 +106,7 @@ class ConfigOption:
         self._action = action
         self._value = None
         self._argparse_type = argparse_type
+        self._argparse_help_msg = argparse_help_msg
 
         self._update_argparser()
 
@@ -161,6 +163,16 @@ class ConfigOption:
         self._argparse_type = value
 
     @property
+    def argparse_help_msg(self):
+        if self._argparse_help_msg is not None:
+            return self._argparse_help_msg
+        return self.help_msg
+
+    @argparse_help_msg.setter
+    def argparse_help_msg(self, value):
+        self._argparse_help_msg = value
+
+    @property
     def metavar(self):
         if self.positional_arg:
             if self._metavar is None:
@@ -169,7 +181,7 @@ class ConfigOption:
 
     @property
     def arg_parse_args(self):
-        args = {'help': self.help_msg,
+        args = {'help': self.argparse_help_msg,
                 'default': None}
 
         if self.nargs:
@@ -216,7 +228,7 @@ class ConfigOption:
     def add_argparser(self, parser, long_arg, short_arg=None,
                       positional_arg=False, choices=None, nargs=None,
                       metavar=None, required=None, action=None,
-                      argparse_type=None):
+                      argparse_type=None, argparse_help_msg=None):
         """Add an command-line argparser to this option."""
 
         self.parser = parser
@@ -229,6 +241,7 @@ class ConfigOption:
         self.required = required
         self._action = action
         self._argparse_type = argparse_type
+        self._argparse_help_msg = argparse_help_msg
 
         self._update_argparser()
 
@@ -343,7 +356,8 @@ class Settings:
                                 short_arg=None, positional_arg=False,
                                 choices=None, nargs=None, metavar=None,
                                 required=None, action=None,
-                                allow_multiple=False, argparse_type=None):
+                                allow_multiple=False, argparse_type=None,
+                                help_msg=None):
         """Add a command-line argument parser to an existing option.
 
         This method is useful to add a parser when the option is registered
@@ -407,6 +421,12 @@ class Settings:
             will, for instance, split a comma separated list may be used,
             resulting in command line users being able to provide convenient
             input.
+
+        help_msg : str
+            A help message, different from the original ConfigOption
+            help message, to be shown on the command line.  To be used when
+            the command line usage and the original help message do not make
+            sense together.
         """
         if not any([long_arg, short_arg, positional_arg]):
             raise SettingsError("To add an argument parser to an option, it "
@@ -426,7 +446,7 @@ class Settings:
 
         option.add_argparser(parser, long_arg, short_arg, positional_arg,
                              choices, nargs, metavar, required, action,
-                             argparse_type)
+                             argparse_type, help_msg)
 
     def as_dict(self, regex=None):
         """Return an dictionary with the current active settings.

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -34,7 +34,7 @@ import unittest
 import warnings
 from difflib import unified_diff
 
-from avocado.core import exceptions, output, parameters, sysinfo, tapparser
+from avocado.core import exceptions, output, parameters, tapparser
 from avocado.core.decorators import skip
 from avocado.core.output import LOG_JOB
 from avocado.core.settings import settings
@@ -298,13 +298,6 @@ class Test(unittest.TestCase, TestData):
         self._logging_handlers = {}
 
         self.__outputdir = utils_path.init_dir(self.logdir, 'data')
-
-        self.__sysinfo_enabled = self._config.get('sysinfo.collect.per_test',
-                                                  False)
-
-        if self.__sysinfo_enabled:
-            self.__sysinfodir = utils_path.init_dir(self.logdir, 'sysinfo')
-            self.__sysinfo_logger = sysinfo.SysInfo(basedir=self.__sysinfodir)
 
         self.__log = LOG_JOB
         original_log_warn = self.log.warning
@@ -714,8 +707,6 @@ class Test(unittest.TestCase, TestData):
         testMethod = getattr(self, self._testMethodName)
         if self._config.get("run.test_runner") != 'nrunner':
             self._start_logging()
-        if self.__sysinfo_enabled:
-            self.__sysinfo_logger.start()
         skip_test_condition = getattr(testMethod, '__skip_test_condition__', False)
         skip_test_condition_negate = getattr(testMethod, '__skip_test_condition_negate__', False)
         if skip_test_condition:
@@ -802,8 +793,6 @@ class Test(unittest.TestCase, TestData):
         os.environ['AVOCADO_TEST_LOGDIR'] = self.logdir
         os.environ['AVOCADO_TEST_LOGFILE'] = self.logfile
         os.environ['AVOCADO_TEST_OUTPUTDIR'] = self.outputdir
-        if self.__sysinfo_enabled:
-            os.environ['AVOCADO_TEST_SYSINFODIR'] = self.__sysinfodir
 
     def _catch_test_status(self, method):
         """Wrapper around test methods for catching and logging failures."""
@@ -848,8 +837,6 @@ class Test(unittest.TestCase, TestData):
         self._catch_test_status(self._tearDown)
         whiteboard_file = os.path.join(self.logdir, 'whiteboard')
         genio.write_file(whiteboard_file, self.whiteboard)
-        if self.__sysinfo_enabled:
-            self.__sysinfo_logger.end(self.__status)
         self.__phase = 'FINISHED'
         self._tag_end()
         self._report()

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -185,10 +185,13 @@ class Run(CLICmd):
                                  parser=parser,
                                  long_arg='--ignore-missing-references')
 
+        help_msg = ('Disable sysinfo collection (like hardware details, '
+                    'profiles, etc).')
         settings.add_argparser_to_option(namespace='sysinfo.collect.enabled',
                                          parser=parser,
                                          action='store_false',
-                                         long_arg='--disable-sysinfo')
+                                         long_arg='--disable-sysinfo',
+                                         help_msg=help_msg)
 
         settings.add_argparser_to_option('run.execution_order',
                                          parser=parser,

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -29,8 +29,8 @@ class SysinfoInit(Init):
     description = 'Initializes sysinfo settings'
 
     def initialize(self):
-        help_msg = ('Enable or disable sysinfo information. Like hardware '
-                    'details, profiles, etc.')
+        help_msg = ('Enable or disable sysinfo collection (like hardware '
+                    'details, profiles, etc.)')
         settings.register_option(section='sysinfo.collect',
                                  key='enabled',
                                  default=True,

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -37,13 +37,6 @@ class SysinfoInit(Init):
                                  key_type=bool,
                                  help_msg=help_msg)
 
-        help_msg = 'Enable sysinfo collection per-test'
-        settings.register_option(section='sysinfo.collect',
-                                 key='per_test',
-                                 default=False,
-                                 key_type=bool,
-                                 help_msg=help_msg)
-
         help_msg = ('Overall timeout to collect commands, when <=0'
                     'no timeout is enforced')
         settings.register_option(section='sysinfo.collect',


### PR DESCRIPTION
I came across some current inconsistencies with sysinfo that I believe can confuse users (and also blocked some work of mine).

This is a proposal to remove the per-test feature for now, given it's not working consistently, until the alternative implementation is brought back.

This is part of https://github.com/avocado-framework/avocado/issues/3877.