### PR TITLE
Travis CI: address setuptools >= 62.1.0 behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 
 install:
     - pip install -r requirements-dev.txt
-    - python3 setup.py develop --user
+    - python3 setup.py develop
 
 script:
     - python3 selftests/check.py --skip static-checks


### PR DESCRIPTION
On the most recent setuptools release, the behavior changed and the
"user's local Python library dir" does not support ".pth" files.

This means that, if using "--user", "setup.py develop" have avocado
in the PYTHONPATH.  The message produced on Travis is:

   Checking .pth file support in /home/travis/.local/lib/python3.9/site-packages
   /home/travis/virtualenv/python3.9.12/bin/python3 -E -c pass
   TEST FAILED: /home/travis/.local/lib/python3.9/site-packages does NOT support .pth files
   bad install directory or PYTHONPATH

Given this is a CI environment, we can simply instruct develop to
install (more of a link, really) in a non-user location.

Signed-off-by: Cleber Rosa <crosa@redhat.com>