### PR TITLE
Selftests: skip tests if modules and commands are not available

### DIFF
--- a/selftests/functional/test_interrupt.py
+++ b/selftests/functional/test_interrupt.py
@@ -5,11 +5,15 @@ import subprocess
 import time
 import unittest
 
-import psutil
-
 from avocado.utils import data_factory, process, script, wait
 from selftests.utils import (AVOCADO, BASEDIR, TestCaseTmpDir,
                              skipOnLevelsInferiorThan)
+
+try:
+    import psutil
+    PSUTIL_AVAILABLE = True
+except ImportError:
+    PSUTIL_AVAILABLE = False
 
 # What is commonly known as "0755" or "u=rwx,g=rx,o=rx"
 DEFAULT_MODE = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
@@ -49,6 +53,7 @@ if __name__ == "__main__":
 """
 
 
+@unittest.skipUnless(PSUTIL_AVAILABLE, "psutil module not available")
 class InterruptTest(TestCaseTmpDir):
 
     @staticmethod

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -10,7 +10,7 @@ import sys
 import time
 import unittest
 
-from avocado.utils import linux_modules, lv_utils, process
+from avocado.utils import linux_modules, lv_utils, path, process
 from selftests.utils import TestCaseTmpDir
 
 
@@ -22,7 +22,7 @@ class LVUtilsTest(TestCaseTmpDir):
 
     @unittest.skipIf(sys.platform.startswith('darwin'),
                      'macOS does not support LVM')
-    @unittest.skipIf(process.system("which vgs", ignore_status=True),
+    @unittest.skipIf(path.find_command("vgs", default=False),
                      "LVM utils not installed (command vgs is missing)")
     @unittest.skipIf(not process.can_sudo(), "This test requires root or "
                      "passwordless sudo configured.")
@@ -114,7 +114,7 @@ class DiskSpace(unittest.TestCase):
                      'macOS does not support scsi_debug module')
     @unittest.skipIf(not process.can_sudo(), "This test requires root or "
                      "passwordless sudo configured.")
-    @unittest.skipIf(process.system("which modprobe", ignore_status=True),
+    @unittest.skipIf(path.find_command("modprobe", default=False),
                      "kmod not installed (command modprobe is missing)")
     def test_get_diskspace(self):
         """

--- a/selftests/unit/utils/test_iso9660.py
+++ b/selftests/unit/utils/test_iso9660.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import unittest.mock
 
-from avocado.utils import iso9660, process
+from avocado.utils import iso9660, path, process
 from selftests.utils import setup_avocado_loggers, temp_dir_prefix
 
 setup_avocado_loggers()
@@ -105,8 +105,8 @@ class IsoInfo(BaseIso9660, unittest.TestCase):
     IsoInfo-based check
     """
 
-    @unittest.skipIf(process.system("which isoinfo", ignore_status=True),
-                     "isoinfo not installed.")
+    @unittest.skipUnless(path.find_command("isoinfo", default=False),
+                         "isoinfo not installed.")
     def setUp(self):
         super().setUp()
         self.iso = iso9660.Iso9660IsoInfo(self.iso_path)
@@ -118,8 +118,8 @@ class IsoRead(BaseIso9660, unittest.TestCase):
     IsoRead-based check
     """
 
-    @unittest.skipIf(process.system("which iso-read", ignore_status=True),
-                     "iso-read not installed.")
+    @unittest.skipUnless(path.find_command("iso-read", default=False),
+                         "iso-read not installed.")
     def setUp(self):
         super().setUp()
         self.iso = iso9660.Iso9660IsoRead(self.iso_path)
@@ -159,11 +159,11 @@ class PyCDLib(BaseIso9660, unittest.TestCase):
         new_iso = iso9660.ISO9660PyCDLib(new_iso_path)
         new_iso.create()
         content = b"AVOCADO"
-        for path in ("README", "/readme", "readme.txt", "quite-long-readme.txt"):
-            new_iso.write(path, content)
+        for file_path in ("README", "/readme", "readme.txt", "quite-long-readme.txt"):
+            new_iso.write(file_path, content)
             new_iso.close()
             read_iso = iso9660.ISO9660PyCDLib(new_iso_path)
-            self.assertEqual(read_iso.read(path), content)
+            self.assertEqual(read_iso.read(file_path), content)
             self.assertTrue(os.path.isfile(new_iso_path))
 
 


### PR DESCRIPTION
This is an attempt to allow for a more Pythonic development workflow,
allowing Avocado selftests to run on a simpler environment than it's
currently required.

Basically, if one has a system with both Python and setuptools,
(core) Avocado should be able to run.  Conversely, I believe if the
same system has the Avocado source code, after a "python setup.py
develop" of sorts, the selftests should be able to run.

To accomplish this, it's necessary to make the extra requirements (not
defined in the setup.py files) *really* optional while running the
tests.

This removes the requirements to have the "psutil" and "jsonschema"
Python modules, and the "which" binary (usually from the package of
same name).

After this, it's possible to test Avocado from scratch with a workflow
such as:

   $ podman run --rm -ti fedora:35

Then, from inside the container:

   $ dnf -y install python3-setuptools
   $ python3 setup.py develop
   $ python3 setup.py test --skip static-checks

Signed-off-by: Cleber Rosa <crosa@redhat.com>