### PR TITLE
Requirements database

### DIFF
--- a/avocado/core/dependencies/requirements/cache/__init__.py
+++ b/avocado/core/dependencies/requirements/cache/__init__.py
@@ -1,3 +1,6 @@
 # The sqlite based backend is the only implementation
 from avocado.core.dependencies.requirements.cache.backends.sqlite import (
-    get_requirement, set_requirement)
+    delete_environment, delete_requirement,
+    get_all_environments_with_requirement, is_environment_prepared,
+    is_requirement_in_cache, set_requirement, update_enviroment,
+    update_requirement_status)

--- a/avocado/core/dependencies/requirements/cache/backends/sqlite.py
+++ b/avocado/core/dependencies/requirements/cache/backends/sqlite.py
@@ -24,6 +24,9 @@ from avocado.core.data_dir import get_datafile_path
 #: The location of the requirements cache database
 CACHE_DATABASE_PATH = get_datafile_path('cache', 'requirements.sqlite')
 
+sqlite3.register_adapter(bool, int)
+sqlite3.register_converter("BOOLEAN", lambda v: bool(int(v)))
+
 #: The definition of the database schema
 SCHEMA = [
     'CREATE TABLE IF NOT EXISTS requirement_type (requirement_type TEXT UNIQUE)',
@@ -41,6 +44,7 @@ SCHEMA = [
      'environment TEXT,'
      'requirement_type TEXT,'
      'requirement TEXT,'
+     'saved BOOLEAN,'
      'FOREIGN KEY(environment_type) REFERENCES environment(environment_type),'
      'FOREIGN KEY(environment) REFERENCES environment(environment),'
      'FOREIGN KEY(requirement_type) REFERENCES requirement_type(requirement_type)'
@@ -59,7 +63,7 @@ def _create_requirement_cache_db():
 
 
 def set_requirement(environment_type, environment,
-                    requirement_type, requirement):
+                    requirement_type, requirement, saved=True):
     if not os.path.exists(CACHE_DATABASE_PATH):
         _create_requirement_cache_db()
 
@@ -71,18 +75,24 @@ def set_requirement(environment_type, environment,
         cursor.execute(sql, (environment_type, environment))
         sql = "INSERT OR IGNORE INTO requirement_type VALUES (?)"
         cursor.execute(sql, (requirement_type, ))
-        sql = "INSERT OR IGNORE INTO requirement VALUES (?, ?, ?, ?)"
+        sql = "INSERT OR IGNORE INTO requirement VALUES (?, ?, ?, ?, ?)"
         cursor.execute(sql, (environment_type, environment,
-                             requirement_type, requirement))
-    conn.commit()
+                             requirement_type, requirement, saved))
+        conn.commit()
 
 
-def get_requirement(environment_type, environment,
-                    requirement_type, requirement):
+def is_requirement_in_cache(environment_type, environment,
+                            requirement_type, requirement):
+    """Checks if requirement is in cache.
+
+        :rtype: True if requirement is in cache
+                False if requirement is not in cache
+                None if requirement is in cache but it is not saved yet.
+    """
     if not os.path.exists(CACHE_DATABASE_PATH):
         return False
 
-    sql = ("SELECT COUNT(*) FROM requirement WHERE ("
+    sql = ("SELECT r.saved FROM requirement r WHERE ("
            "environment_type = ? AND "
            "environment = ? AND "
            "requirement_type = ? AND "
@@ -94,5 +104,196 @@ def get_requirement(environment_type, environment,
                                       requirement_type, requirement))
         row = result.fetchone()
         if row is not None:
-            return row[0] == 1
+            if row[0]:
+                return True
+            return None
     return False
+
+
+def is_environment_prepared(environment):
+    """Checks if environment has all requirements saved."""
+
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return False
+
+    sql = ("SELECT COUNT(*) FROM requirement r JOIN "
+           "environment e ON e.environment = r.environment "
+           "WHERE (r.environment = ? AND "
+           "r.saved = 0)")
+
+    with sqlite3.connect(CACHE_DATABASE_PATH,
+                         detect_types=sqlite3.PARSE_DECLTYPES) as conn:
+        cursor = conn.cursor()
+        result = cursor.execute(sql, (environment,))
+
+        row = result.fetchone()
+        if row is not None:
+            return row[0] == 0
+    return False
+
+
+def update_enviroment(environment_type, old_environment, new_environment):
+    """Updates environment information for each requirement in one environment.
+
+    It will remove the old environment and add the new one to the cache.
+
+    :param environment_type: Type of fetched environment
+    :type environment_type: str
+    :param old_environment: Environment which should be updated
+    :type environment: str
+    :param new_environment: Environment, which will be a reimbursement for the
+                            old one.
+    :type environment: str
+    """
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return False
+
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        cursor = conn.cursor()
+        sql = "INSERT OR IGNORE INTO environment VALUES (?, ?)"
+        cursor.execute(sql, (environment_type, new_environment))
+
+        sql = ("UPDATE requirement SET environment = ? WHERE ("
+               "environment_type = ? AND "
+               "environment = ? )")
+
+        cursor.execute(sql, (new_environment, environment_type,
+                             old_environment))
+
+        sql = ("DELETE FROM environment WHERE ("
+               "environment_type = ? AND "
+               "environment = ? )")
+
+        cursor.execute(sql, (environment_type, old_environment))
+        conn.commit()
+
+
+def update_requirement_status(environment_type, environment, requirement_type,
+                              requirement, new_status):
+    """Updates status of selected requirement in cache.
+
+    The status has two values, save=True or not_save=False.
+
+    :param environment_type: Type of fetched environment
+    :type environment_type: str
+    :param environment: Environment where the requirement is
+    :type environment: str
+    :param requirement_type: Type of the requirement in environment
+    :type requirement_type: str
+    :param requirement: Name of requirement
+    :type requirement: str
+    :param new_status: Requirement status which will be updated
+    :type new_status: bool
+    """
+
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return False
+
+    sql = ("UPDATE requirement SET saved = ? WHERE ("
+           "environment_type = ? AND "
+           "environment = ? AND "
+           "requirement_type = ? AND "
+           "requirement = ?)")
+
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute(sql, (new_status, environment_type, environment,
+                             requirement_type, requirement))
+        conn.commit()
+
+    return True
+
+
+def delete_environment(environment_type, environment):
+    """Deletes environment with all its requirements from cache.
+
+    :param environment_type: Type of environment
+    :type environment_type: str
+    :param environment: Environment which will be deleted
+    :type environment: str
+    """
+
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return False
+
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        sql = ("DELETE FROM requirement WHERE ("
+               "environment_type = ? AND "
+               "environment = ? )")
+        cursor = conn.cursor()
+        cursor.execute(sql, (environment_type, environment))
+        sql = ("DELETE FROM environment WHERE ("
+               "environment_type = ? AND "
+               "environment = ? )")
+        cursor.execute(sql, (environment_type, environment))
+        conn.commit()
+
+
+def delete_requirement(environment_type, environment, requirement_type,
+                       requirement):
+    """Deletes requirement from cache.
+
+    :param environment_type: Type of environment
+    :type environment_type: str
+    :param environment: Environment where the requirement is.
+    :type environment: str
+    :param requirement_type: Type of the requirement in environment
+    :type requirement_type: str
+    :param requirement: Name of requirement which will be deleted
+    :type requirement: str
+    """
+
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return False
+
+    with sqlite3.connect(CACHE_DATABASE_PATH) as conn:
+        sql = ("DELETE FROM requirement WHERE ("
+               "environment_type = ? AND "
+               "environment = ? AND "
+               "requirement_type = ? AND "
+               "requirement = ?)")
+        cursor = conn.cursor()
+        cursor.execute(sql, (environment_type, environment, requirement_type,
+                             requirement))
+        conn.commit()
+
+
+def get_all_environments_with_requirement(environment_type, requirement_type,
+                                          requirement):
+    """Fetches all environments with selected requirement from cache.
+
+    :param environment_type: Type of fetched environment
+    :type environment_type: str
+    :param requirement_type: Type of the requirement in environment
+    :type requirement_type: str
+    :param requirement: Name of requirement
+    :type requirement: str
+    :return: Dict with all environments which has selected requirements.
+
+    """
+    requirements = {}
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return requirements
+
+    environment_select = ("SELECT e.environment FROM requirement r JOIN "
+                          "environment e ON e.environment = r.environment "
+                          "WHERE (r.environment_type = ? AND "
+                          "r.requirement_type = ? AND "
+                          "r.requirement = ?)")
+    sql = (f"SELECT r.environment, r.requirement_type, r.requirement "
+           f"FROM requirement AS r, ({environment_select}) AS e "
+           f"WHERE r.environment = e.environment")
+
+    with sqlite3.connect(CACHE_DATABASE_PATH,
+                         detect_types=sqlite3.PARSE_DECLTYPES) as conn:
+        cursor = conn.cursor()
+        result = cursor.execute(sql, (environment_type,
+                                      requirement_type,
+                                      requirement))
+
+        for row in result.fetchall():
+            if row[0] in requirements:
+                requirements[row[0]].append((row[1], row[2]))
+            else:
+                requirements[row[0]] = [(row[1], row[2])]
+    return requirements

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -364,6 +364,46 @@ class Spawner(Plugin):
         :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
         """
 
+    @staticmethod
+    @abc.abstractmethod
+    async def is_requirement_in_cache(runtime_task):
+        """Checks if it's necessary to run the requirement.
+
+        There are occasions when the similar requirement has been run and its
+        results are already saved in cache. In such occasion, it is not
+        necessary to run the task again. For example, this might be useful for
+        tasks which would install the same package to the same environment.
+
+        :param runtime_task: runtime task with requirement
+        :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
+        :return: If the results are already in cache.
+        :rtype: True if task is in cache
+                False if task is not in cache
+                None if task is running in different process and should be in
+                cache soon.
+        """
+
+    @staticmethod
+    @abc.abstractmethod
+    async def save_requirement_in_cache(runtime_task):
+        """Saves the information about requirement in cache before
+        the runtime_task is run.
+
+        :param runtime_task: runtime task with requirement
+        :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
+        """
+
+    @staticmethod
+    @abc.abstractmethod
+    async def update_requirement_cache(runtime_task, result):
+        """Updates the information about requirement in cache based on result.
+
+        :param runtime_task: runtime task with requirement
+        :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
+        :param result: result of runtime_task
+        :type result: `avocado.core.teststatus.STATUSES`
+        """
+
 
 class DeploymentSpawner(Spawner):
     """Spawners that needs basic deployment are based on this class.

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -47,6 +47,18 @@ class MockSpawner(Spawner):
     async def check_task_requirements(runtime_task):
         return True
 
+    @staticmethod
+    async def is_requirement_in_cache(runtime_task):
+        return False
+
+    @staticmethod
+    async def save_requirement_in_cache(runtime_task):
+        pass
+
+    @staticmethod
+    async def update_requirement_cache(runtime_task, result):
+        pass
+
 
 class MockRandomAliveSpawner(MockSpawner):
     """A mocking spawner that simulates randomness about tasks being alive."""

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -57,8 +57,7 @@ class RuntimeTask:
 
     def are_dependencies_finished(self):
         for dependency in self.dependencies:
-            if not dependency.status or not ("FINISHED" in dependency.status
-                                             or "FAILED" in dependency.status):
+            if not dependency.status or "FINISHED" not in dependency.status:
                 return False
         return True
 
@@ -69,6 +68,15 @@ class RuntimeTask:
             if dependency.status and "FINISHED" in dependency.status:
                 finished.append(dependency)
         return finished
+
+    def is_possible_to_run(self):
+        dependency_finished = self.are_dependencies_finished()
+        if dependency_finished:
+            for dependency in self.dependencies:
+                if dependency.result != 'pass':
+                    return False
+            return True
+        return False
 
     @classmethod
     def from_runnable(cls, runnable, no_digits, index, variant,

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -62,6 +62,14 @@ class RuntimeTask:
                 return False
         return True
 
+    def get_finished_dependencies(self):
+        """Returns all dependencies which already finished."""
+        finished = []
+        for dependency in self.dependencies:
+            if dependency.status and "FINISHED" in dependency.status:
+                finished.append(dependency)
+        return finished
+
     @classmethod
     def from_runnable(cls, runnable, no_digits, index, variant,
                       test_suite_name=None, status_server_uri=None,

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -151,37 +151,6 @@ class Worker:
 
     async def triage(self):
         """Reads from triaging, moves into either: ready or finished."""
-        async def check_finished_dependencies(runtime_task):
-            for dependency in runtime_task.dependencies:
-                task = dependency.task
-                # check if this dependency `task` failed on triage
-                # this is needed because this kind of task fail does not
-                # have information in the status repo
-                for finished_rt_task in self._state_machine.finished:
-                    if (finished_rt_task.task is task and
-                            finished_rt_task.status == 'FAILED ON TRIAGE'):
-
-                        await self._state_machine.finish_task(runtime_task,
-                                                              "FAILED ON TRIAGE")
-                        return
-                # from here, this dependency `task` ran, so, let's check
-                # the its latest data in the status repo
-                latest_task_data = \
-                    self._state_machine._status_repo.get_latest_task_data(
-                        str(task.identifier))
-                # maybe, the latest data is not available yet
-                if latest_task_data is None:
-                    async with self._state_machine.lock:
-                        self._state_machine.triaging.append(runtime_task)
-                    await asyncio.sleep(0.1)
-                    return
-                # if this dependency task failed, skip the parent task
-                if latest_task_data['result'] not in ['pass']:
-                    await self._state_machine.finish_task(runtime_task,
-                                                          "FAILED ON TRIAGE")
-                    return
-            # everything is fine!
-            return True
 
         try:
             async with self._state_machine.lock:
@@ -214,7 +183,7 @@ class Worker:
 
             # dependencies finished, let's check if they finished
             # successfully, so we can move on with the parent task
-            dependencies_ok = await check_finished_dependencies(runtime_task)
+            dependencies_ok = runtime_task.is_possible_to_run()
             if not dependencies_ok:
                 LOG.debug('Task "%s" has failed dependencies',
                           runtime_task.task.identifier)
@@ -277,7 +246,6 @@ class Worker:
                     remaining = runtime_task.execution_timeout - time.monotonic()
                 await asyncio.wait_for(self._spawner.wait_task(runtime_task),
                                        remaining)
-                runtime_task.status = 'FINISHED'
             except asyncio.TimeoutError:
                 runtime_task.status = 'FINISHED W/ TIMEOUT'
                 await self._spawner.terminate_task(runtime_task)
@@ -288,13 +256,25 @@ class Worker:
                            'id': str(runtime_task.task.identifier),
                            'job_id': runtime_task.task.job_id}
                 self._state_machine._status_repo.process_message(message)
+        # from here, this `task` ran, so, let's check
+        # the its latest data in the status repo
+        latest_task_data = \
+            self._state_machine._status_repo.get_latest_task_data(
+                str(runtime_task.task.identifier)) or {}
+        # maybe, the results are not available yet
+        while latest_task_data.get("result", None) is None:
+            await asyncio.sleep(0.1)
+            latest_task_data = \
+                self._state_machine._status_repo.get_latest_task_data(
+                    str(runtime_task.task.identifier)) or {}
+        runtime_task.result = latest_task_data['result']
         result_stats = set(key.upper()for key in
                            self._state_machine._status_repo.result_stats.keys())
         if self._failfast and not result_stats.isdisjoint(STATUSES_NOT_OK):
             await self._state_machine.abort("FAILFAST is enabled")
             raise TestFailFast("Interrupting job (failfast).")
 
-        await self._state_machine.finish_task(runtime_task)
+        await self._state_machine.finish_task(runtime_task, "FINISHED")
 
     async def run(self):
         """Pushes Tasks forward and makes them do something with their lives."""

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -2,8 +2,13 @@ import asyncio
 import os
 import sys
 
+from avocado.core.dependencies.requirements import cache
 from avocado.core.plugin_interfaces import Spawner
 from avocado.core.spawners.common import SpawnerMixin, SpawnMethod
+from avocado.core.teststatus import STATUSES_NOT_OK
+
+ENVIRONMENT_TYPE = 'local'
+ENVIRONMENT = 'localhost.localdomain'
 
 
 class ProcessSpawner(Spawner, SpawnerMixin):
@@ -64,3 +69,33 @@ class ProcessSpawner(Spawner, SpawnerMixin):
         if runtime_task.task.runnable.runner_command() is None:
             return False
         return True
+
+    @staticmethod
+    async def update_requirement_cache(runtime_task, result):
+        kind = runtime_task.task.runnable.kind
+        name = runtime_task.task.runnable.kwargs.get('name')
+        cache.set_requirement(ENVIRONMENT_TYPE, ENVIRONMENT, kind, name)
+        if result in STATUSES_NOT_OK:
+            cache.delete_requirement(ENVIRONMENT_TYPE, ENVIRONMENT, kind, name)
+            return
+        cache.update_requirement_status(ENVIRONMENT_TYPE,
+                                        ENVIRONMENT,
+                                        kind,
+                                        name,
+                                        True)
+
+    @staticmethod
+    async def is_requirement_in_cache(runtime_task):
+        kind = runtime_task.task.runnable.kind
+        name = runtime_task.task.runnable.kwargs.get('name')
+        return cache.is_requirement_in_cache(ENVIRONMENT_TYPE,
+                                             ENVIRONMENT,
+                                             kind,
+                                             name)
+
+    @staticmethod
+    async def save_requirement_in_cache(runtime_task):
+        kind = runtime_task.task.runnable.kind
+        name = runtime_task.task.runnable.kwargs.get('name')
+        cache.set_requirement(ENVIRONMENT_TYPE, ENVIRONMENT, kind, name,
+                              False)

--- a/selftests/functional/serial/test_requirements.py
+++ b/selftests/functional/serial/test_requirements.py
@@ -34,27 +34,39 @@ class FailTest(Test):
 MULTIPLE_SUCCESS = '''#!/usr/bin/env python3
 
 from avocado import Test
+from avocado.utils import process
 
 
 class SuccessTest(Test):
+
+    def check_hello(self):
+        result = process.run("hello", ignore_status=True)
+        self.assertEqual(result.exit_status, 0)
+        self.assertIn('Hello, world!', result.stdout_text,)
 
     def test_a(self):
         """
         :avocado: dependency={"type": "package", "name": "hello"}
         """
+        self.check_hello()
+
     def test_b(self):
         """
         :avocado: dependency={"type": "package", "name": "hello"}
         """
+        self.check_hello()
+
     def test_c(self):
         """
         :avocado: dependency={"type": "package", "name": "hello"}
         """
+        self.check_hello()
 '''
 
 MULTIPLE_FAIL = '''#!/usr/bin/env python3
 
 from avocado import Test
+from avocado.utils import process
 
 
 class FailTest(Test):
@@ -68,6 +80,10 @@ class FailTest(Test):
         """
         :avocado: dependency={"type": "package", "name": "hello"}
         """
+        result = process.run("hello", ignore_status=True)
+        self.assertEqual(result.exit_status, 0)
+        self.assertIn('Hello, world!', result.stdout_text,)
+
     def test_c(self):
         """
         :avocado: dependency={"type": "package", "name": "hello"}
@@ -78,7 +94,6 @@ class FailTest(Test):
 
 class BasicTest(TestCaseTmpDir):
 
-    command = '%s run %s'
     skip_install_message = ("This test runs on CI environments only as it"
                             " installs packages to test the feature, which"
                             " may not be desired locally, in the user's"
@@ -88,51 +103,86 @@ class BasicTest(TestCaseTmpDir):
                                     " manager, and some environments don't"
                                     " have it available.")
 
-    @unittest.skipUnless(os.getenv('CI'), skip_package_manager_message)
-    def test_single_success(self):
+    def get_command(self, path, podman=False):
+        spawner = ''
+        if podman:
+            spawner = ("--nrunner-spawner=podman "
+                       "--spawner-podman-image=fedora:latest")
+        return f"{AVOCADO} run {spawner} {path}"
+
+    def single_success(self, podman=False):
         with script.Script(os.path.join(self.tmpdir.name,
                                         'test_single_success.py'),
                            SINGLE_SUCCESS_CHECK) as test:
-            command = self.command % (AVOCADO, test.path)
+            command = self.get_command(test.path, podman)
             result = process.run(command, ignore_status=True)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
             self.assertIn('PASS 1', result.stdout_text,)
             self.assertNotIn('bash', result.stdout_text,)
 
-    @unittest.skipUnless(os.getenv('CI'), skip_package_manager_message)
-    def test_single_fail(self):
+    def single_fail(self, podman=False):
         with script.Script(os.path.join(self.tmpdir.name,
                                         'test_single_fail.py'),
                            SINGLE_FAIL_CHECK) as test:
-            command = self.command % (AVOCADO, test.path)
+            command = self.get_command(test.path, podman)
             result = process.run(command, ignore_status=True)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
             self.assertIn('PASS 0', result.stdout_text,)
             self.assertIn('SKIP 1', result.stdout_text,)
             self.assertNotIn('-foo-bar-', result.stdout_text,)
 
-    @unittest.skipUnless(os.getenv('CI'), skip_install_message)
-    def test_multiple_success(self):
+    def multiple_success(self, podman=False):
         with script.Script(os.path.join(self.tmpdir.name,
                                         'test_multiple_success.py'),
                            MULTIPLE_SUCCESS) as test:
-            command = self.command % (AVOCADO, test.path)
+            command = self.get_command(test.path, podman)
             result = process.run(command, ignore_status=True)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
             self.assertIn('PASS 3', result.stdout_text,)
             self.assertNotIn('vim-common', result.stdout_text,)
 
-    @unittest.skipUnless(os.getenv('CI'), skip_install_message)
-    def test_multiple_fails(self):
+    def multiple_fails(self, podman=False):
         with script.Script(os.path.join(self.tmpdir.name,
                                         'test_multiple_fail.py'),
                            MULTIPLE_FAIL) as test:
-            command = self.command % (AVOCADO, test.path)
+            command = self.get_command(test.path, podman)
             result = process.run(command, ignore_status=True)
             self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
             self.assertIn('PASS 1', result.stdout_text,)
             self.assertIn('SKIP 2', result.stdout_text,)
             self.assertNotIn('-foo-bar-', result.stdout_text,)
+
+    @unittest.skipUnless(os.getenv('CI'), skip_package_manager_message)
+    def test_single_success(self):
+        self.single_success()
+
+    @unittest.skipUnless(os.getenv('CI'), skip_package_manager_message)
+    def test_single_success_podman(self):
+        self.single_success(podman=True)
+
+    @unittest.skipUnless(os.getenv('CI'), skip_package_manager_message)
+    def test_single_fail(self):
+        self.single_fail()
+
+    @unittest.skipUnless(os.getenv('CI'), skip_package_manager_message)
+    def test_single_fail_podman(self):
+        self.single_fail(podman=True)
+
+    @unittest.skipUnless(os.getenv('CI'), skip_install_message)
+    def test_multiple_success(self):
+        self.multiple_success()
+
+    @unittest.skipUnless(os.getenv('CI'), skip_install_message)
+    def test_multiple_success_podman(self):
+        self.multiple_success(podman=True)
+
+    @unittest.skipUnless(os.getenv('CI'), skip_install_message)
+    def test_multiple_fails(self):
+        self.multiple_fails()
+
+    @unittest.skipUnless(os.getenv('CI'), skip_install_message)
+    def test_multiple_fails_podman(self):
+        self.multiple_fails(podman=True)
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/selftests/functional/test_requirements_cache.py
+++ b/selftests/functional/test_requirements_cache.py
@@ -11,12 +11,25 @@ ENTRIES = [
      'bash'),
     ('podman',
      'cd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e',
+     'package',
+     'hello'),
+    ('podman',
+     'ad34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e',
+     'package',
+     'hello'),
+    ('podman',
+     'cd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e',
      'core',
      'avocado'),
     ('local',
      'localhost.localdomain',
      'core',
-     'avocado')
+     'avocado'),
+    ('podman',
+     'pd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e',
+     'package',
+     'foo',
+     0),
     ]
 
 
@@ -27,13 +40,53 @@ class Cache(TestCaseTmpDir):
                 'avocado.core.dependencies.requirements.cache.backends.sqlite.CACHE_DATABASE_PATH',
                 os.path.join(self.tmpdir.name,
                              'requirements.sqlite')):
-            for entry in ENTRIES:
+            for entry in ENTRIES[:-1]:
                 cache.set_requirement(*entry)
-                self.assertTrue(cache.get_requirement(*entry))
+                self.assertTrue(cache.is_requirement_in_cache(*entry))
+            entry = ENTRIES[-1]
+            cache.set_requirement(*entry)
+            self.assertIsNone(cache.is_requirement_in_cache(entry[0],
+                                                            entry[1],
+                                                            entry[2],
+                                                            entry[3]))
+            self.assertFalse(cache.is_requirement_in_cache('local',
+                                                           'localhost.localdomain',
+                                                           'package',
+                                                           'foo'))
 
     def test_empty(self):
         with unittest.mock.patch(
                 'avocado.core.dependencies.requirements.cache.backends.sqlite.CACHE_DATABASE_PATH',
                 os.path.join(self.tmpdir.name,
                              'requirements.sqlite')):
-            self.assertFalse(cache.get_requirement(*ENTRIES[0]))
+            self.assertFalse(cache.is_requirement_in_cache(*ENTRIES[0]))
+
+    def test_is_environment_prepared(self):
+        with unittest.mock.patch(
+                'avocado.core.dependencies.requirements.cache.backends.sqlite.CACHE_DATABASE_PATH',
+                os.path.join(self.tmpdir.name,
+                             'requirements.sqlite')):
+            for entry in ENTRIES:
+                cache.set_requirement(*entry)
+            self.assertFalse(cache.is_environment_prepared(
+                "pd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e"))
+            self.assertTrue(cache.is_environment_prepared(
+                "cd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e"))
+
+    def test_get_all_environments_with_requirement(self):
+        with unittest.mock.patch(
+                'avocado.core.dependencies.requirements.cache.backends.sqlite.CACHE_DATABASE_PATH',
+                os.path.join(self.tmpdir.name,
+                             'requirements.sqlite')):
+            for entry in ENTRIES:
+                cache.set_requirement(*entry)
+            all_requirements = cache.get_all_environments_with_requirement(
+                'podman', 'package', 'hello')
+            expected_data = {
+                'ad34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e':
+                [('package', 'hello')],
+                'cd34d13b2980d0a9d438f754b2e94f85443076d0ebe1b0db09a0439f35feca5e':
+                [('core', 'avocado'),
+                 ('package', 'bash'),
+                 ('package', 'hello')]}
+            self.assertEqual(all_requirements, expected_data)

--- a/selftests/unit/test_task_runtime.py
+++ b/selftests/unit/test_task_runtime.py
@@ -76,7 +76,9 @@ class DependencyGraph(TestCaseTmpDir):
             self.assertTrue(
                 runtime_tests[2].task.identifier.name.endswith("test_b"))
             self.assertTrue(
-                runtime_tests[3].task.identifier.name.endswith("test_c"))
+                runtime_tests[3].task.identifier.name.endswith("hello"))
+            self.assertTrue(
+                runtime_tests[4].task.identifier.name.endswith("test_c"))
 
     def test_multiple_dependencies(self):
         with script.Script(os.path.join(self.tmpdir.name,
@@ -94,6 +96,8 @@ class DependencyGraph(TestCaseTmpDir):
             self.assertTrue(
                 runtime_tests[2].task.identifier.name.endswith("test_b"))
             self.assertTrue(
-                runtime_tests[3].task.identifier.name.endswith("-foo-bar-"))
+                runtime_tests[3].task.identifier.name.endswith("hello"))
             self.assertTrue(
-                runtime_tests[4].task.identifier.name.endswith("test_c"))
+                runtime_tests[4].task.identifier.name.endswith("-foo-bar-"))
+            self.assertTrue(
+                runtime_tests[5].task.identifier.name.endswith("test_c"))


### PR DESCRIPTION
This PR adds the ability to spawners to store requirements into cache.
This will make more efficient running multiple tests with the same
requirement or rerunning the jobs itself.

This also brings ability to use requirements with podman spawner. So now
is possible to run something like this:
```
class SuccessTest(Test):

    def check_hello(self):
        result = process.run("hello", ignore_status=True)
        self.assertEqual(result.exit_status, 0)
        self.assertIn('Hello, world!', result.stdout_text,)

    def test_a(self):
        """
        avocado dependency={"type": "package", "name": "hello"}
        """
        self.check_hello()
```

Warning: Right now, the requirement cache doesn't have any controls for
clearing cache or updating, and also didn't check the current
environment. So if the user do some changes to the environment outside
Avocado runtime, like uninstalling package, podman prune, removing
asset, etc. The tests with requirements will be broken.

Signed-off-by: Jan Richter <jarichte@redhat.com>