### PR TITLE
task.timeout.running fix

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -328,6 +328,15 @@ class Spawner(Plugin):
         :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
         """
 
+    @abc.abstractmethod
+    async def terminate_task(self, runtime_task):
+        """Terminates a task before finish.
+
+        :param runtime_task: wrapper for a Task with additional runtime
+                             information.
+        :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
+        """
+
     @staticmethod
     @abc.abstractmethod
     async def check_task_requirements(runtime_task):

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -40,6 +40,9 @@ class MockSpawner(Spawner):
                 return
             await asyncio.sleep(0.1)
 
+    async def terminate_task(self, runtime_task):
+        self._known_tasks[runtime_task] = False
+
     @staticmethod
     async def check_task_requirements(runtime_task):
         return True

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -280,6 +280,14 @@ class Worker:
                 runtime_task.status = 'FINISHED'
             except asyncio.TimeoutError:
                 runtime_task.status = 'FINISHED W/ TIMEOUT'
+                await self._spawner.terminate_task(runtime_task)
+                message = {'status': 'finished',
+                           'result': 'interrupted',
+                           'fail_reason': 'Test interrupted: Timeout reached',
+                           'time': time.monotonic(),
+                           'id': str(runtime_task.task.identifier),
+                           'job_id': runtime_task.task.job_id}
+                self._state_machine._status_repo.process_message(message)
         result_stats = set(key.upper()for key in
                            self._state_machine._status_repo.result_stats.keys())
         if self._failfast and not result_stats.isdisjoint(STATUSES_NOT_OK):

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -278,6 +278,15 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
                 return
             await asyncio.sleep(0.1)
 
+    async def terminate_task(self, runtime_task):
+        try:
+            await self.podman.stop(runtime_task.spawner_handle)
+        except PodmanException as ex:
+            msg = f"Could not stop container: {ex}"
+            runtime_task.status = msg
+            LOG.error(msg)
+            return False
+
     @staticmethod
     async def check_task_requirements(runtime_task):
         """Check the runtime task requirements needed to be able to run"""

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -54,6 +54,10 @@ class ProcessSpawner(Spawner, SpawnerMixin):
         await runtime_task.spawner_handle.wait()
 
     @staticmethod
+    async def terminate_task(runtime_task):
+        runtime_task.spawner_handle.terminate()
+
+    @staticmethod
     async def check_task_requirements(runtime_task):
         """Check the runtime task requirements needed to be able to run"""
         # right now, limit the check to the runner availability.

--- a/avocado/utils/podman.py
+++ b/avocado/utils/podman.py
@@ -125,3 +125,14 @@ class Podman:
             return await self.execute("start", container_id)
         except PodmanException as ex:
             raise PodmanException("Failed to start the container.") from ex
+
+    async def stop(self, container_id):
+        """Stops a container and return the returncode, stdout and stderr.
+
+        :param str container_id: Container identification string to stop.
+        :rtype: tuple with returncode, stdout and stderr.
+        """
+        try:
+            return await self.execute("stop", "-t=0", container_id)
+        except PodmanException as ex:
+            raise PodmanException("Failed to stop the container.") from ex

--- a/selftests/functional/plugin/spawners/test_podman.py
+++ b/selftests/functional/plugin/spawners/test_podman.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import unittest
 
+from avocado.core.job import Job
 from avocado.utils import process, script
 from selftests.utils import AVOCADO, TestCaseTmpDir
 
@@ -12,6 +13,16 @@ class PassTest(Test):
 
     def test(self):
         pass
+"""
+
+TEST_INSTRUMENTED_SLEEP = """import time
+from avocado import Test
+
+
+class PassTest(Test):
+
+    def test(self):
+        time.sleep(10)
 """
 
 
@@ -41,3 +52,22 @@ class PodmanSpawnerTest(TestCaseTmpDir):
         self.assertEqual(result.exit_status, 0)
         self.assertIn("/bin/true: STARTED", result.stdout_text)
         self.assertIn("/bin/true:  PASS", result.stdout_text)
+
+    def test_sleep_longer_timeout_podman(self):
+
+        with script.Script(os.path.join(self.tmpdir.name, "sleeptest.py"),
+                           TEST_INSTRUMENTED_SLEEP) as test:
+            config = {'resolver.references': [test.path],
+                      'run.results_dir': self.tmpdir.name,
+                      'task.timeout.running': 2,
+                      'nrunner.spawner': 'podman',
+                      'spawner.podman.image': 'fedora:latest'}
+
+            with Job.from_config(job_config=config) as job:
+                job.run()
+
+        self.assertEqual(1, job.result.interrupted)
+        self.assertEqual(0, job.result.passed)
+        self.assertEqual(0, job.result.skipped)
+        self.assertEqual('Test interrupted: Timeout reached',
+                         job.result.tests[0]['fail_reason'])

--- a/selftests/functional/test_task_timeout.py
+++ b/selftests/functional/test_task_timeout.py
@@ -27,8 +27,11 @@ class TaskTimeOutTest(TestCaseTmpDir):
         with Job.from_config(job_config=config) as job:
             job.run()
 
-        self.assertEqual(1, job.result.skipped)
+        self.assertEqual(1, job.result.interrupted)
         self.assertEqual(0, job.result.passed)
+        self.assertEqual(0, job.result.skipped)
+        self.assertEqual('Test interrupted: Timeout reached',
+                         job.result.tests[0]['fail_reason'])
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
In the current avocado version, the `task.timeout.running` option wasn't
working. Because we didn't have a mechanism for interrupting tasks after
the timeout reached. This PR adds an ability to spawners to
terminate the pawned task when it is necessary.

It fixes the #5383, but it also helps with solving problems with post
test plugins.

Reference: #5383
Signed-off-by: Jan Richter <jarichte@redhat.com>