### PR TITLE
Pylint: bump to 2.13.7

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -471,10 +471,6 @@ class Job:
             base_logdir = self.config.get('run.results_dir')
             if base_logdir is not None:
                 try:
-                    FileNotFoundError
-                except NameError:
-                    FileNotFoundError = OSError   # pylint: disable=W0622
-                try:
                     shutil.rmtree(base_logdir)
                 except FileNotFoundError:
                     pass

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -17,7 +17,7 @@ class MockSpawner(Spawner):
     def __init__(self):
         self._known_tasks = {}
 
-    def is_task_alive(self, runtime_task):
+    def is_task_alive(self, runtime_task):  # pylint: disable=W0221
         alive = self._known_tasks.get(runtime_task, None)
         # task was never spawned
         if alive is None:

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -730,7 +730,7 @@ class Test(unittest.TestCase, TestData):
 
     @staticmethod
     @_deprecate_params_message
-    def fail(msg=None):
+    def fail(msg=None):  # pylint: disable=W0221
         """
         Fails the currently running test.
 

--- a/avocado/plugins/dependency.py
+++ b/avocado/plugins/dependency.py
@@ -27,7 +27,7 @@ class DependencyResolver(PreTest):
     description = 'Dependency resolver for tests with dependencies'
 
     @staticmethod
-    def pre_test_runnables(test_runnable):
+    def pre_test_runnables(test_runnable):  # pylint: disable=W0221
         if not test_runnable.dependencies:
             return []
         dependency_runnables = []

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -96,7 +96,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
 
     _PYTHON_VERSIONS_CACHE = {}
 
-    def is_task_alive(self, runtime_task):
+    def is_task_alive(self, runtime_task):  # pylint: disable=W0221
         if runtime_task.spawner_handle is None:
             return False
         podman_bin = self.config.get('spawner.podman.bin')

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -50,11 +50,11 @@ class ProcessSpawner(Spawner, SpawnerMixin):
         runtime_task.task.setup_output_dir(output_dir_path)
 
     @staticmethod
-    async def wait_task(runtime_task):
+    async def wait_task(runtime_task):  # pylint: disable=W0221
         await runtime_task.spawner_handle.wait()
 
     @staticmethod
-    async def terminate_task(runtime_task):
+    async def terminate_task(runtime_task):  # pylint: disable=W0221
         runtime_task.spawner_handle.terminate()
 
     @staticmethod

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -122,7 +122,7 @@ def strip_console_codes(output, custom_codes=None):
     old_word = ""
     return_str = ""
     index = 0
-    output = f"[m{output}"
+    output = f"\x1B[m{output}"
     console_codes = "%[G@8]|\\[[@A-HJ-MPXa-hl-nqrsu\\`]"
     console_codes += "|\\[[\\d;]+[HJKgqnrm]|#8|\\([B0UK]|\\)"
     if custom_codes is not None and custom_codes not in console_codes:

--- a/avocado/utils/datadrainer.py
+++ b/avocado/utils/datadrainer.py
@@ -125,7 +125,7 @@ class FDDrainer(BaseDrainer):
 
     name = 'avocado.utils.datadrainer.FDDrainer'
 
-    def data_available(self):
+    def data_available(self):  # pylint: disable=W0221
         try:
             return select.select([self._source], [], [], 1)[0]
         except OSError as exc:

--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -124,7 +124,7 @@ class GdbMiScannerBase(spark.GenericScanner):
         inner = self.__unescape(s[1:len(s)-1])
         self.rv.append(Token('c_string', inner))
 
-    def t_default(self, s):
+    def t_default(self, s):  # pylint: disable=W0221
         r'( . | \n )+'
         raise Exception(f"Specification error: unmatched input for '{s}'")
 
@@ -184,7 +184,7 @@ class GdbMiParser(spark.GenericASTBuilder):
                 list ::= { value value_list }
         '''
 
-    def terminal(self, token):
+    def terminal(self, token):  # pylint: disable=W0221
         #  Homogeneous AST.
         rv = AST(token.type)
         rv.value = token.value  # pylint: disable=W0201

--- a/avocado/utils/external/spark.py
+++ b/avocado/utils/external/spark.py
@@ -28,7 +28,7 @@ def _namelist(instance):
     namelist, namedict, classlist = [], {}, [instance.__class__]
     for c in classlist:
         for b in c.__bases__:
-            classlist.append(b)
+            classlist.append(b)  # pylint: disable=W4701
         for name in c.__dict__.keys():
             if name not in namedict:
                 namelist.append(name)
@@ -286,7 +286,7 @@ class GenericParser:
                 newrhs = list(rhs)
                 newrhs[i] = self._NULLABLE + sym
                 newrule = (lhs, tuple(newrhs))
-                worklist.append((newrule, i + 1,
+                worklist.append((newrule, i + 1,  # pylint: disable=W4701
                                  candidate, oldrule))
                 candidate = 0
                 i += 1

--- a/avocado/utils/external/spark.py
+++ b/avocado/utils/external/spark.py
@@ -693,7 +693,7 @@ class GenericASTBuilder(GenericParser):
         GenericParser.__init__(self, start)
         self.AST = AST
 
-    def preprocess(self, rule, func):
+    def preprocess(self, rule, func):  # pylint: disable=W0221
         rebind = (lambda lhs, self=self:
                   lambda args, lhs=lhs, self=self: self.buildASTNode(args, lhs))
         lhs, _ = rule
@@ -798,7 +798,7 @@ class GenericASTMatcher(GenericParser):
         GenericParser.__init__(self, start)
         self.ast = ast
 
-    def preprocess(self, rule, func):
+    def preprocess(self, rule, func):  # pylint: disable=W0221
         rebind = (lambda func, self=self:
                   lambda args, func=func, self=self:
                   self.foundMatch(args, func))
@@ -834,7 +834,7 @@ class GenericASTMatcher(GenericParser):
         self.match_r(ast)
         self.parse(self.input)
 
-    def resolve(self, input_list):
+    def resolve(self, input_list):  # pylint: disable=W0221
         #
         #  Resolve ambiguity in favor of the longest RHS.
         #

--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -273,16 +273,18 @@ class Partition:
             try:
                 process.system(f"kill -9 {int(pid)}",
                                ignore_status=True, sudo=True)
-            except process.CmdError as details:
-                raise PartitionError(self, "Failed to kill processes", details)
+            except process.CmdError as kill_details:
+                raise PartitionError(self, "Failed to kill processes",
+                                     kill_details)
         # Unmount
         try:
             process.run(f"umount -f {mountpoint}", sudo=True)
-        except process.CmdError as details:
+        except process.CmdError:
             try:
                 process.run(f"umount -l {mountpoint}", sudo=True)
-            except process.CmdError as details:
-                raise PartitionError(self, "Force unmount failed", details)
+            except process.CmdError as umount_details:
+                raise PartitionError(self, "Force unmount failed",
+                                     umount_details)
 
     def unmount(self, force=True):
         """

--- a/avocado/utils/software_manager/backends/dnf.py
+++ b/avocado/utils/software_manager/backends/dnf.py
@@ -20,7 +20,7 @@ class DnfBackend(YumBackend):
         """
         super().__init__(cmd='dnf')
 
-    def build_dep(self, name):
+    def build_dep(self, name):  # pylint: disable=W0221
         """
         Install build-dependencies for package [name]
 

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -290,7 +290,7 @@ class UbuntuImageProvider(ImageProviderBase):
         self.url_images = self.url_versions + 'releases/{version}/release/'
         self.image_pattern = 'ubuntu-(?P<version>{version})-server-cloudimg-(?P<arch>{arch}).img'
 
-    def get_best_version(self, versions):
+    def get_best_version(self, versions):  # pylint: disable=W0221
         """ Return best (more recent) version """
         max_float = max([float(item) for item in versions])
         return str(f'{max_float:2.2f}')
@@ -410,7 +410,7 @@ class OpenSUSEImageProvider(ImageProviderBase):
         versions = super().get_versions()
         return self._convert_version_numbers(versions)
 
-    def get_best_version(self, versions):
+    def get_best_version(self, versions):  # pylint: disable=W0221
         version_numbers = self._convert_version_numbers(versions)
         if str(self._version).startswith('4'):
             version_numbers = [v for v in version_numbers if v >= 40.0]

--- a/examples/plugins/tests/magic/avocado_magic/resolver.py
+++ b/examples/plugins/tests/magic/avocado_magic/resolver.py
@@ -30,7 +30,7 @@ class MagicResolver(Resolver):
     description = 'Test resolver for magic words'
 
     @staticmethod
-    def resolve(reference):
+    def resolve(reference):  # pylint: disable=W0221
         if reference not in VALID_MAGIC_WORDS:
             return ReferenceResolution(
                 reference,
@@ -48,7 +48,7 @@ class MagicDiscoverer(Discoverer):
     description = 'Test discoverer for magic words'
 
     @staticmethod
-    def discover():
+    def discover():  # pylint: disable=W0221
         resolutions = []
         for reference in VALID_MAGIC_WORDS:
             resolutions.append(MagicResolver.resolve(reference))

--- a/optional_plugins/golang/avocado_golang/golang.py
+++ b/optional_plugins/golang/avocado_golang/golang.py
@@ -66,7 +66,7 @@ class GolangResolver(Resolver):
     description = 'Test resolver for Go language tests'
 
     @staticmethod
-    def resolve(reference):
+    def resolve(reference):  # pylint: disable=W0221
 
         if GO_BIN is None:
             return ReferenceResolution(reference,

--- a/optional_plugins/robot/avocado_robot/robot.py
+++ b/optional_plugins/robot/avocado_robot/robot.py
@@ -50,7 +50,7 @@ class RobotResolver(Resolver):
     description = 'Test resolver for Robot Framework tests'
 
     @staticmethod
-    def resolve(reference):
+    def resolve(reference):  # pylint: disable=W0221
 
         # It may be possible to have Robot Framework tests in other
         # types of files such as reStructuredText (.rst), but given

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 # inspektor (static and style checks)
 isort==5.8.0
 pyenchant==3.2.0
-pylint==2.12.2
+pylint==2.13.7
 inspektor==0.5.2
 autopep8==1.5.7
 

--- a/selftests/functional/test_list.py
+++ b/selftests/functional/test_list.py
@@ -266,7 +266,7 @@ class ListTestFunctional(TestCaseTmpDir):
                  "This is suppose to be skipped"),
                 ("unittests.py:First.test_pass", "PASS", None)]
         for test in jres["tests"]:
-            for exp in exps:
+            for exp in exps[:]:
                 if exp[0] in test["id"]:
                     self.assertEqual(test["status"], exp[1],
                                      (f"Status of {exp} not as expected: "

--- a/selftests/functional/test_lv_utils.py
+++ b/selftests/functional/test_lv_utils.py
@@ -86,21 +86,21 @@ class LVUtilsTest(TestCaseTmpDir):
                                         vg_name, loop_device)
             self.assertTrue(os.path.exists(ramdisk_basedir))
             self.assertFalse(glob.glob(os.path.join(ramdisk_basedir, "*")))
-        except BaseException as details:
+        except BaseException:
             try:
                 process.run(f"mountpoint {mount_loc} && umount {mount_loc}",
                             shell=True, sudo=True)
-            except BaseException as details:
-                print(f"Fail to unmount LV: {details}")
+            except BaseException as mountpoint_details:
+                print(f"Fail to unmount LV: {mountpoint_details}")
             try:
                 lv_utils.lv_remove(vg_name, lv_name)
-            except BaseException as details:
-                print(f"Fail to cleanup LV: {details}")
+            except BaseException as lv_remove_details:
+                print(f"Fail to cleanup LV: {lv_remove_details}")
             try:
                 lv_utils.vg_ramdisk_cleanup(ramdisk_filename, vg_ramdisk_dir,
                                             vg_name, loop_device)
-            except BaseException as details:
-                print(f"Fail to cleanup vg_ramdisk: {details}")
+            except BaseException as vg_cleanup_details:
+                print(f"Fail to cleanup vg_ramdisk: {vg_cleanup_details}")
 
 
 class DiskSpace(unittest.TestCase):

--- a/selftests/functional/test_task_timeout.py
+++ b/selftests/functional/test_task_timeout.py
@@ -21,8 +21,7 @@ class TaskTimeOutTest(TestCaseTmpDir):
     def test_sleep_longer_timeout(self):
         config = {'resolver.references': [self.script.path],
                   'run.results_dir': self.tmpdir.name,
-                  'task.timeout.running': 2,
-                  'run.test_runner': 'nrunner'}
+                  'task.timeout.running': 2}
 
         with Job.from_config(job_config=config) as job:
             job.run()

--- a/selftests/lint.sh
+++ b/selftests/lint.sh
@@ -20,9 +20,6 @@ FILES=$(git ls-files 'selftests*.py')
 ${PYLINT} ${PYLINT_OPTIONS} --disable=W0212,W0703 ${FILES}
 status2=$?
 
-# This is just a Python 3 porting check. We are not still ready for a full
-# --py3k, so we are enabling just a few checks at this time.
-#
 # We are not using pylintrc here because this is a completely different type of check.
 # Maybe soon, we can have multiple pytlintrc files.
 FILES=$(git ls-files '*.py')

--- a/selftests/unit/utils/test_astring.py
+++ b/selftests/unit/utils/test_astring.py
@@ -55,8 +55,8 @@ class AstringUtilsTest(unittest.TestCase):
         self.assertEqual(astring.tabular_output(matrix, header),
                          "0 1  2   3    4\n"
                          "a an dog word last\n"
-                         "[94ma [0man cc[91mc "
-                         "[91md[92md[94md[90md[0m last")
+                         "\x1B[94ma \x1B[0man cc\x1B[91mc "
+                         "\x1B[91md\x1B[92md\x1B[94md\x1B[90md\x1B[0m last")
 
     def test_tabular_output_different_no_cols(self):
         matrix = [[], [1], [2, 2], [333, 333, 333], [4, 4, 4, 4444]]

--- a/selftests/unit/utils/test_datadrainer.py
+++ b/selftests/unit/utils/test_datadrainer.py
@@ -18,7 +18,8 @@ class Magic(datadrainer.BaseDrainer):
     name = 'test_utils_datadrainer.Magic'
     magic = 'MAGIC_magic_MAGIC'
 
-    def data_available(self):
+    @staticmethod
+    def data_available():
         return True
 
     def read(self):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 import shutil
 import sys
 from abc import abstractmethod
-from distutils.command.clean import clean
+from distutils.command.clean import clean  # pylint: disable=W0402
 from pathlib import Path
 from subprocess import CalledProcessError, run
 


### PR DESCRIPTION
The 2.13.7 version covers additional checks by default (addressed     earlier) and happens to be the version shipped with Fedora 36 (a     popular development environment for the Avocado team).