### PR TITLE
Drop SIMPLE test and other legacy code [v2]

### DIFF
--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -554,8 +554,8 @@ class FileLoader(SimpleFileLoader):
     """
 
     name = 'file'
-    NOT_TEST_STR = ("Not an INSTRUMENTED (avocado.Test based), PyUNITTEST ("
-                    "unittest.TestCase based) or SIMPLE (executable) test")
+    NOT_TEST_STR = ("Not an INSTRUMENTED (avocado.Test based) or SIMPLE "
+                    "(executable) test")
 
     @staticmethod
     def get_type_label_mapping():
@@ -581,25 +581,6 @@ class FileLoader(SimpleFileLoader):
             return isinstance(tst, str)
         else:
             return not isinstance(tst, str) and issubclass(tst, test_class)
-
-    @staticmethod
-    def _find_python_unittests(test_path, disabled, subtests_filter):
-        result = []
-        class_methods = safeloader.find_python_unittests(test_path)
-        for klass, methods in class_methods.items():
-            if klass in disabled:
-                continue
-            if test_path.endswith(".py"):
-                test_path = test_path[:-3]
-            test_module_name = os.path.relpath(test_path)
-            test_module_name = test_module_name.replace(os.path.sep, ".")
-            candidates = [(f"{test_module_name}.{klass}.{method}",
-                           tags) for (method, tags, _) in methods]
-            if subtests_filter:
-                result += [_ for _ in candidates if subtests_filter.search(_)]
-            else:
-                result += candidates
-        return result
 
     def _make_python_file_tests(self, test_path, make_broken,
                                 subtests_filter, test_name=None):

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -376,14 +376,12 @@ class SimpleFileLoader(TestLoader):
     @staticmethod
     def get_type_label_mapping():
         return {NotATest: 'NOT_A_TEST',
-                MissingTest: 'MISSING',
                 BrokenSymlink: 'BROKEN_SYMLINK',
                 AccessDeniedPath: 'ACCESS_DENIED'}
 
     @staticmethod
     def get_decorator_mapping():
         return {NotATest: output.TERM_SUPPORT.warn_header_str,
-                MissingTest: output.TERM_SUPPORT.fail_header_str,
                 BrokenSymlink: output.TERM_SUPPORT.fail_header_str,
                 AccessDeniedPath: output.TERM_SUPPORT.fail_header_str}
 

--- a/avocado/core/loader.py
+++ b/avocado/core/loader.py
@@ -44,6 +44,20 @@ class MissingTest:
     """
 
 
+class BrokenSymlink:
+    """ Dummy object to represent reference pointing to a BrokenSymlink path """
+
+
+class AccessDeniedPath:
+    """ Dummy object to represent reference pointing to a inaccessible path """
+
+
+class NotATest:
+    """
+    Class representing something that is not a test
+    """
+
+
 class LoaderError(Exception):
     """ Loader exception """
 
@@ -328,14 +342,6 @@ class TestLoader:
         raise NotImplementedError
 
 
-class BrokenSymlink:
-    """ Dummy object to represent reference pointing to a BrokenSymlink path """
-
-
-class AccessDeniedPath:
-    """ Dummy object to represent reference pointing to a inaccessible path """
-
-
 def add_loader_options(parser, section='run'):
     arggrp = parser.add_argument_group('loader options')
     help_msg = ("Overrides the priority of the test loaders. You can specify "
@@ -351,12 +357,6 @@ def add_loader_options(parser, section='run'):
                              parser=arggrp,
                              long_arg='--loaders',
                              metavar='LOADER_NAME_OR_TEST_TYPE')
-
-
-class NotATest:
-    """
-    Class representing something that is not a test
-    """
 
 
 class SimpleFileLoader(TestLoader):

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -1,6 +1,7 @@
 import logging
 
 from avocado.core.status.utils import json_loads
+from avocado.core.teststatus import STATUSES
 
 LOG = logging.getLogger(__name__)
 
@@ -37,6 +38,16 @@ class StatusRepo:
 
     def _handle_task_finished(self, message):
         task_id = message['id']
+
+        result = message.get('result')
+        if result is not None and result.upper() not in STATUSES:
+            overriden = 'error'
+            message['result'] = overriden
+            message['fail_reason'] = (f'Runner error occurred: Test reports '
+                                      f'unsupported status "{result}"')
+            LOG.error('Task "%s" finished message with unsupported status '
+                      '"%s", changing to "%s"', task_id, result, overriden)
+
         self._set_by_result(message)
         self._set_task_data(message)
         LOG.debug('Task "%s" finished message: "%s"', task_id, message)

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -24,7 +24,6 @@ import inspect
 import logging
 import os
 import pipes
-import re
 import shutil
 import sys
 import tempfile
@@ -1015,38 +1014,6 @@ class SimpleTest(Test):
             self._log_detailed_cmd_info(details.result)
             test_failure = self._cmd_error_to_test_failure(details)
             raise exceptions.TestFail(test_failure)
-
-        warn_regex = self._config.get('simpletests.status.warn_regex')
-        warn_location = self._config.get('simpletests.status.warn_location')
-        skip_regex = self._config.get('simpletests.status.skip_regex')
-        skip_location = self._config.get('simpletests.status.skip_location')
-
-        # Keeping compatibility with 'avocado_warn' libexec
-        for regex in [warn_regex, r'^\d\d:\d\d:\d\d WARN \|']:
-            warn_msg = ("Test passed but there were warnings on {st} during "
-                        "execution. Check the log for details.")
-            if regex is not None:
-                re_warn = re.compile(regex, re.MULTILINE)
-                if warn_location in ['all', 'stdout']:
-                    if re_warn.search(result.stdout_text):
-                        raise exceptions.TestWarn(warn_msg.format(st='stdout'))
-
-                if warn_location in ['all', 'stderr']:
-                    if re_warn.search(result.stderr_text):
-                        raise exceptions.TestWarn(warn_msg.format(st='stderr'))
-
-        if skip_regex is not None:
-            re_skip = re.compile(skip_regex, re.MULTILINE)
-            skip_msg = ("Test passed but {st} indicates test was skipped. "
-                        "Check the log for details.")
-
-            if skip_location in ['all', 'stdout']:
-                if re_skip.search(result.stdout_text):
-                    raise exceptions.TestSkipError(skip_msg.format(st='stdout'))
-
-            if skip_location in ['all', 'stderr']:
-                if re_skip.search(result.stderr_text):
-                    raise exceptions.TestSkipError(skip_msg.format(st='stderr'))
 
     def test(self):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -29,7 +29,6 @@ import tempfile
 import time
 import unittest
 import warnings
-from difflib import unified_diff
 
 from avocado.core import exceptions, parameters
 from avocado.core.output import LOG_JOB
@@ -566,62 +565,6 @@ class Test(unittest.TestCase, TestData):
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
         self._logging_handlers[logger.name] = file_handler
-
-    def _check_reference(self, produced_file_path, reference_file_name,
-                         diff_file_name, child_log_name, name='Content'):
-        '''
-        Compares the file produced by the test with the reference file
-
-        :param produced_file_path: the location of the file that was produced
-                                   by this test execution
-        :type produced_file_path: str
-        :param reference_file_name: the name of the file that will compared
-                                    with the content produced by this test
-        :type reference_file_name: str
-        :param diff_file_name: in case of differences between the produced
-                               and reference file, a file with this name will
-                               be saved to the test results directory, with
-                               the differences in unified diff format
-        :type diff_file_name: str
-        :param child_log_name: the name of a logger, child of :data:`LOG_JOB`,
-                               to be used when logging the content differences
-        :type child_log_name: str
-        :param name: optional parameter for a descriptive name of the type of
-                     content being checked here
-        :type name: str
-        :returns: True if the check was performed (there was a reference file) and
-                  was successful, and False otherwise (there was no such reference
-                  file and thus no check was performed).
-        :raises: :class:`exceptions.TestFail` when the check is performed and fails
-        '''
-        reference_path = self.get_data(reference_file_name)
-        if reference_path is not None:
-            expected = genio.read_file(reference_path)
-            actual = genio.read_file(produced_file_path)
-            diff_path = os.path.join(self.logdir, diff_file_name)
-
-            fmt = '%(message)s'
-            formatter = logging.Formatter(fmt=fmt)
-            log_diff = LOG_JOB.getChild(child_log_name)
-            self._register_log_file_handler(log_diff,
-                                            formatter,
-                                            diff_path)
-
-            diff = unified_diff(expected.splitlines(), actual.splitlines(),
-                                fromfile=reference_path,
-                                tofile=produced_file_path)
-            diff_content = []
-            for diff_line in diff:
-                diff_content.append(diff_line.rstrip('\n'))
-
-            if diff_content:
-                self.log.debug('%s Diff:', name)
-                for line in diff_content:
-                    log_diff.debug(line)
-                self.fail(f'Actual test {name} differs from expected one')
-            else:
-                return True
-        return False
 
     def _run_test(self):
         """

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -21,7 +21,6 @@ framework tests.
 import asyncio
 import functools
 import inspect
-import logging
 import os
 import shutil
 import sys
@@ -52,31 +51,6 @@ TEST_STATE_ATTRIBUTES = ('name', 'logdir', 'logfile',
                          'actual_time_start', 'actual_time_end',
                          'fail_reason', 'fail_class', 'traceback',
                          'tags', 'timeout', 'whiteboard', 'phase')
-
-
-class RawFileHandler(logging.FileHandler):
-
-    """
-    File Handler that doesn't include arbitrary characters to the
-    logged stream but still respects the formatter.
-    """
-
-    def emit(self, record):
-        """
-        Modifying the original emit() to avoid including a new line
-        in streams that should be logged in its purest form, like in
-        stdout/stderr recordings.
-        """
-        if self.stream is None:
-            self.stream = self._open()
-        try:
-            msg = self.format(record)
-            stream = self.stream
-            stream.write(astring.to_text(msg, self.encoding,
-                                         'xmlcharrefreplace'))
-            self.flush()
-        except Exception:  # pylint: disable=W0703
-            self.handleError(record)
 
 
 class TestData:
@@ -553,18 +527,6 @@ class Test(unittest.TestCase, TestData):
                            for path, key, value
                            in self.__params.iteritems()]
         return state
-
-    def _register_log_file_handler(self, logger, formatter, filename,
-                                   log_level=logging.DEBUG, raw=False):
-        if raw:
-            file_handler = RawFileHandler(filename=filename,
-                                          encoding=astring.ENCODING)
-        else:
-            file_handler = logging.FileHandler(filename=filename)
-        file_handler.setLevel(log_level)
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
-        self._logging_handlers[logger.name] = file_handler
 
     def _run_test(self):
         """

--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -102,6 +102,14 @@ class ExecTestRunner(BaseRunner):
                 self.runnable.output_dir
         return avocado_test_env_variables
 
+    @staticmethod
+    def _is_uri_a_file_on_cwd(uri):
+        if (uri is not None and
+            os.path.basename(uri) == uri and
+                os.access(uri, os.R_OK | os.X_OK)):
+            return True
+        return False
+
     def run(self, runnable):
         # pylint: disable=W0201
         self.runnable = runnable
@@ -126,6 +134,11 @@ class ExecTestRunner(BaseRunner):
 
         if env and 'PATH' not in env:
             env['PATH'] = os.environ.get('PATH')
+
+        # Support for running executable tests in the current working directory
+        if self._is_uri_a_file_on_cwd(self.runnable.uri):
+            env['PATH'] += f':{os.getcwd()}'
+
         try:
             process = subprocess.Popen(
                 [self.runnable.uri] + list(self.runnable.args),

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -201,11 +201,7 @@ number of arguments that will be given to that class initialization.
 
 So the primary "code payload" for every Avocado test in the legacy
 architecture will always be Python code that inherits from
-:class:`avocado.core.test.Test`.  Even when the user wants to run a
-standalone executable (a ``SIMPLE`` test in the legacy architecture
-terminology), that still means loading and instantiating (effectively
-executing) the Python class' :class:`avocado.core.test.SimpleTest`
-code.
+:class:`avocado.core.test.Test`.
 
 Once all the test factories are found by :mod:`avocado.core.loader`,
 as described in the previous section, the legacy architecture runs

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1364,44 +1364,6 @@ by ``avocado exec-path`` (if any).  Also, the example test
 .. tip:: These extensions may be available as a separate package.  For
          RPM packages, look for the ``bash`` sub-package.
 
-.. _test_type_simple_status:
-
-SIMPLE Tests Status
--------------------
-
-With SIMPLE tests, Avocado checks the exit code of the test to determine
-whether the test PASSed or FAILed.
-
-If your test exits with exit code 0 but you still want to set a different test
-status in some conditions, Avocado can search a given regular expression in
-the test outputs and, based on that, set the status to WARN or SKIP.
-
-To use that feature, you have to set the proper keys in the configuration
-file. For instance, to set the test status to SKIP when the test outputs
-a line like this: '11:08:24 Test Skipped'::
-
-    [simpletests.output]
-    skip_regex = ^\d\d:\d\d:\d\d Test Skipped$
-
-That configuration will make Avocado to search the
-`Python Regular Expression <http://docs.python.org/2.7/howto/regex.html>`__
-on  both stdout and stderr. If you want to limit the search for only one of
-them, there's another key for that configuration, resulting in::
-
-    [simpletests.output]
-    skip_regex = ^\d\d:\d\d:\d\d Test Skipped$
-    skip_location = stderr
-
-The equivalent settings can be present for the WARN status. For instance,
-if you want to set the test status to WARN when the test outputs a line
-starting with string ``WARNING:``, the configuration file will look like this::
-
-    [simpletests.output]
-    skip_regex = ^\d\d:\d\d:\d\d Test Skipped$
-    skip_location = stderr
-    warn_regex = ^WARNING:
-    warn_location = all
-
 Job Cleanup
 -----------
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -250,7 +250,7 @@ class RunnerOperationTest(TestCaseTmpDir):
                                     "avocado_unsupported_status") as tst:
             res = process.run((f"{AVOCADO} run --disable-sysinfo "
                                f"--job-results-dir {self.tmpdir.name} {tst} "
-                               f"--test-runner=runner --json -"),
+                               f"--json -"),
                               ignore_status=True)
             self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
             results = json.loads(res.stdout_text)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -541,14 +541,13 @@ class RunnerOperationTest(TestCaseTmpDir):
     def test_invalid_python(self):
         test = script.make_script(os.path.join(self.tmpdir.name, 'test.py'),
                                   INVALID_PYTHON_TEST)
-        cmd_line = (f'{AVOCADO} --show test run --disable-sysinfo '
-                    f'--job-results-dir {self.tmpdir.name} '
-                    f'--test-runner=runner {test}')
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} {test}')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL
         self.assertEqual(result.exit_status, expected_rc,
                          f"Avocado did not return rc {expected_rc}:\n{result}")
-        self.assertIn(f'1-{test}:MyTest.test_my_name -> TestError',
+        self.assertIn(f'{test}:MyTest.test_my_name:  ERROR',
                       result.stdout_text)
 
     @unittest.skipIf(not READ_BINARY, "read binary not available.")

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -59,17 +59,6 @@ class MyTest(Test):
 '''
 
 
-REPORTS_STATUS_AND_HANG = '''
-from avocado import Test
-import time
-
-class MyTest(Test):
-    def test(self):
-         self.runner_queue.put({"running": False})
-         time.sleep(70)
-'''
-
-
 DIE_WITHOUT_REPORTING_STATUS = '''
 from avocado import Test
 import os
@@ -259,36 +248,6 @@ class RunnerOperationTest(TestCaseTmpDir):
                               f"{'ERROR'}\n{res}"))
             self.assertIn("Runner error occurred: Test reports unsupported",
                           results["tests"][0]["fail_reason"])
-
-    @skipOnLevelsInferiorThan(1)
-    def test_hanged_test_with_status(self):
-        """Check that avocado handles hanged tests properly.
-
-        :avocado: tags=parallel:1
-        """
-        with script.TemporaryScript("report_status_and_hang.py",
-                                    REPORTS_STATUS_AND_HANG,
-                                    "hanged_test_with_status") as tst:
-            res = process.run((f"{AVOCADO} run --disable-sysinfo "
-                               f"--job-results-dir {self.tmpdir.name} {tst} "
-                               f"--test-runner=runner --json - "
-                               f"--job-timeout 1"),
-                              ignore_status=True)
-            self.assertEqual(res.exit_status, exit_codes.AVOCADO_TESTS_FAIL)
-            results = json.loads(res.stdout_text)
-            self.assertEqual(results["tests"][0]["status"], "ERROR",
-                             (f"{results['tests'][0]['status']} != "
-                              f"{'ERROR'}\n{res}"))
-            self.assertIn("Test reported status but did not finish",
-                          results["tests"][0]["fail_reason"])
-            # Currently it should finish up to 1s after the job-timeout
-            # but the prep and postprocess could take a bit longer on
-            # some environments, so let's just check it does not take
-            # > 60s, which is the deadline for force-finishing the test.
-            self.assertLess(res.duration, 55,
-                            (f"Test execution took too long, "
-                             f"which is likely because the hanged test was "
-                             f"not interrupted. Results:\n{res}"))
 
     def test_no_status_reported(self):
         with script.TemporaryScript("die_without_reporting_status.py",

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -479,11 +479,12 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_not_found(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
-                    f'{self.tmpdir.name} --test-runner=runner sbrubles')
+                    f'{self.tmpdir.name} sbrubles')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
-        self.assertIn(b'Unable to resolve reference', result.stderr)
-        self.assertNotIn(b'Unable to resolve reference', result.stdout)
+        self.assertEqual(result.stdout, b'')
+        self.assertEqual(result.stderr,
+                         b'Could not resolve references: sbrubles\n')
 
     def test_invalid_unique_id(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo '

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -469,11 +469,13 @@ class RunnerOperationTest(TestCaseTmpDir):
 
     def test_empty_test_list(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '
-                    f'{self.tmpdir.name}--test-runner=runner')
+                    f'{self.tmpdir.name}')
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
-        self.assertIn(b'No test references provided nor any other arguments '
-                      b'resolved into tests', result.stderr)
+        self.assertEqual(result.stderr,
+                         (b'Test Suite could not be created. No test references'
+                          b' provided nor any other arguments resolved into '
+                          b'tests\n'))
 
     def test_not_found(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo --job-results-dir '

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -750,8 +750,7 @@ class RunnerExecTest(TestCaseTmpDir):
         os.chdir(test_base_dir)
         test_file_name = os.path.basename(self.pass_script.path)
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo '
-                    f'--test-runner=runner "{test_file_name}"')
+                    f'--disable-sysinfo  "{test_file_name}"')
         result = process.run(cmd_line, ignore_status=True)
         expected_rc = exit_codes.AVOCADO_ALL_OK
         self.assertEqual(result.exit_status, expected_rc,

--- a/selftests/functional/test_job_timeout.py
+++ b/selftests/functional/test_job_timeout.py
@@ -101,7 +101,7 @@ class JobTimeOutTest(TestCaseTmpDir):
     def test_sleep_longer_timeout(self):
         """:avocado: tags=parallel:1"""
         cmd_line = (f'{AVOCADO} run --job-results-dir {self.tmpdir.name} '
-                    f'--disable-sysinfo --test-runner=runner --xunit - '
+                    f'--disable-sysinfo --xunit - '
                     f'--job-timeout=5 {self.script.path} '
                     f'examples/tests/passtest.py')
         self.run_and_check(cmd_line, 0, 2, 0, 0, 0)

--- a/selftests/unit/test_loader.py
+++ b/selftests/unit/test_loader.py
@@ -281,8 +281,11 @@ class LoaderTest(unittest.TestCase):
         with script.TemporaryScript('test.py', AVOCADO_TEST_OK) as avocado_test:
             with unittest.mock.patch('avocado.core.loader.safeloader.find_avocado_tests') as _mock:
                 _mock.side_effect = BaseException()
-                tests = self.loader.discover(avocado_test.path)
-                self.assertEqual(tests[0][1]["name"], avocado_test.path)
+                tests = self.loader.discover(avocado_test.path,
+                                             loader.DiscoverMode.ALL)
+                self.assertEqual(tests[0][1]["name"],
+                                 f"{avocado_test.path}: Not an INSTRUMENTED "
+                                 f"(avocado.Test based) test")
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -4,7 +4,6 @@ import unittest.mock
 
 from avocado.core import test
 from avocado.core.test_id import TestID
-from avocado.utils import script
 from selftests.utils import setup_avocado_loggers, temp_dir_prefix
 
 setup_avocado_loggers()
@@ -187,43 +186,6 @@ class TestClassTest(unittest.TestCase):
 
     def tearDown(self):
         self.base_logdir.cleanup()
-
-
-class SimpleTestClassTest(unittest.TestCase):
-
-    def setUp(self):
-        prefix = temp_dir_prefix(self)
-        self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
-        self.script = None
-
-    def test_simple_test_pass_status(self):
-        self.script = script.TemporaryScript(
-            'avocado_pass.sh',
-            PASS_SCRIPT_CONTENTS,
-            'avocado_simpletest_unittest')
-        self.script.save()
-        tst_instance = test.SimpleTest(
-            name=TestID(1, self.script.path),
-            base_logdir=self.tmpdir.name)
-        tst_instance.run_avocado()
-        self.assertEqual(tst_instance.status, 'PASS')
-
-    def test_simple_test_fail_status(self):
-        self.script = script.TemporaryScript(
-            'avocado_fail.sh',
-            FAIL_SCRIPT_CONTENTS,
-            'avocado_simpletest_unittest')
-        self.script.save()
-        tst_instance = test.SimpleTest(
-            name=TestID(1, self.script.path),
-            base_logdir=self.tmpdir.name)
-        tst_instance.run_avocado()
-        self.assertEqual(tst_instance.status, 'FAIL')
-
-    def tearDown(self):
-        if self.script is not None:
-            self.script.remove()
-        self.tmpdir.cleanup()
 
 
 if __name__ == '__main__':

--- a/selftests/unit/test_test.py
+++ b/selftests/unit/test_test.py
@@ -115,42 +115,6 @@ class TestClassTestUnit(unittest.TestCase):
         self.assertRaises(AttributeError, setattr, dummy_test, "name", "whatever")
         self.assertRaises(AttributeError, setattr, dummy_test, "status", "whatever")
 
-    def test_check_reference_success(self):
-        '''
-        Tests that a check is made, and is successful
-        '''
-        class GetDataTest(test.Test):
-            def test(self):
-                pass
-
-            def get_data(self, filename, source=None, must_exist=True):
-                # return the filename (path, really) unchanged
-                return filename
-
-        tst = GetDataTest("test", TestID(1, "test"),
-                          base_logdir=self.tmpdir.name)
-        content = 'expected content\n'
-        content_path = os.path.join(tst.logdir, 'content')
-        with open(content_path, 'w', encoding='utf-8') as produced:
-            produced.write(content)
-        self.assertTrue(tst._check_reference(content_path,
-                                             content_path,
-                                             'content.diff',
-                                             'content_diff',
-                                             'Content'))
-
-    def test_check_reference_does_not_exist(self):
-        '''
-        Tests that a check is not made for a file that does not exist
-        '''
-        tst = self.DummyTest("test", TestID(1, "test"),
-                             base_logdir=self.tmpdir.name)
-        self.assertFalse(tst._check_reference('does_not_exist',
-                                              'stdout.expected',
-                                              'stdout.diff',
-                                              'stdout_diff',
-                                              'Stdout'))
-
 
 class TestClassTest(unittest.TestCase):
 


### PR DESCRIPTION
This completely removes the SIMPLE test support for the legacy runner, along with some other legacy runner related code.

---

Changes from v1 (#5341):
* Dropped commit [selftests/functional/test_basic.py: split RunnerExecTestStatus](https://github.com/avocado-framework/avocado/pull/5341/commits/69c04e97ed067527aa35f50c89d2bd262520954d) as the tests get removed in a later commit.
* Included "fail reason" for tests returning unsupported status, matching the legacy behavior