### PR TITLE
Fedora 35 CI container: remove duplicate python3-jsonschema install

### DIFF
--- a/contrib/containers/ci/selftests/fedora-35.docker
+++ b/contrib/containers/ci/selftests/fedora-35.docker
@@ -2,9 +2,5 @@ FROM fedora:35
 LABEL description "Fedora image used on integration checks"
 RUN dnf -y module enable avocado:latest
 RUN dnf -y install dnf-plugins-core git findutils make which
-# python3-jsonschema is a new build requirement introduced in the 97.0
-# development cycle. REMOVE after Avocado 97.0 is available on
-# Fedora's "avocado:latest" stream
-RUN dnf -y install python3-jsonschema
 RUN dnf -y builddep python-avocado
 RUN dnf -y clean all

--- a/contrib/containers/ci/selftests/fedora-35.docker
+++ b/contrib/containers/ci/selftests/fedora-35.docker
@@ -1,5 +1,5 @@
 FROM fedora:35
-LABEL description "Fedora image used on integration checks, such as cirrus-ci"
+LABEL description "Fedora image used on integration checks"
 RUN dnf -y module enable avocado:latest
 RUN dnf -y install dnf-plugins-core git findutils make which
 # python3-jsonschema is a new build requirement introduced in the 97.0


### PR DESCRIPTION
As explained in 39eccf80cd, the manual install was needed until an RPM
version with `python3-jsonschema` as a `BuildRequirement` hit the official repos.
    
It has happened with Avocado 97.0 RPMs, so we can now remove this manual (and now duplicate) step.