### PR TITLE
fix data_factory.py

### DIFF
--- a/avocado/utils/data_factory.py
+++ b/avocado/utils/data_factory.py
@@ -77,7 +77,7 @@ def make_dir_and_populate(basedir='/tmp'):
             str_length = _RAND_POOL.randint(30, 50)
             n_lines = _RAND_POOL.randint(5, 7)
             for _ in range(n_lines):
-                os.write(fd, generate_random_string(str_length))
+                os.write(fd, generate_random_string(str_length).encode())
             os.close(fd)
     except OSError as details:
         log_msg = "Failed to generate dir in '%s' and populate: %s"


### PR DESCRIPTION
header: fix function make_dir_and_populate
message: When use funciton make_dir_and_populate to create a directory in basedir and populate with a number of files,
raise TypeError: a bytes-like object is required, not 'str'
This PR fix this bug
Reference: See the following drawing
![企业微信截图_16575253716941](https://user-images.githubusercontent.com/42006321/178213681-9a5b99ae-0481-44f1-a2e4-3a0db16fe3a4.png)
Signed-off-by:WangPeng wangpengb@uniontech.com
