### PR TITLE
CI: update to use currently supported Fedora versions

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ansible (${{matrix.extra}})
     runs-on: ubuntu-latest
     container:
-      image: fedora:34
+      image: fedora:36
     env:
       RUN_BEFORE: 'dnf install -y git ansible'
       GIT_URL: 'https://github.com/${{github.repository}}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        container: ["fedora:34",
-                    "fedora:35",
+        container: ["fedora:35",
+                    "fedora:36",
                     "registry.access.redhat.com/ubi8/ubi",
                     "registry.access.redhat.com/ubi9-beta/ubi",
                     "debian:10.10",
@@ -264,8 +264,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        container: ["fedora:34",
-                    "fedora:35",
+        container: ["fedora:35",
+                    "fedora:36",
                     "registry.access.redhat.com/ubi8/ubi",
                     "registry.access.redhat.com/ubi9-beta/ubi",
                     "debian:10.10",
@@ -295,7 +295,7 @@ jobs:
     name: Fedora develop install/uninstall task
     runs-on: ubuntu-latest
     container:
-      image: fedora:35
+      image: fedora:36
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -59,9 +59,9 @@ jobs:
     name: Check the right RPM packages are available in COPR
     runs-on: ubuntu-latest
     env:
-      FEDORA_VERSION: '34'
+      FEDORA_VERSION: '36'
     container:
-      image: fedora:34
+      image: fedora:36
     steps:
       - name: install repos and packages
         run: |
@@ -85,7 +85,7 @@ jobs:
     name: Avocado deployment
     runs-on: ubuntu-latest
     container:
-      image: fedora:34
+      image: fedora:36
     env:
       GIT_URL: 'https://github.com/avocado-framework/avocado'
       INVENTORY: 'selftests/deployment/inventory'


### PR DESCRIPTION
Fedora 35 and 36 are the currently supported versions and should be
used on CI.

This also fixes an issue with the "Check the right RPM packages are
available" CI check (part of the Pre-release tests) because it was
using an EOL chroot (Fedora 34).

Signed-off-by: Cleber Rosa <crosa@redhat.com>