### PR TITLE
failfast for any "NOT OK" status

### DIFF
--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -5,6 +5,7 @@ import multiprocessing
 import time
 
 from avocado.core.exceptions import TestFailFast
+from avocado.core.teststatus import STATUSES_NOT_OK
 
 LOG = logging.getLogger(__name__)
 
@@ -279,8 +280,9 @@ class Worker:
                 runtime_task.status = 'FINISHED'
             except asyncio.TimeoutError:
                 runtime_task.status = 'FINISHED W/ TIMEOUT'
-        result_stats = self._state_machine._status_repo.result_stats
-        if self._failfast and 'fail' in result_stats:
+        result_stats = set(key.upper()for key in
+                           self._state_machine._status_repo.result_stats.keys())
+        if self._failfast and not result_stats.isdisjoint(STATUSES_NOT_OK):
             await self._state_machine.abort("FAILFAST is enabled")
             raise TestFailFast("Interrupting job (failfast).")
 

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -193,7 +193,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         expected = '[{"paths": ["/run/*"], "variant_id": null, "variant": [["/", []]]}]'
         self.assertEqual(variants, expected)
 
-    def test_runner_failfast(self):
+    def test_runner_failfast_fail(self):
         cmd_line = (f'{AVOCADO} run --disable-sysinfo '
                     f'--job-results-dir {self.tmpdir.name} '
                     f'examples/tests/passtest.py examples/tests/failtest.py '
@@ -202,6 +202,19 @@ class RunnerOperationTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b'Interrupting job (failfast).', result.stdout)
         self.assertIn(b'PASS 1 | ERROR 0 | FAIL 1 | SKIP 1', result.stdout)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
+        self.assertEqual(result.exit_status, expected_rc,
+                         f"Avocado did not return rc {expected_rc}:\n{result}")
+
+    def test_runner_failfast_error(self):
+        cmd_line = (f'{AVOCADO} run --disable-sysinfo '
+                    f'--job-results-dir {self.tmpdir.name} '
+                    f'examples/tests/passtest.py examples/tests/errortest.py '
+                    f'examples/tests/passtest.py --failfast '
+                    f'--nrunner-max-parallel-tasks=1')
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertIn(b'Interrupting job (failfast).', result.stdout)
+        self.assertIn(b'PASS 1 | ERROR 1 | FAIL 0 | SKIP 1', result.stdout)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.assertEqual(result.exit_status, expected_rc,
                          f"Avocado did not return rc {expected_rc}:\n{result}")


### PR DESCRIPTION
This PR will add `failfast` option for any "NOT OK" status. Until
now, the `failfast` was working only for `fail` status. This change adds
the same ability to `error` and `interrupted` statuses as well.

Reference: #5357
Signed-off-by: Jan Richter <jarichte@redhat.com>