### PR TITLE
suite name contains slash fix

### DIFF
--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -24,6 +24,7 @@ from avocado.core.nrunner.config import ConfigDecoder, ConfigEncoder
 from avocado.core.output import LOG_JOB, LOG_UI
 from avocado.core.settings import settings
 from avocado.core.varianter import VARIANTS_FILENAME
+from avocado.utils.astring import string_to_safe_path
 from avocado.utils.path import init_dir
 
 JOB_DATA_DIR = 'jobdata'
@@ -77,6 +78,7 @@ def record(job, cmdline=None):
             suite_var_name = f"variants-{idx}-{suite.name}.json"
         else:
             suite_var_name = f"variants-{idx}.json"
+        suite_var_name = string_to_safe_path(suite_var_name)
         path_suite_variant = os.path.join(base_dir, suite_var_name)
         record_suite_variant(path_suite_variant, suite)
 


### PR DESCRIPTION
When the suite name contains a slash, the avocado crashes because the
`jobdata` module will try to save information to a folder with path
created from the suite name, which doesn't exist. This commit will use
`astring.string_to_safe_path()` for the jobdata folder path, which fixes
the issue.

Reference: #5365
Signed-off-by: Jan Richter <jarichte@redhat.com>