### PR TITLE
Introduce podman-image runner/dependency

### DIFF
--- a/avocado/core/dependencies/resolver.py
+++ b/avocado/core/dependencies/resolver.py
@@ -17,9 +17,6 @@ from avocado.core.nrunner.runnable import Runnable
 
 class DependencyResolver:
 
-    name = 'dependency'
-    description = 'Dependency resolver for tests with dependencies'
-
     @staticmethod
     def resolve(runnable):
         dependency_runnables = []

--- a/avocado/core/dependencies/resolver.py
+++ b/avocado/core/dependencies/resolver.py
@@ -25,7 +25,10 @@ class DependencyResolver:
             # original `dependencies` dictionary from the test
             dependency_copy = dependency.copy()
             kind = dependency_copy.pop('type')
-            dependency_runnable = Runnable(kind, None, config=runnable.config,
+            uri = dependency_copy.pop('uri', None)
+            args = dependency_copy.pop('args', ())
+            dependency_runnable = Runnable(kind, uri, *args,
+                                           config=runnable.config,
                                            **dependency_copy)
             dependency_runnables.append(dependency_runnable)
         return dependency_runnables

--- a/avocado/plugins/runners/podman_image.py
+++ b/avocado/plugins/runners/podman_image.py
@@ -1,0 +1,71 @@
+import asyncio
+import time
+from multiprocessing import Process, SimpleQueue
+
+from avocado.core.nrunner.app import BaseRunnerApp
+from avocado.core.nrunner.runner import RUNNER_RUN_STATUS_INTERVAL, BaseRunner
+from avocado.core.utils import messages
+from avocado.utils.podman import Podman, PodmanException
+
+
+class PodmanImageRunner(BaseRunner):
+    """Runner for dependencies of type podman-image
+
+    This runner handles download and verification.
+
+    Runnable attributes usage:
+
+     * kind: 'podman-image'
+
+     * uri: the name of the image
+
+     * args: not used
+    """
+
+    name = 'podman-image'
+    description = f'Runner for dependencies of type {name}'
+
+    def _run_podman_pull(self, uri, queue):
+        try:
+            podman = Podman()
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(podman.execute('pull', uri))
+            result = 'pass'
+        except PodmanException:
+            result = 'fail'
+        queue.put({'result': result})
+
+    def run(self, runnable):
+        # pylint: disable=W0201
+        self.runnable = runnable
+        yield messages.StartedMessage.get()
+
+        if not runnable.uri:
+            reason = 'uri identifying the podman image is required'
+            yield messages.FinishedMessage.get('error', reason)
+        else:
+            queue = SimpleQueue()
+            process = Process(target=self._run_podman_pull,
+                              args=(runnable.uri, queue))
+            process.start()
+            while queue.empty():
+                time.sleep(RUNNER_RUN_STATUS_INTERVAL)
+                yield messages.RunningMessage.get()
+
+            output = queue.get()
+            yield messages.FinishedMessage.get(output['result'])
+
+
+class RunnerApp(BaseRunnerApp):
+    PROG_NAME = f'avocado-runner-{PodmanImageRunner.name}'
+    PROG_DESCRIPTION = (PodmanImageRunner.description)
+    RUNNABLE_KINDS_CAPABLE = [PodmanImageRunner.name]
+
+
+def main():
+    app = RunnerApp(print)
+    app.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -28,7 +28,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-avocado
 Version: 97.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2+ and GPLv2 and MIT
 URL: https://avocado-framework.github.io/
 %if 0%{?rel_build}
@@ -197,6 +197,7 @@ PATH=%{buildroot}%{_bindir}:%{buildroot}%{_libexecdir}/avocado:$PATH \
 %{_bindir}/avocado-runner-tap
 %{_bindir}/avocado-runner-asset
 %{_bindir}/avocado-runner-package
+%{_bindir}/avocado-runner-podman-image
 %{_bindir}/avocado-runner-sysinfo
 %{_bindir}/avocado-software-manager
 %{_bindir}/avocado-external-runner
@@ -376,6 +377,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Thu Jun  9 2022 Cleber Rosa <crosa@redhat.com> - 97.0-2
+- Added new avocado-runner-podman-image script
+
 * Tue May 24 2022 Cleber Rosa <crosa@redhat.com> - 97.0-1
 - New release
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -546,6 +546,11 @@ def create_suites(args):  # pylint: disable=W0621
              'runnable-run-no-args-exit-code': 0,
              'runnable-run-uri-only-exit-code': 0,
              'task-run-id-only-exit-code': 0},
+
+            {'runner': 'avocado-runner-podman-image',
+             'runnable-run-no-args-exit-code': 0,
+             'runnable-run-uri-only-exit-code': 0,
+             'task-run-id-only-exit-code': 0},
         ]
     }
 

--- a/selftests/functional/utils/test_podman.py
+++ b/selftests/functional/utils/test_podman.py
@@ -9,6 +9,7 @@ class PodmanTest(Test):
     def test_python_version(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
+        :avocado: dependency={"type": "podman-image", "uri": "fedora:34"}
         :avocado: tags=slow
         """
         podman = Podman()

--- a/setup.py
+++ b/setup.py
@@ -320,6 +320,7 @@ if __name__ == '__main__':
                   'avocado-runner-tap = avocado.plugins.runners.tap:main',
                   'avocado-runner-asset = avocado.plugins.runners.asset:main',
                   'avocado-runner-package = avocado.plugins.runners.package:main',
+                  'avocado-runner-podman-image = avocado.plugins.runners.podman_image:main',
                   'avocado-runner-sysinfo = avocado.plugins.runners.sysinfo:main',
                   'avocado-software-manager = avocado.utils.software_manager.main:main',
                   'avocado-external-runner = scripts.external_runner:main',
@@ -407,6 +408,7 @@ if __name__ == '__main__':
                   'python-unittest = avocado.plugins.runners.python_unittest:PythonUnittestRunner',
                   'asset = avocado.plugins.runners.asset:AssetRunner',
                   'package = avocado.plugins.runners.package:PackageRunner',
+                  'podman-image = avocado.plugins.runners.podman_image:PodmanImageRunner',
                   'sysinfo = avocado.plugins.runners.sysinfo:SysinfoRunner',
                   ],
               'avocado.plugins.spawner': [


### PR DESCRIPTION
Avocado's dependency mechanism exists for the exact purpose of     proactively preparing a test requirement *outside* of the actual test.    This reduces the debugging for test failures which are not within the scope of what is attempted to be verified, adds time overhead to a test, etc.
    
This introduces a "podman-image" runner, which can be used as a dependency in tests.  This way, the image will be available before the test runs, or, if it fails to be made available, the test won't be run.