### PR TITLE
Messages timestamp changes

### DIFF
--- a/avocado/core/nrunner/app.py
+++ b/avocado/core/nrunner/app.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import sys
+import time
 
 import pkg_resources
 
@@ -105,7 +106,7 @@ class BaseRunnerApp:
     )
 
     def __init__(self, echo=print, prog=None, description=None):
-        self.echo = echo
+        self._echo = echo
         self.parser = None
         if prog is None:
             prog = self.PROG_NAME
@@ -113,6 +114,10 @@ class BaseRunnerApp:
             description = self.PROG_DESCRIPTION
         self._class_commands_method = self._get_commands_method()
         self._setup_parser(prog, description)
+
+    def echo(self, message):
+        message['time'] = time.monotonic()
+        self._echo(message)
 
     def _setup_parser(self, prog, description):
         self.parser = argparse.ArgumentParser(prog=prog,
@@ -220,7 +225,7 @@ class BaseRunnerApp:
         of a given kind, or identifying if a runner script has a given feature
         (as implemented by a command).
         """
-        self.echo(json.dumps(self.get_capabilities()))
+        self._echo(json.dumps(self.get_capabilities()))
 
     def command_runnable_run(self, args):
         """

--- a/avocado/core/nrunner/runner.py
+++ b/avocado/core/nrunner/runner.py
@@ -1,5 +1,3 @@
-import time
-
 from avocado.core.nrunner.runnable import \
     RUNNERS_REGISTRY_STANDALONE_EXECUTABLE
 from avocado.core.plugin_interfaces import RunnableRunner
@@ -64,6 +62,5 @@ class BaseRunner(RunnableRunner):
         status = {}
         if isinstance(additional_info, dict):
             status = additional_info
-        status.update({'status': status_type,
-                       'time': time.monotonic()})
+        status.update({'status': status_type})
         return status

--- a/avocado/core/nrunner/task.py
+++ b/avocado/core/nrunner/task.py
@@ -2,6 +2,7 @@ import base64
 import json
 import socket
 import tempfile
+import time
 from uuid import uuid1
 
 from avocado.core.nrunner.runnable import (
@@ -177,6 +178,7 @@ class Task:
         runner_klass = self.runnable.pick_runner_class()
         runner = runner_klass()
         for status in runner.run(self.runnable):
+            status['time'] = time.monotonic()
             if status['status'] == 'started':
                 status.update({'output_dir': self.runnable.output_dir})
             status.update({"id": self.identifier})

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -201,7 +201,6 @@ class Runner(unittest.TestCase):
         results = [status for status in runner.run(runnable)]
         last_result = results[-1]
         self.assertEqual(last_result['status'], 'finished')
-        self.assertIn('time', last_result)
 
     def test_runner_exec(self):
         runnable = Runnable('exec-test', sys.executable,
@@ -218,7 +217,6 @@ class Runner(unittest.TestCase):
         self.assertEqual(stderr_result['log'], b'')
         self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['returncode'], 0)
-        self.assertIn('time', last_result)
 
     def test_runner_exec_test_ok(self):
         runnable = Runnable('exec-test', sys.executable,
@@ -236,7 +234,6 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['result'], 'pass')
         self.assertEqual(last_result['returncode'], 0)
-        self.assertIn('time', last_result)
 
     @skipUnlessPathExists('/bin/false')
     def test_runner_exec_test_fail(self):
@@ -254,7 +251,6 @@ class Runner(unittest.TestCase):
         self.assertEqual(last_result['status'], 'finished')
         self.assertEqual(last_result['result'], 'fail')
         self.assertEqual(last_result['returncode'], 1)
-        self.assertIn('time', last_result)
 
     def test_runner_python_unittest_error(self):
         runnable = Runnable('python-unittest', 'error')


### PR DESCRIPTION
This change the message timestamp value from time when the message was
created to time when the message was published. This will fix the issue
where the publishing order of messages was different from order by time
and the status repo discard messages in the wrong order.

Reference: #5327
Signed-off-by: Jan Richter <jarichte@redhat.com>