### PR TITLE
typo fixes, update experimental python and some more f-strings

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.11.0-alpha.2]
+        python-version: [3.11.0-alpha.7]
       fail-fast: false
     outputs:
       job_status: ${{ job.status }}
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.11.0-alpha.2]
+        python-version: [3.11.0-alpha.7]
       fail-fast: false
 
     steps:

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -41,12 +41,12 @@ class StatusRepo:
 
         result = message.get('result')
         if result is not None and result.upper() not in STATUSES:
-            overriden = 'error'
-            message['result'] = overriden
+            overridden = 'error'
+            message['result'] = overridden
             message['fail_reason'] = (f'Runner error occurred: Test reports '
                                       f'unsupported status "{result}"')
             LOG.error('Task "%s" finished message with unsupported status '
-                      '"%s", changing to "%s"', task_id, result, overriden)
+                      '"%s", changing to "%s"', task_id, result, overridden)
 
         self._set_by_result(message)
         self._set_task_data(message)

--- a/avocado/core/tree.py
+++ b/avocado/core/tree.py
@@ -102,10 +102,10 @@ class TreeEnvironment(dict):
         # Use __str__ instead of __repr__ to improve readability
         if self:
             _values = ["%s: %s" % _ for _ in sort_fn(list(self.items()))]  # pylint: disable=C0209
-            values = "{%s}" % ", ".join(_values)  # pylint: disable=C0209
+            values = f"{{{', '.join(_values)}}}"
             _origin = [f"{key}: {node.path}"
                        for key, node in sort_fn(list(self.origin.items()))]
-            origin = "{%s}" % ", ".join(_origin)  # pylint: disable=C0209
+            origin = f"{{{', '.join(_origin)}}}"
         else:
             values = "{}"
             origin = "{}"

--- a/avocado/utils/git.py
+++ b/avocado/utils/git.py
@@ -102,7 +102,7 @@ class GitRepoHelper:
                 not suppress them (False).
         """
         os.chdir(self.destination_dir)
-        return process.run(r"%s %s" % (self.cmd, astring.shell_escape(cmd)),  # pylint: disable=C0209
+        return process.run(fr"{self.cmd} {astring.shell_escape(cmd)}",
                            ignore_status=ignore_status)
 
     def fetch(self, uri):

--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -199,7 +199,7 @@ def vg_ramdisk_cleanup(ramdisk_filename=None, vg_ramdisk_dir=None,
                   DeprecationWarning)
     errs = []
     if vg_name is not None:
-        loop_device = re.search(r"([/\w-]+) +%s +lvm2" % vg_name,  # pylint: disable=C0209
+        loop_device = re.search(fr"([/\w-]+) +{vg_name} +lvm2",
                                 process.run("pvs", sudo=True).stdout_text)
         if loop_device is not None:
             loop_device = loop_device.group(1)
@@ -361,7 +361,7 @@ def lv_check(vg_name, lv_name):
     cmd = f"lvdisplay {vg_name}"
     result = process.run(cmd, ignore_status=True, sudo=True)
 
-    lvpattern = r"LV Name\s+%s\s+" % lv_name  # pylint: disable=C0209
+    lvpattern = fr"LV Name\s+{lv_name}\s+"
     match = re.search(lvpattern, result.stdout_text.rstrip())
     if match:
         LOGGER.debug("Provided Logical volume %s exists in %s",

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -316,7 +316,7 @@ def read_from_vmstat(key):
     """
     with open("/proc/vmstat") as vmstat:  # pylint: disable=W1514
         vmstat_info = vmstat.read()
-        return int(re.findall(r"%s\s+(\d+)" % key, vmstat_info)[0])  # pylint: disable=C0209
+        return int(re.findall(fr"{key}\s+(\d+)", vmstat_info)[0])
 
 
 def read_from_smaps(pid, key):
@@ -334,7 +334,7 @@ def read_from_smaps(pid, key):
         smaps_info = smaps.read()
 
         memory_size = 0
-        for each_number in re.findall(r"%s:\s+(\d+)" % key, smaps_info):  # pylint: disable=C0209
+        for each_number in re.findall(fr"{key}:\s+(\d+)", smaps_info):
             memory_size += int(each_number)
 
         return memory_size
@@ -356,7 +356,7 @@ def read_from_numa_maps(pid, key):
         numa_map_info = numa_maps.read()
 
         numa_maps_dict = {}
-        numa_pattern = r"(^[\dabcdfe]+)\s+.*%s[=:](\d+)" % key  # pylint: disable=C0209
+        numa_pattern = fr"(^[\dabcdfe]+)\s+.*{key}[=:](\d+)"
         for address, number in re.findall(numa_pattern, numa_map_info, re.M):
             numa_maps_dict[address] = number
 

--- a/docs/source/guides/user/chapters/tags.rst
+++ b/docs/source/guides/user/chapters/tags.rst
@@ -132,7 +132,7 @@ And to be even more specific, you can use::
   avocado-instrumented byteorder.py:ByteOrder.test_be
 
 A "negated" form is also available to filter out tests that do *not*
-have a given value.  To filter out tests that have an endianess set,
+have a given value.  To filter out tests that have an endianness set,
 but are *not* big endian you can use::
 
   $ avocado list byteorder.py --filter-by-tags endianness:-big


### PR DESCRIPTION
A set of small changes I had in the pipeline:

* switch some more strings to f-strings
I override some strings because I needed some testing before migrating them. Switch them now and remove the pylint override on C0209

* `weekly.yml`: update development Python version to alpha.7

* typo fixes found by codespell
