### PR TITLE
Drop unused module level variable in the podman spawner

### DIFF
--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -15,9 +15,6 @@ from avocado.utils.podman import Podman, PodmanException
 LOG = logging.getLogger(__name__)
 
 
-ENTRY_POINT_CMD = "/tmp/avocado-runner"
-
-
 class PodmanSpawnerInit(Init):
 
     description = 'Podman (container) based spawner initialization'


### PR DESCRIPTION
After the migration to eggs and more sophisticated avocado deployment this is no longer necessary.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>