### PR TITLE
Packit: disable network during builds

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -11,3 +11,4 @@ jobs:
       - centos-stream-9
       - epel-8
       - epel-9
+      enable_net: False


### PR DESCRIPTION
The default mock/koji/etc behavior is to *not* have network enabled.
This allows common errors to be caught, such as dependencies being
resolved by means other than BuildRequires (such as an implicit
install of a Python dependency listed in setup.py).

Now Packit has this configuration available, so let's use it.

Reference: https://github.com/packit/packit/pull/1504
Signed-off-by: Cleber Rosa <crosa@redhat.com>