### PR TITLE
 Runnable with default config [v2]

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -26,8 +26,6 @@ import tempfile
 from avocado.core.dispatcher import SpawnerDispatcher
 from avocado.core.exceptions import JobError, TestFailFast
 from avocado.core.messages import MessageHandler
-from avocado.core.nrunner.runnable import (
-    RUNNERS_REGISTRY_STANDALONE_EXECUTABLE, STANDALONE_EXECUTABLE_CONFIG_USED)
 from avocado.core.nrunner.runner import check_runnables_runner_requirements
 from avocado.core.output import LOG_JOB
 from avocado.core.plugin_interfaces import CLI, Init
@@ -181,14 +179,7 @@ class Runner(RunnerInterface):
         :type config: dict
         """
         for runnable in runnables:
-            command = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE.get(runnable.kind)
-            if command is None:
-                continue
-            command = " ".join(command)
-            configuration_used = STANDALONE_EXECUTABLE_CONFIG_USED.get(command)
-            for config_item in configuration_used:
-                if config_item in config:
-                    runnable.config[config_item] = config.get(config_item)
+            runnable.config = config
 
     def _determine_status_server_uri(self, test_suite):
         # pylint: disable=W0201

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -46,6 +46,18 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'time': ", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
+    def test_instrumented(self):
+        test_uri = os.path.join(BASEDIR, "examples", "tests",
+                                "passtest.py:PassTest.test")
+        res = process.run(f"{RUNNER} runnable-run -k avocado-instrumented -u "
+                          f"{test_uri}",
+                          ignore_status=True)
+        self.assertIn(b"'status': 'started'", res.stdout)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'result': 'pass'", res.stdout)
+        self.assertIn(b"'time': ", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
     def test_exec_test(self):
         # 'base64:LWM=' becomes '-c' and makes Python execute the
         # commands on the subsequent argument

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -73,7 +73,7 @@ class RunnableTest(unittest.TestCase):
 
     def test_identifier_args(self):
         config = {'runner.identifier_format': '{uri}-{args[0]}'}
-        runnable = Runnable('exec-text', 'uri', 'arg1', 'arg2',
+        runnable = Runnable('exec-test', 'uri', 'arg1', 'arg2',
                             config=config)
         self.assertEqual(runnable.identifier, 'uri-arg1')
 


### PR DESCRIPTION
Some runners (like instrumented) need config values for proper working.
When we are running tasks by `avocado run` or Job API the default
configuration is inserted to runners via runnable. The problem starts
when you run test runner with `runnable-run` command even a small test
as 'avocado-runner runnable-run -k avocado-instrumented -u
examples/tests/passtest.py:PassTest.test` will fail because of missing
configuration. This PR solves this problem by adding default
configuration to the runnable.

Changes from v1 (#5313):
* Usage of features from #5326
It helps to add only necessary config for runners.

Signed-off-by: Jan Richter <jarichte@redhat.com>