### PR TITLE
functional/utils/test_podman.py: convert test to async

### DIFF
--- a/selftests/functional/utils/test_podman.py
+++ b/selftests/functional/utils/test_podman.py
@@ -1,18 +1,14 @@
-import asyncio
-
 from avocado import Test
 from avocado.utils.podman import Podman
 
 
 class PodmanTest(Test):
 
-    def test_python_version(self):
+    async def test_python_version(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
         :avocado: tags=slow
         """
         podman = Podman()
-        loop = asyncio.get_event_loop()
-        coro = podman.get_python_version('fedora:34')
-        result = loop.run_until_complete(coro)
+        result = await podman.get_python_version('fedora:34')
         self.assertEqual(result, (3, 9, '/usr/bin/python3'))


### PR DESCRIPTION
The core of the test interacts with an async method, so it's easier to
have the test itself as an async based test.

Signed-off-by: Cleber Rosa <crosa@redhat.com>