### PR TITLE
selftests/run: failfast and plugins fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
       matrix:
         python-version: [3.10.0]
     env:
-      SELF_CHECK_CONTINUOUS: "yes"
       CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
 
     steps:

--- a/selftests/run
+++ b/selftests/run
@@ -3,16 +3,13 @@
 
 __author__ = 'Lucas Meneghel Rodrigues <lmr@redhat.com>'
 
-import os
 import sys
 import unittest
 
 from selftests.utils import test_suite
 
 if __name__ == '__main__':
-    failfast = not os.environ.get("SELF_CHECK_CONTINUOUS")
-    runner = unittest.TextTestRunner(failfast=failfast,
-                                     verbosity=1,
+    runner = unittest.TextTestRunner(verbosity=1,
                                      resultclass=unittest.TextTestResult)
     result = runner.run(test_suite())
     if result.failures or result.errors:

--- a/selftests/utils.py
+++ b/selftests/utils.py
@@ -85,11 +85,13 @@ def get_temporary_config(klass):
 
 
 #: The plugin module names and directories under optional_plugins
-PLUGINS = {'varianter_yaml_to_mux': 'avocado-framework-plugin-varianter-yaml-to-mux',
-           'runner_remote': 'avocado-framework-plugin-runner-remote',
-           'runner_vm': 'avocado-framework-plugin-runner-vm',
-           'varianter_cit': 'avocado-framework-plugin-varianter-cit',
-           'html': 'avocado-framework-plugin-result-html'}
+PLUGINS = {
+    'golang': 'avocado-framework-plugin-golang',
+    'html': 'avocado-framework-plugin-result-html',
+    'robot': 'avocado-framework-plugin-robot',
+    'varianter_cit': 'avocado-framework-plugin-varianter-cit',
+    'varianter_yaml_to_mux': 'avocado-framework-plugin-varianter-yaml-to-mux',
+}
 
 
 def test_suite(base_selftests=True, plugin_selftests=None):


### PR DESCRIPTION
This fixes a condition where the test suite used during `selftests/run` and `selftests/run_coverage` miss some of the optional plugins.