### PR TITLE
Discarding older messages from status repo fix

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -216,8 +216,8 @@ class Runner(RunnerInterface):
         message_handler = MessageHandler()
         while True:
             try:
-                (task_id, _, _, index) = \
-                    self.status_repo.status_journal_summary.pop(0)
+                (_, task_id, _, index) = \
+                    self.status_repo.status_journal_summary_pop()
 
             except IndexError:
                 await asyncio.sleep(0.05)

--- a/selftests/unit/test_status_repo.py
+++ b/selftests/unit/test_status_repo.py
@@ -131,9 +131,13 @@ class StatusRepo(TestCase):
                "job_id": "0000000000000000000000000000000000000000"}
         self.status_repo.process_message(msg)
         self.assertEqual(self.status_repo.get_task_status("1-foo"), "finished")
-        self.assertEqual(self.status_repo.status_journal_summary.pop(),
-                         ("1-foo", "finished", 1000000004.0, 3))
-        self.assertEqual(self.status_repo.status_journal_summary.pop(),
-                         ("1-foo", "running", 1000000003.0, 0))
+        self.assertEqual(self.status_repo.status_journal_summary_pop(),
+                         (1000000001.0, "1-foo", "started", 2))
+        self.assertEqual(self.status_repo.status_journal_summary_pop(),
+                         (1000000002.0, "1-foo", "running", 1))
+        self.assertEqual(self.status_repo.status_journal_summary_pop(),
+                         (1000000003.0, "1-foo", "running", 0))
+        self.assertEqual(self.status_repo.status_journal_summary_pop(),
+                         (1000000004.0, "1-foo", "finished", 3))
         with self.assertRaises(IndexError):
-            self.status_repo.status_journal_summary.pop()
+            self.status_repo.status_journal_summary_pop()


### PR DESCRIPTION
The status repo was discarding messages when the message timestamp was
lower than the latest save message. This change removes timestamp
checking and ensures the status changes only in expected life-cycle of a
test: started->running->finished. This means that change from running to
finished is possible, but from finished to running is not.

This change also stores every message into the `status_journal_summary`
list and sorts them by the timestamp. This sort is not optimal because,
the `runner_nrunner` plugin reads data from the status journal during
runner to server communication. This means that status repo sorts
messages which haven't been read yet by `runner_nrunner` plugin, but
can't ensure the order of the whole communication.

Reference: #5327
Signed-off-by: Jan Richter <jarichte@redhat.com>