### PR TITLE
Propagate avocado tags to results

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -163,6 +163,7 @@ class FinishMessageHandler(BaseMessageHandler):
         message['time_elapsed'] = time_elapsed
 
         message['logdir'] = task.metadata['task_path']
+        message['tags'] = task.runnable.get_serializable_tags()
 
         if task.category == 'test':
             job.result.check_test(message)

--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -245,6 +245,8 @@ class Runnable:
         return json.dumps(self.get_dict(), cls=ConfigEncoder)
 
     def get_serializable_tags(self):
+        if self.tags is None:
+            return {}
         tags = {}
         # sets are not serializable in json
         for key, val in self.tags.items():

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -42,7 +42,6 @@ class JSONResult(Result):
             fail_reason = test.get('fail_reason', UNKNOWN)
             if fail_reason is not None:
                 fail_reason = astring.to_text(fail_reason)
-            tags = test.get('tags') or {}
             # Actually we are saving the TestID() there.
             test_id = test.get('name', UNKNOWN)
             if isinstance(test_id, TestID):
@@ -53,7 +52,7 @@ class JSONResult(Result):
                           'end': test.get('time_end', -1),
                           'time': test.get('time_elapsed', -1),
                           'status': test.get('status', {}),
-                          'tags': {k: list(v or {}) for k, v in tags.items()},
+                          'tags': test.get('tags') or {},
                           'whiteboard': test.get('whiteboard', UNKNOWN),
                           'logdir': test.get('logdir', UNKNOWN),
                           'logfile': test.get('logfile', UNKNOWN),

--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -29,3 +29,14 @@ class JsonResultTest(TestCaseTmpDir):
             test_data = data['tests'].pop()
             self.assertEqual('This test is supposed to fail',
                              test_data['fail_reason'])
+
+    def test_tags_in_result(self):
+        cmd_line = (f'{AVOCADO} run examples/tests/failtest.py '
+                    f'--job-results-dir {self.tmpdir.name} --disable-sysinfo')
+        process.run(cmd_line, ignore_status=True)
+        json_path = path.join(self.tmpdir.name, 'latest', 'results.json')
+        with open(json_path, 'r', encoding='utf-8') as json_file:
+            data = json.load(json_file)
+            test_data = data['tests'][0]
+            self.assertEqual({'failure_expected': None},
+                             test_data['tags'])


### PR DESCRIPTION
This will fix the problem where the tag attribute in the result was
empty because the avocado test tags wasn't propagated to the results.
This will help to recognize which tags were used for each test.

Reference:  #5387
Signed-off-by: Jan Richter <jarichte@redhat.com>