### PR TITLE
Podman spawner with volumes for tests

### DIFF
--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -181,6 +181,19 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
                             'avocado.core.nrunner',
                             'task-run']
 
+        test_opts = ()
+        if runtime_task.task.category == 'test':
+            runnable_uri = runtime_task.task.runnable.uri
+            try:
+                test_path, _ = runnable_uri.split(':', 1)
+            except ValueError:
+                test_path = runnable_uri
+            if os.path.exists(test_path):
+                to = os.path.join('/tmp', test_path)
+                runtime_task.task.runnable.uri = os.path.join('/tmp',
+                                                              runnable_uri)
+                test_opts = ("-v", f"{os.path.abspath(test_path)}:{to}:ro")
+
         task = runtime_task.task
         entry_point_args.extend(task.get_command_args())
         entry_point = json.dumps(entry_point_args)
@@ -209,6 +222,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             _, stdout, _ = await self.podman.execute("create",
                                                      *status_server_opts,
                                                      *output_opts,
+                                                     *test_opts,
                                                      entry_point_arg,
                                                      *envs,
                                                      image)

--- a/selftests/functional/plugin/spawners/test_podman.py
+++ b/selftests/functional/plugin/spawners/test_podman.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+import unittest
+
+from avocado.utils import process, script
+from selftests.utils import AVOCADO, TestCaseTmpDir
+
+TEST_INSTRUMENTED_PASS = """from avocado import Test
+
+
+class PassTest(Test):
+
+    def test(self):
+        pass
+"""
+
+
+@unittest.skipIf(shutil.which('podman') is None,
+                 "Podman not installed (command podman is missing)")
+class PodmanSpawnerTest(TestCaseTmpDir):
+
+    def test_avocado_instrumented(self):
+
+        with script.Script(os.path.join(self.tmpdir.name, "passtest.py"),
+                           TEST_INSTRUMENTED_PASS) as test:
+            result = process.run(f"{AVOCADO} run "
+                                 f"--job-results-dir {self.tmpdir.name} "
+                                 f"--disable-sysinfo --nrunner-spawner=podman "
+                                 f"--spawner-podman-image=fedora:latest -- "
+                                 f"{test}", ignore_status=True)
+        self.assertEqual(result.exit_status, 0)
+        self.assertIn("passtest.py:PassTest.test: STARTED", result.stdout_text)
+        self.assertIn("passtest.py:PassTest.test:  PASS", result.stdout_text)
+
+    def test_exec(self):
+        result = process.run(f"{AVOCADO} run "
+                             f"--job-results-dir {self.tmpdir.name} "
+                             f"--disable-sysinfo --nrunner-spawner=podman "
+                             f"--spawner-podman-image=fedora:latest -- "
+                             f"/bin/true", ignore_status=True)
+        self.assertEqual(result.exit_status, 0)
+        self.assertIn("/bin/true: STARTED", result.stdout_text)
+        self.assertIn("/bin/true:  PASS", result.stdout_text)


### PR DESCRIPTION
This adds the ability of podman spawner to create read-only volumes for
tests. Because of this, the avocado runners will be able to find test
files inside the container based on runnable uri. With this change is
possible to run exec-tests and avocado-instrumented tests with podman
spawner.

Signed-off-by: Jan Richter <jarichte@redhat.com>