### PR TITLE
Travis CI: work around failure with charset_normalizer

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -26,3 +26,8 @@ netifaces
 # For tests that validate the produced XUnit output
 elementpath==1.1.8
 xmlschema==1.0.11
+
+# resultsdb plugin uses requests, which in turn uses one
+# available char detection module.  Thin makes the one to be
+# used more predictable and works on more Python versions
+chardet==4.0.0


### PR DESCRIPTION
Travis seems to bundle a specific version of charset_normalizer, which
contains type notations and fails on Python 3.5:

  File "/home/travis/virtualenv/python3.5.10/lib/python3.5/site-packages/requests-2.28.1-py3.5.egg/requests/compat.py", line 13, in <module>
    import charset_normalizer as chardet
  File "/home/travis/virtualenv/python3.5.10/lib/python3.5/site-packages/charset_normalizer-2.1.0-py3.5.egg/charset_normalizer/__init__.py", line 24, in <module>
    from .api import from_bytes, from_fp, from_path, normalize
  File "/home/travis/virtualenv/python3.5.10/lib/python3.5/site-packages/charset_normalizer-2.1.0-py3.5.egg/charset_normalizer/api.py", line 70
    previous_logger_level: int = logger.level
                         ^
  SyntaxError: invalid syntax

Let's make requests use chardet instead, which is compatible.

Signed-off-by: Cleber Rosa <crosa@redhat.com>