### PR TITLE
Test results with warning fix

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -33,6 +33,7 @@ from avocado.core import exceptions, parameters
 from avocado.core.output import LOG_JOB
 from avocado.core.settings import settings
 from avocado.core.test_id import TestID
+from avocado.core.teststatus import STATUSES_NOT_OK
 from avocado.core.version import VERSION
 from avocado.utils import asset, astring, data_structures, genio
 from avocado.utils import path as utils_path
@@ -678,7 +679,7 @@ class Test(unittest.TestCase, TestData):
         """Wrapper around test methods for catching and logging failures."""
         try:
             method()
-            if self.__log_warn_used:
+            if self.__log_warn_used and self.__status not in STATUSES_NOT_OK:
                 raise exceptions.TestWarn(
                     "Test passed but there were warnings "
                     "during execution. Check the log for "

--- a/examples/tests/failtest_with_warning.py
+++ b/examples/tests/failtest_with_warning.py
@@ -1,0 +1,17 @@
+from avocado import Test
+
+
+class FailTest(Test):
+
+    """
+    Example test for avocado. Straight up fail the test.
+
+    :avocado: tags=failure_expected
+    """
+
+    def test(self):
+        """
+        Should fail.
+        """
+        self.log.warning("This is warning")
+        self.fail("This test is supposed to fail")

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -334,6 +334,19 @@ class RunnerOperationTest(TestCaseTmpDir):
             f"Avocado did not return rc {expected_rc}:\n{result}",
         )
 
+    def test_runner_test_fail_with_warning(self):
+        cmd_line = (
+            f"{AVOCADO} run --disable-sysinfo --job-results-dir "
+            f"{self.tmpdir.name} examples/tests/failtest_with_warning.py"
+        )
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
+        self.assertEqual(
+            result.exit_status,
+            expected_rc,
+            f"Avocado did not return rc {expected_rc}:\n{result}",
+        )
+
     def test_runner_nonexistent_test(self):
         cmd_line = (
             f"{AVOCADO} run --disable-sysinfo --job-results-dir "


### PR DESCRIPTION
If a test logged a warning via the log.warning command, then no matter
what happened afterwards, the test result was WARN. This fixes this
problem. So the test result will be WARN only when the test itself
succeed with warning.

Reference: #5375
Signed-off-by: Jan Richter <jarichte@redhat.com>