### PR TITLE
COPR SRPM build: set git repo directory as safe

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,4 +1,6 @@
 pkg_install := $(shell dnf -y install git rpm-build)
+pwd := $(shell pwd)
+git_config_safe_directory := $(shell git config --global --add safe.directory $(pwd))
 commit := $(shell git log --pretty=format:'%H' -n 1)
 commit_date := $(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
 short_commit := $(shell git rev-parse --short=9 HEAD)


### PR DESCRIPTION
The creation of SRPM in COPR is currently failing, giving errors
such as:

   make -f /mnt/workdir-ipj4venx/avocado/.copr/Makefile srpm
      outdir="/mnt/safe-resultdir-unosjbwi"
      spec="/mnt/workdir-ipj4venx/avocado"']
   cwd: /var/lib/copr-rpmbuild/workspace/workdir-ipj4venx/avocado
   rc: 2
   stdout: fatal: unsafe repository ('/mnt/workdir-ipj4venx/avocado'
   is owned by someone else)

   To add an exception for this directory, call:

      git config --global --add safe.directory /mnt/workdir-ipj4venx/avocado
      fatal: unsafe repository ('/mnt/workdir-ipj4venx/avocado' is
      owned by someone else)

Let's work around this limitation and more recent git behavior and set
the safe mode on the repo directory manually.

Signed-off-by: Cleber Rosa <crosa@redhat.com>