### PR TITLE
COPR RPM version check: reuse check on CI

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -54,32 +54,15 @@ jobs:
           path: /home/runner/avocado/job-results/
           retention-days: 1
 
-  # Re-implements ./selftests/pre_release/tests/check-copr-rpm-version.sh
   check-rpm-available-copr:
     name: Check the right RPM packages are available in COPR
     runs-on: ubuntu-latest
-    env:
-      FEDORA_VERSION: '36'
-    container:
-      image: fedora:36
     steps:
-      - name: install repos and packages
-        run: |
-          dnf -y install git
-          dnf -y module disable avocado
-          dnf -y install 'dnf-command(copr)'
-          dnf -y copr enable @avocado/avocado-latest
       - uses: actions/checkout@v2
         with:
           ref: 'master'
       - name: Check the right RPM packages are available
-        run: |
-          VERSION=$(python3 setup.py --version 2>/dev/null)
-          RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
-          git config --global --add safe.directory `pwd`
-          COMMIT_DATE=$(git log -n 1 --pretty='format:%cd' --date='format:%Y%m%d')
-          SHORT_COMMIT=$(git rev-parse --short=9 master)
-          dnf -y install python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${{env.FEDORA_VERSION}}
+        run: ./selftests/pre_release/tests/check-copr-rpm-version.sh
 
   avocado-deployment-copr:
     name: Avocado deployment

--- a/contrib/containers/ci/selftests/check-copr-rpm-version.docker
+++ b/contrib/containers/ci/selftests/check-copr-rpm-version.docker
@@ -1,0 +1,7 @@
+# This container is used in selftests/pre_release/tests/check-copr-rpm-version.sh
+FROM fedora:36
+LABEL description "Fedora image used on COPR RPM version check"
+RUN dnf -y module disable avocado:latest
+RUN dnf -y install 'dnf-command(copr)'
+RUN dnf -y copr enable @avocado/avocado-latest
+RUN dnf -y clean all

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -16,7 +16,7 @@ DISTRO_VERSION=36
 
 RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
 
-PODMAN=$(which podman)
+PODMAN=$(which podman 2>/dev/null || which docker)
 PODMAN_IMAGE=quay.io/avocado-framework/check-copr-rpm-version
 
 $PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y install ${RPM_NVR}"

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+# This script accepts a package NVR as its first argument.  If not given,
+# it will default to a NVR based on the info of the repository given
+
 # Put here the name of your GIT remote that tracks the official
 # repo, that is, https://github.com/avocado-framework/avocado
 # (or the git:// url version of the same repo)
@@ -14,7 +17,8 @@ SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/master)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
 DISTRO_VERSION=36
 
-RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
+DEFAULT_RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
+RPM_NVR="${1:-$DEFAULT_RPM_NVR}"
 
 PODMAN=$(which podman 2>/dev/null || which docker)
 PODMAN_IMAGE=quay.io/avocado-framework/check-copr-rpm-version

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -9,7 +9,7 @@ git fetch $ORIGIN
 
 ORIGIN_MASTER_COMMIT=$(git log --pretty=format:'%h' -n 1 $ORIGIN/master)
 VERSION=$(python setup.py --version 2>/dev/null)
-COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
+COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1 $ORIGIN/master)
 SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/master)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
 DISTRO_VERSION=36

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -12,12 +12,11 @@ VERSION=$(python setup.py --version 2>/dev/null)
 COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
 SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/master)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
-DISTRO=fedora
-DISTRO_VERSION=34
+DISTRO_VERSION=36
 
 RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
 
 PODMAN=$(which podman)
-PODMAN_IMAGE="${DISTRO}:${DISTRO_VERSION}"
+PODMAN_IMAGE=quay.io/avocado-framework/check-copr-rpm-version
 
-$PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y module disable avocado && dnf -y install 'dnf-command(copr)' && dnf -y copr enable @avocado/avocado-latest && dnf -y install ${RPM_NVR}"
+$PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y install ${RPM_NVR}"


### PR DESCRIPTION
The Pre-Release check has a "reimplementation" of the COPR RPM version check, but it doesn't need to be so.

This moves the prep steps to a container, that is used on the standalone script (`selftests/pre_release/tests/check-copr-rpm-version.sh), and the same standalone script is now used on the CI check.

A run can be seen here:

https://github.com/clebergnu/avocado/runs/7286291740?check_suite_focus=true
