### PR TITLE
Pre test plugins

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -62,6 +62,19 @@ class JobPrePostDispatcher(EnabledExtensionManager):
         super().__init__('avocado.plugins.job.prepost')
 
 
+class TestPreDispatcher(EnabledExtensionManager):
+
+    """
+    Calls extensions before Test execution
+
+    Automatically adds all the extension with entry points registered under
+    'avocado.plugins.test.pre'
+    """
+
+    def __init__(self):
+        super().__init__('avocado.plugins.test.pre')
+
+
 class ResultDispatcher(EnabledExtensionManager):
 
     def __init__(self):

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -162,6 +162,23 @@ class JobPostTests(Plugin):
         """Entry point for job running actions after the tests execution."""
 
 
+class PreTest(Plugin):
+    """Base plugin interface for adding tasks before a test run.
+
+    This interface helps to create `avocado.core.nrunner.Task` for running
+    additional actions inside spawner environment before Test.
+    """
+
+    @abc.abstractmethod
+    def pre_test_runnables(self, test_runnable):
+        """Entry point for creating runnables, which will be run before test.
+
+        :param test_runnable: Runnable of the Test itself.
+        :return: PreTest task runnables created by plugin.
+        :rtype: list of :class:`avocado.core.nrunner.Runnable`
+        """
+
+
 class ResultEvents(JobPreTests, JobPostTests):
     """Base plugin interface for event based (stream-able) results.
 

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from itertools import chain
 
-from avocado.core.dependencies.resolver import DependencyResolver
 from avocado.core.dispatcher import TestPreDispatcher
 from avocado.core.nrunner.task import Task
 from avocado.core.test_id import TestID
@@ -161,8 +160,6 @@ class PreRuntimeTask(RuntimeTask):
         pre_runnables = list(chain.from_iterable(
             TestPreDispatcher().map_method_with_return('pre_test_runnables',
                                                        runnable)))
-        if runnable.dependencies:
-            pre_runnables = pre_runnables + DependencyResolver.resolve(runnable)
         pre_test_tasks = []
         for pre_runnable in pre_runnables:
             pre_task = cls.from_runnable(pre_runnable,

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
+from itertools import chain
 
 from avocado.core.dependencies.resolver import DependencyResolver
+from avocado.core.dispatcher import TestPreDispatcher
 from avocado.core.nrunner.task import Task
 from avocado.core.test_id import TestID
 from avocado.core.varianter import dump_variant
@@ -26,6 +28,8 @@ class RuntimeTask:
         self.task = task
         #: Additional descriptive information about the task status
         self.status = None
+        #: Information about task result when it is finished
+        self.result = None
         #: Timeout limit for the completion of the task execution
         self.execution_timeout = None
         #: A handle that may be set by a spawner, and that may be
@@ -55,10 +59,17 @@ class RuntimeTask:
             return hash(self) == hash(other)
         return False
 
+    def are_dependencies_finished(self):
+        for dependency in self.dependencies:
+            if not dependency.status or not ("FINISHED" in dependency.status
+                                             or "FAILED" in dependency.status):
+                return False
+        return True
+
     @classmethod
-    def get_test_from_runnable(cls, runnable, no_digits, index, variant,
-                               test_suite_name=None, status_server_uri=None,
-                               job_id=None):
+    def from_runnable(cls, runnable, no_digits, index, variant,
+                      test_suite_name=None, status_server_uri=None,
+                      job_id=None):
         """Creates runtime task for test from runnable
 
         :param runnable: the "description" of what the task should run.
@@ -76,7 +87,7 @@ class RuntimeTask:
                        sent to the destination job's status server and will
                        make into the job's results.
         :type job_id: str
-        :returns: RUntimeTask of the test from runnable
+        :returns: RuntimeTask of the test from runnable
         """
 
         # create test ID
@@ -98,10 +109,41 @@ class RuntimeTask:
                     job_id=job_id)
         return cls(task)
 
+
+class PreRuntimeTask(RuntimeTask):
+
     @classmethod
-    def get_dependencies_form_runnable(cls, runnable, status_server_uri=None,
-                                       job_id=None):
-        """Creates runtime tasks for dependencies from runnable
+    def from_runnable(cls, pre_runnable, status_server_uri=None, job_id=None):  # pylint: disable=W0221
+        """Creates runtime task for pre_test plugin from runnable
+
+        :param pre_runnable: the "description" of what the task should run.
+        :type runnable: :class:`avocado.core.nrunner.Runnable`
+        :param status_server_uri: the URIs for the status servers that this
+                                  task should send updates to.
+        :type status_server_uri: list
+        :param job_id: the ID of the job, for authenticating messages that get
+                       sent to the destination job's status server and will
+                       make into the job's results.
+        :type job_id: str
+        :returns: RuntimeTask of the test from runnable
+        """
+        name = f'{pre_runnable.kind}-{pre_runnable.kwargs.get("name")}'
+        prefix = 0
+        # the human UI works with TestID objects, so we need to
+        # use it to name Task
+        task_id = TestID(prefix, name)
+        # creates the dependency task
+        task = Task(pre_runnable,
+                    identifier=task_id,
+                    status_uris=status_server_uri,
+                    category='pre_test',
+                    job_id=job_id)
+        return cls(task)
+
+    @classmethod
+    def get_pre_tasks_from_runnable(cls, runnable, status_server_uri=None,
+                                    job_id=None):
+        """Creates runtime tasks for preTest task from runnable
 
         :param runnable: the "description" of what the task should run.
         :type runnable: :class:`avocado.core.nrunner.Runnable`
@@ -112,42 +154,22 @@ class RuntimeTask:
                        sent to the destination job's status server and will
                        make into the job's results.
         :type job_id: str
-        :returns: RUntimeTasks of the dependencies from runnable
+        :returns: Pre RuntimeTasks of the dependencies from runnable
         :rtype: list
         """
-        if runnable.dependencies is None:
-            return []
 
-        # creates the runnables for the dependencies
-        dependencies_runnables = DependencyResolver.resolve(runnable)
-        dependencies_runtime_tasks = []
-        # creates the tasks and runtime tasks for the dependencies
-        for dependency_runnable in dependencies_runnables:
-            name = (f"{dependency_runnable.kind}-"
-                    f"{dependency_runnable.kwargs.get('name')}")
-            prefix = 0
-            # the human UI works with TestID objects, so we need to
-            # use it to name Task
-            task_id = TestID(prefix, name)
-            # with --dry-run we don't want to run dependencies
-            if runnable.kind == 'dry-run':
-                dependency_runnable.kind = 'noop'
-            # creates the dependency task
-            dependency_task = Task(dependency_runnable,
-                                   identifier=task_id,
-                                   status_uris=status_server_uri,
-                                   category='dependency',
-                                   job_id=job_id)
-            dependencies_runtime_tasks.append(cls(dependency_task))
-
-        return dependencies_runtime_tasks
-
-    def is_dependencies_finished(self):
-        for dependency in self.dependencies:
-            if not dependency.status or not ("FINISHED" in dependency.status
-                                             or "FAILED" in dependency.status):
-                return False
-        return True
+        pre_runnables = list(chain.from_iterable(
+            TestPreDispatcher().map_method_with_return('pre_test_runnables',
+                                                       runnable)))
+        if runnable.dependencies:
+            pre_runnables = pre_runnables + DependencyResolver.resolve(runnable)
+        pre_test_tasks = []
+        for pre_runnable in pre_runnables:
+            pre_task = cls.from_runnable(pre_runnable,
+                                         status_server_uri,
+                                         job_id)
+            pre_test_tasks.append(pre_task)
+        return pre_test_tasks
 
 
 class RuntimeTaskGraph:
@@ -176,30 +198,35 @@ class RuntimeTaskGraph:
         no_digits = len(str(len(tests)))
         for index, (runnable, variant) in enumerate(tests, start=1):
             runnable = deepcopy(runnable)
-            runtime_test = RuntimeTask.get_test_from_runnable(
-                runnable,
-                no_digits,
-                index,
-                variant,
-                test_suite_name,
-                status_server_uri,
-                job_id)
+            runtime_test = RuntimeTask.from_runnable(runnable,
+                                                     no_digits,
+                                                     index, variant,
+                                                     test_suite_name,
+                                                     status_server_uri,
+                                                     job_id)
             self.graph[runtime_test] = runtime_test
 
-            dependencies_tasks = RuntimeTask.get_dependencies_form_runnable(
-                runnable,
-                status_server_uri,
-                job_id)
-            self._connect_dependencies_with_test(dependencies_tasks,
-                                                 runtime_test)
+            # with --dry-run we don't want to run dependencies
+            if runnable.kind != 'dry-run':
+                pre_tasks = PreRuntimeTask.get_pre_tasks_from_runnable(
+                    runnable,
+                    status_server_uri,
+                    job_id)
+                self._connect_tasks(pre_tasks, [runtime_test])
 
-    def _connect_dependencies_with_test(self, dependencies, runtime_test):
-        for dependency_task in dependencies:
-            if dependency_task in self.graph:
-                dependency_task = self.graph.get(dependency_task)
+    def _connect_tasks(self, dependencies, tasks):
+        def _get_task_from_graph(task):
+            if task in self.graph:
+                task = self.graph.get(task)
             else:
-                self.graph[dependency_task] = dependency_task
-            runtime_test.dependencies.append(dependency_task)
+                self.graph[task] = task
+            return task
+
+        for dependency_task in dependencies:
+            dependency_task = _get_task_from_graph(dependency_task)
+            for task in tasks:
+                task = _get_task_from_graph(task)
+                task.dependencies.append(dependency_task)
 
     def get_tasks_in_topological_order(self):
         """Computes the topological order of runtime tasks in graph

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -205,7 +205,7 @@ class Worker:
         # handle task dependencies
         if runtime_task.dependencies:
             # check of all the dependency tasks finished
-            if not runtime_task.is_dependencies_finished():
+            if not runtime_task.are_dependencies_finished():
                 async with self._state_machine.lock:
                     self._state_machine.triaging.append(runtime_task)
                     runtime_task.status = 'WAITING DEPENDENCIES'

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -23,8 +23,9 @@ from datetime import datetime
 from avocado.core import exit_codes, safeloader
 from avocado.core.nrunner.runnable import Runnable
 from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import CLICmd, JobPreTests
+from avocado.core.plugin_interfaces import CLICmd, JobPreTests, PreTest
 from avocado.core.settings import settings
+from avocado.plugins.pretest import pre_test
 from avocado.utils import data_structures
 from avocado.utils.asset import SUPPORTED_OPERATORS, Asset
 from avocado.utils.astring import iter_tabular_output
@@ -282,6 +283,19 @@ class FetchAssetJob(JobPreTests):  # pylint: disable=R0903
 
         for candidate in candidates:
             fetch_assets(*candidate, logger)
+
+
+class AssetPreTest(PreTest):
+    """Implements the asset pre tests plugin.
+
+    It will create pre-test tasks for fetching assets based on the
+     `:avocado: dependency=` definition inside the test’s docstring.
+    """
+    name = "asset requirement"
+    description = "Fetch of files using the Avocado Assets utility."
+
+    def pre_test_runnables(self, test_runnable):
+        return pre_test.pre_test_runnables(test_runnable, "asset")
 
 
 class Assets(CLICmd):

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -54,6 +54,8 @@ class Plugins(CLICmd):
              'Plugins that add new options to commands (cli):'),
             (dispatcher.JobPrePostDispatcher(),
              'Plugins that run before/after the execution of jobs (job.prepost):'),
+            (dispatcher.TestPreDispatcher(),
+             'Plugins that run before the execution of each test (test.pre):'),
             (dispatcher.ResultDispatcher(),
              'Plugins that generate job result in different formats (result):'),
             (dispatcher.ResultEventsDispatcher(config),

--- a/avocado/plugins/pretest/package.py
+++ b/avocado/plugins/pretest/package.py
@@ -1,0 +1,29 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2022
+# Authors: Jan Richter <jarichte@redhat.com>
+
+from avocado.core.plugin_interfaces import PreTest
+from avocado.plugins.pretest import pre_test
+
+
+class PackagePreTest(PreTest):
+    """Implements the package pre tests plugin.
+
+    It will create pre-test tasks for managing packages based on the
+     `:avocado: dependency=` definition inside the test’s docstring.
+    """
+    name = "package requirement"
+    description = "Management of packages by the Software Manager utility."
+
+    def pre_test_runnables(self, test_runnable):
+        return pre_test.pre_test_runnables(test_runnable, "package")

--- a/avocado/plugins/pretest/pre_test.py
+++ b/avocado/plugins/pretest/pre_test.py
@@ -1,0 +1,31 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2022
+# Authors: Jan Richter <jarichte@redhat.com>
+
+from avocado.core.nrunner.runnable import Runnable
+
+
+def pre_test_runnables(test_runnable, kind):
+    runnables = []
+    if test_runnable.dependencies:
+        for dependency in test_runnable.dependencies:
+            if dependency['type'] == kind:
+                # make a copy to change the dictionary and do not affect
+                # the original `dependencies` dictionary from the test
+                dependency_copy = dependency.copy()
+                kind = dependency_copy.pop('type')
+                runnable = Runnable(kind, None,
+                                    config=test_runnable.config,
+                                    **dependency_copy)
+                runnables.append(runnable)
+    return runnables

--- a/docs/source/guides/user/chapters/plugins.rst
+++ b/docs/source/guides/user/chapters/plugins.rst
@@ -166,7 +166,7 @@ test phases.  Here's a sequence of the job phases:
 4) :meth:`Post tests hook <avocado.core.job.Job.post_tests>`
 
 Plugin writers can have their own code called at Avocado during a job
-by writing a that will be called at phase number 2 (``pre_tests``) by
+that will be called at phase number 2 (``pre_tests``) by
 writing a method according to the
 :meth:`avocado.core.plugin_interfaces.JobPreTests` interface.
 Accordingly, plugin writers can have their own called at phase number

--- a/selftests/unit/plugin/test_package.py
+++ b/selftests/unit/plugin/test_package.py
@@ -1,17 +1,17 @@
 import unittest
 
-from avocado.core.dependencies.resolver import DependencyResolver
 from avocado.core.nrunner.runnable import Runnable
+from avocado.plugins.pretest.package import PackagePreTest
 
 
 class BasicTests(unittest.TestCase):
-    """Basic unit tests for the RequirementResolver class"""
+    """Basic unit tests for the PackagePreTest class"""
 
-    def test_dependencies_runnables(self):
+    def test_package_runnables(self):
         runnable = Runnable(kind='package', uri=None,
                             dependencies=[{'type': 'package', 'name': 'foo'},
                                           {'type': 'package', 'name': 'bar'}])
-        dependency_runnables = DependencyResolver.resolve(runnable)
+        dependency_runnables = PackagePreTest().pre_test_runnables(runnable)
         kind = 'package'
         self.assertEqual(kind, dependency_runnables[0].kind)
         self.assertEqual(kind, dependency_runnables[1].kind)

--- a/setup.py
+++ b/setup.py
@@ -371,6 +371,7 @@ if __name__ == '__main__':
                   ],
               'avocado.plugins.test.pre': [
                   'package = avocado.plugins.pretest.package:PackagePreTest',
+                  'asset = avocado.plugins.asset:AssetPreTest',
                   ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',

--- a/setup.py
+++ b/setup.py
@@ -369,6 +369,9 @@ if __name__ == '__main__':
                   'human = avocado.plugins.human:HumanJob',
                   'testlogsui = avocado.plugins.testlogs:TestLogsUI',
                   ],
+              'avocado.plugins.test.pre': [
+                  'package = avocado.plugins.pretest.package:PackagePreTest',
+                  ],
               'avocado.plugins.result': [
                   'xunit = avocado.plugins.xunit:XUnitResult',
                   'json = avocado.plugins.jsonresult:JSONResult',


### PR DESCRIPTION
Infrastructure for creating pre-test plugins. Such plugin will
be able to add tasks before or after the test task.

It is based on a Draft  #5281

Reference: #5204
Signed-off-by: Jan Richter [jarichte@redhat.com](mailto:jarichte@redhat.com)