### PR TITLE
Runnable with default config [v3] 

### DIFF
--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -1,6 +1,7 @@
 import base64
 import collections
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -8,6 +9,9 @@ import sys
 import pkg_resources
 
 from avocado.core.nrunner.config import ConfigDecoder, ConfigEncoder
+from avocado.core.settings import settings
+
+LOG = logging.getLogger(__name__)
 
 #: All known runner commands, capable of being used by a
 #: SpawnMethod.STANDALONE_EXECUTABLE compatible spawners
@@ -64,6 +68,8 @@ class Runnable:
     """
 
     def __init__(self, kind, uri, *args, config=None, **kwargs):
+        if config is None:
+            config = self.filter_runnable_config(kind, {})
         self.kind = kind
         #: The main reference to what needs to be run.  This is free
         #: form, but commonly set to the path to a file containing the
@@ -74,6 +80,7 @@ class Runnable:
         #: that is passed to runners, as long as a runner declares
         #: its interest in using them with
         #: attr:`avocado.core.nrunner.runner.BaseRunner.CONFIGURATION_USED`
+        self._config = {}
         self.config = config or {}
         self.args = args
         self.tags = kwargs.pop('tags', None)
@@ -81,6 +88,8 @@ class Runnable:
         self.variant = kwargs.pop('variant', None)
         self.output_dir = kwargs.pop('output_dir', None)
         self.kwargs = kwargs
+        self._identifier_format = config.get("runner.identifier_format",
+                                             "{uri}")
 
     def __repr__(self):
         fmt = ('<Runnable kind="{}" uri="{}" config="{}" args="{}" '
@@ -115,7 +124,7 @@ class Runnable:
         Since this is formatter, combined values can be used. Example:
         "{uri}-{args}".
         """
-        fmt = self.config.get("runner.identifier_format")
+        fmt = self._identifier_format
 
         # For the cases where there is no config (when calling the Runnable
         # directly
@@ -140,16 +149,45 @@ class Runnable:
 
         return fmt.format(**options)
 
+    @property
+    def config(self):
+        return self._config
+
+    @config.setter
+    def config(self, config):
+        """Sets the config values based on the runnable kind.
+
+        This is not avocado config, it is a runnable config which is a subset
+        of avocado config based on `STANDALONE_EXECUTABLE_CONFIG_USED` which
+        describes essential configuration values for each runner kind.
+
+        :param config: A config dict with new values for Runnable.
+        :type config: dict
+        """
+        command = self.pick_runner_command(self.kind)
+        if command is not None:
+            command = " ".join(command)
+            configuration_used = STANDALONE_EXECUTABLE_CONFIG_USED.get(command)
+            if not set(configuration_used).issubset(set(config.keys())):
+                LOG.warning("The runnable config should have only values "
+                            "essential for its runner. In the next version of "
+                            "avocado, this will raise a Value Error. Please "
+                            "use avocado.core.nrunner.runnable.Runnable.filter_runnable_config "
+                            "or avocado.core.nrunner.runnable.Runnable.from_avocado_config")
+        self._config = config
+
     @classmethod
     def from_args(cls, args):
         """Returns a runnable from arguments"""
         decoded_args = [_arg_decode_base64(arg) for arg in args.get('arg', ())]
-        return cls(args.get('kind'),
-                   args.get('uri'),
-                   *decoded_args,
-                   config=json.loads(args.get('config', '{}'),
-                                     cls=ConfigDecoder),
-                   **_key_val_args_to_kwargs(args.get('kwargs', [])))
+        return cls.from_avocado_config(args.get('kind'),
+                                       args.get('uri'),
+                                       *decoded_args,
+                                       config=json.loads(args.get('config',
+                                                                  '{}'),
+                                                         cls=ConfigDecoder),
+                                       **_key_val_args_to_kwargs(args.get(
+                                           'kwargs', [])))
 
     @classmethod
     def from_recipe(cls, recipe_path):
@@ -163,11 +201,50 @@ class Runnable:
         with open(recipe_path, encoding='utf-8') as recipe_file:
             recipe = json.load(recipe_file)
         config = ConfigDecoder.decode_set(recipe.get('config', {}))
-        return cls(recipe.get('kind'),
-                   recipe.get('uri'),
-                   *recipe.get('args', ()),
-                   config=config,
-                   **recipe.get('kwargs', {}))
+        return cls.from_avocado_config(recipe.get('kind'),
+                                       recipe.get('uri'),
+                                       *recipe.get('args', ()),
+                                       config=config,
+                                       **recipe.get('kwargs', {}))
+
+    @classmethod
+    def from_avocado_config(cls,  kind, uri, *args, config=None, **kwargs):
+        """Creates runnable with only essential config for runner of specific kind."""
+        if not config:
+            config = {}
+        config = cls.filter_runnable_config(kind, config)
+        return cls(kind, uri, *args, config=config, **kwargs)
+
+    @staticmethod
+    def filter_runnable_config(kind, config):
+        """
+        Returns only essential values for specific runner.
+
+        It will use configuration from argument completed by values from
+        config file and avocado default configuration.
+
+        :param kind: Kind of runner which should use the configuration.
+        :type kind: str
+        :param config: Configuration values for runner. If some values will be
+                       missing the default ones and from config file will be
+                       used.
+        :type config: dict
+        :returns: Config dict, which has only values essential for runner
+                  based on STANDALONE_EXECUTABLE_CONFIG_USED
+        :rtype: dict
+        """
+        command = Runnable.pick_runner_command(kind)
+        if command is not None:
+            whole_config = settings.as_dict()
+            whole_config.update(config)
+            command = " ".join(command)
+            configuration_used = STANDALONE_EXECUTABLE_CONFIG_USED.get(command)
+            filtered_config = {}
+            for config_item in configuration_used:
+                filtered_config[config_item] = whole_config.get(config_item)
+            return filtered_config
+        else:
+            raise ValueError(f"Unsupported kind of runnable: {kind}")
 
     def get_command_args(self):
         """

--- a/avocado/core/nrunner/runner.py
+++ b/avocado/core/nrunner/runner.py
@@ -33,7 +33,7 @@ def check_runnables_runner_requirements(runnables, runners_registry=None):
     missing = []
 
     for runnable in runnables:
-        runner = runnable.pick_runner_command(runners_registry)
+        runner = runnable.pick_runner_command(runnable.kind, runners_registry)
         if runner:
             ok.append(runnable)
         else:

--- a/avocado/core/nrunner/task.py
+++ b/avocado/core/nrunner/task.py
@@ -124,7 +124,7 @@ class Task:
         """
         if runners_registry is None:
             runners_registry = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE
-        return self.runnable.pick_runner_command(runners_registry)
+        return self.runnable.runner_command(runners_registry)
 
     def setup_output_dir(self, output_dir=None):
         if not self.runnable.output_dir:

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -26,8 +26,7 @@ import tempfile
 from avocado.core.dispatcher import SpawnerDispatcher
 from avocado.core.exceptions import JobError, TestFailFast
 from avocado.core.messages import MessageHandler
-from avocado.core.nrunner.runnable import (
-    RUNNERS_REGISTRY_STANDALONE_EXECUTABLE, STANDALONE_EXECUTABLE_CONFIG_USED)
+from avocado.core.nrunner.runnable import Runnable
 from avocado.core.nrunner.runner import check_runnables_runner_requirements
 from avocado.core.output import LOG_JOB
 from avocado.core.plugin_interfaces import CLI, Init
@@ -181,14 +180,8 @@ class Runner(RunnerInterface):
         :type config: dict
         """
         for runnable in runnables:
-            command = RUNNERS_REGISTRY_STANDALONE_EXECUTABLE.get(runnable.kind)
-            if command is None:
-                continue
-            command = " ".join(command)
-            configuration_used = STANDALONE_EXECUTABLE_CONFIG_USED.get(command)
-            for config_item in configuration_used:
-                if config_item in config:
-                    runnable.config[config_item] = config.get(config_item)
+            runnable.config = Runnable.filter_runnable_config(runnable.kind,
+                                                              config)
 
     def _determine_status_server_uri(self, test_suite):
         # pylint: disable=W0201

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -282,6 +282,6 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
     async def check_task_requirements(runtime_task):
         """Check the runtime task requirements needed to be able to run"""
         # right now, limit the check to the runner availability.
-        if runtime_task.task.runnable.pick_runner_command() is None:
+        if runtime_task.task.runnable.runner_command() is None:
             return False
         return True

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -23,7 +23,7 @@ class ProcessSpawner(Spawner, SpawnerMixin):
     async def spawn_task(self, runtime_task):
         self.create_task_output_dir(runtime_task)
         task = runtime_task.task
-        runner = task.runnable.pick_runner_command()
+        runner = task.runnable.runner_command()
         args = runner[1:] + ['task-run'] + task.get_command_args()
         runner = runner[0]
         # When running Avocado Python modules, the interpreter on the new
@@ -57,6 +57,6 @@ class ProcessSpawner(Spawner, SpawnerMixin):
     async def check_task_requirements(runtime_task):
         """Check the runtime task requirements needed to be able to run"""
         # right now, limit the check to the runner availability.
-        if runtime_task.task.runnable.pick_runner_command() is None:
+        if runtime_task.task.runnable.runner_command() is None:
             return False
         return True

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -46,6 +46,18 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'time': ", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
+    def test_instrumented(self):
+        test_uri = os.path.join(BASEDIR, "examples", "tests",
+                                "passtest.py:PassTest.test")
+        res = process.run(f"{RUNNER} runnable-run -k avocado-instrumented -u "
+                          f"{test_uri}",
+                          ignore_status=True)
+        self.assertIn(b"'status': 'started'", res.stdout)
+        self.assertIn(b"'status': 'finished'", res.stdout)
+        self.assertIn(b"'result': 'pass'", res.stdout)
+        self.assertIn(b"'time': ", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
     def test_exec_test(self):
         # 'base64:LWM=' becomes '-c' and makes Python execute the
         # commands on the subsequent argument

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -395,39 +395,40 @@ echo 'ok 2 - description 2'"""
 class RunnerCommandSelection(unittest.TestCase):
 
     def setUp(self):
-        self.runnable = Runnable('mykind',
-                                 'test_runner_command_selection')
+        self.kind = 'mykind'
 
     def test_is_task_kind_supported(self):
         cmd = ['sh', '-c',
                'test $0 = capabilities && '
                'echo -n {\\"runnables\\": [\\"mykind\\"]}']
-        self.assertTrue(self.runnable.is_kind_supported_by_runner_command(cmd))
+        self.assertTrue(Runnable.is_kind_supported_by_runner_command(self.kind,
+                                                                     cmd))
 
     def test_is_task_kind_supported_other_kind(self):
         cmd = ['sh', '-c',
                'test $0 = capabilities && '
                'echo -n {\\"runnables\\": [\\"otherkind\\"]}']
-        self.assertFalse(self.runnable.is_kind_supported_by_runner_command(cmd))
+        self.assertFalse(Runnable.is_kind_supported_by_runner_command(self.kind,
+                                                                      cmd))
 
     def test_is_task_kind_supported_no_output(self):
         cmd = ['sh', '-c', 'echo -n ""']
-        self.assertFalse(self.runnable.is_kind_supported_by_runner_command(cmd))
+        self.assertFalse(Runnable.is_kind_supported_by_runner_command(self.kind,
+                                                                      cmd))
 
 
 class PickRunner(unittest.TestCase):
 
     def setUp(self):
-        self.runnable = Runnable('lets-image-a-kind',
-                                 'test_pick_runner_command')
+        self.kind = 'lets-image-a-kind'
 
     def test_pick_runner_command(self):
         runner = ['avocado-runner-lets-image-a-kind']
         known = {'lets-image-a-kind': runner}
-        self.assertEqual(self.runnable.pick_runner_command(known), runner)
+        self.assertEqual(Runnable.pick_runner_command(self.kind, known), runner)
 
     def test_pick_runner_command_empty(self):
-        self.assertFalse(self.runnable.pick_runner_command({}))
+        self.assertFalse(Runnable.pick_runner_command(self.kind, {}))
 
 
 class TaskTest(unittest.TestCase):

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -61,12 +61,12 @@ class RunnableTest(unittest.TestCase):
 
     def test_recipe_exec(self):
         open_mocked = unittest.mock.mock_open(
-            read_data=('{"kind": "exec", "uri": "/bin/sh", '
+            read_data=('{"kind": "exec-test", "uri": "/bin/sh", '
                        '"args": ["/etc/profile"], '
                        '"kwargs": {"TERM": "vt3270"}}'))
         with unittest.mock.patch("builtins.open", open_mocked):
             runnable = Runnable.from_recipe("fake_path")
-        self.assertEqual(runnable.kind, "exec")
+        self.assertEqual(runnable.kind, "exec-test")
         self.assertEqual(runnable.uri, "/bin/sh")
         self.assertEqual(runnable.args, ("/etc/profile",))
         self.assertEqual(runnable.kwargs, {"TERM": "vt3270"})
@@ -99,8 +99,8 @@ class RunnableTest(unittest.TestCase):
         self.assertEqual(runnable.get_json(), expected)
 
     def test_runner_from_runnable_error(self):
-        runnable = Runnable('unsupported_kind', '')
         try:
+            runnable = Runnable('unsupported_kind', '')
             runnable.pick_runner_class()
         except ValueError as e:
             self.assertEqual(str(e), 'Unsupported kind of runnable: unsupported_kind')
@@ -115,20 +115,20 @@ class RunnableFromCommandLineArgs(unittest.TestCase):
         self.assertIsNone(runnable.uri)
 
     def test_exec_args(self):
-        parsed_args = {'kind': 'exec', 'uri': '/path/to/executable',
+        parsed_args = {'kind': 'exec-test', 'uri': '/path/to/executable',
                        'arg': ['-a', '-b', '-c']}
         runnable = Runnable.from_args(parsed_args)
-        self.assertEqual(runnable.kind, 'exec')
+        self.assertEqual(runnable.kind, 'exec-test')
         self.assertEqual(runnable.uri, '/path/to/executable')
         self.assertEqual(runnable.args, ('-a', '-b', '-c'))
         self.assertEqual(runnable.kwargs, {})
 
     def test_exec_args_kwargs(self):
-        parsed_args = {'kind': 'exec', 'uri': '/path/to/executable',
+        parsed_args = {'kind': 'exec-test', 'uri': '/path/to/executable',
                        'arg': ['-a', '-b', '-c'],
                        'kwargs': [('DEBUG', '1'), ('LC_ALL', 'C')]}
         runnable = Runnable.from_args(parsed_args)
-        self.assertEqual(runnable.kind, 'exec')
+        self.assertEqual(runnable.kind, 'exec-test')
         self.assertEqual(runnable.uri, '/path/to/executable')
         self.assertEqual(runnable.args, ('-a', '-b', '-c'))
         self.assertEqual(runnable.kwargs.get('DEBUG'), '1')
@@ -170,21 +170,21 @@ class RunnableToRecipe(unittest.TestCase):
         self.assertEqual(loaded_runnable.kind, 'noop')
 
     def test_runnable_to_recipe_uri(self):
-        runnable = Runnable('exec', '/bin/true')
+        runnable = Runnable('exec-test', '/bin/true')
         recipe_path = os.path.join(self.tmpdir.name, 'recipe.json')
         runnable.write_json(recipe_path)
         self.assertTrue(os.path.exists(recipe_path))
         loaded_runnable = Runnable.from_recipe(recipe_path)
-        self.assertEqual(loaded_runnable.kind, 'exec')
+        self.assertEqual(loaded_runnable.kind, 'exec-test')
         self.assertEqual(loaded_runnable.uri, '/bin/true')
 
     def test_runnable_to_recipe_args(self):
-        runnable = Runnable('exec', '/bin/sleep', '0.01')
+        runnable = Runnable('exec-test', '/bin/sleep', '0.01')
         recipe_path = os.path.join(self.tmpdir.name, 'recipe.json')
         runnable.write_json(recipe_path)
         self.assertTrue(os.path.exists(recipe_path))
         loaded_runnable = Runnable.from_recipe(recipe_path)
-        self.assertEqual(loaded_runnable.kind, 'exec')
+        self.assertEqual(loaded_runnable.kind, 'exec-test')
         self.assertEqual(loaded_runnable.uri, '/bin/sleep')
         self.assertEqual(loaded_runnable.args, ('0.01', ))
 

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -73,7 +73,7 @@ class RunnableTest(unittest.TestCase):
 
     def test_identifier_args(self):
         config = {'runner.identifier_format': '{uri}-{args[0]}'}
-        runnable = Runnable('exec-text', 'uri', 'arg1', 'arg2',
+        runnable = Runnable('exec-test', 'uri', 'arg1', 'arg2',
                             config=config)
         self.assertEqual(runnable.identifier, 'uri-arg1')
 


### PR DESCRIPTION
Some runners (like instrumented) need config values for proper working.
When we are running tasks by `avocado run` or Job API the default
configuration is inserted to runners via runnable. The problem starts
when you run test runner with `runnable-run` command even a small test
as 'avocado-runner runnable-run -k avocado-instrumented -u
examples/tests/passtest.py:PassTest.test` will fail because of missing
configuration. This PR solves this problem by adding default
configuration to the runnable.

Changes from v1 (#5313):
* Usage of features from #5326
It helps to add only necessary config for runners.

Cahnges from v2(#5363):
* The pick_runner_command as static method.
* Class method for creating Runnables with only essential config.
* Method for filtering config
* config setter doesn't filter the config, only logs warning when the config is not essential.

Signed-off-by: Jan Richter <jarichte@redhat.com>