### PR TITLE
avocado/core/nrunner/task.py: remove unused spawn_handle attribute

### DIFF
--- a/avocado/core/nrunner/task.py
+++ b/avocado/core/nrunner/task.py
@@ -106,7 +106,6 @@ class Task:
                 status_uris = [status_uris]
             for status_uri in status_uris:
                 self.status_services.append(TaskStatusService(status_uri))
-        self.spawn_handle = None
         self.metadata = {}
 
     def __repr__(self):


### PR DESCRIPTION
This Task attribute is not used, having the RuntimeTask
"spawner_handle" attribute taken its place.

Signed-off-by: Cleber Rosa <crosa@redhat.com>