### PR TITLE
network/interface.py: flush_ipaddr function to flush ip addr on inter…

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -471,6 +471,22 @@ class NetworkInterface:
             msg = f'Failed to remove ipaddr. {ex}'
             raise NWException(msg)
 
+    def flush_ipaddr(self):
+        """Flush all the IP address for this interface.
+
+        This method will try to flush the ip address from this interface
+        and if fails it will raise a NWException. Be careful, you can
+        lost connection.
+
+        You must have sudo permissions to run this method on a host.
+        """
+        cmd = f'ip addr flush dev {self.name}'
+        try:
+            run_command(cmd, self.host, sudo=True)
+        except Exception as ex:
+            msg = f'Failed to flush ipaddr. {ex}'
+            raise NWException(msg)
+
     def remove_link(self):
         """Deletes virtual interface link.
 


### PR DESCRIPTION
flush_ipaddr function is required to flush all the existing ip address
for the interface under test, before configuring a new ip with out
bring down/up the interface

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>