### PR TITLE
Fedora version update for vmimage

### DIFF
--- a/selftests/pre_release/tests/vmimage.py.data/variants.yml
+++ b/selftests/pre_release/tests/vmimage.py.data/variants.yml
@@ -50,12 +50,12 @@ distro: !mux
     !filter-out : /run/architectures/ppc
     !filter-out : /run/architectures/ppc64
     version: !mux
-      33:
-        version: 33
       34:
         version: 34
       35:
         version: 35
+      36:
+        version: 36
   ubuntu:
     name: ubuntu
     !filter-out : /run/architectures/arm


### PR DESCRIPTION
This will update the Fedora versions in vmimage pre-release checks.

Signed-off-by: Jan Richter <jarichte@redhat.com>