### PR TITLE
nrunner: refactors to exec-like runners [v2]

### DIFF
--- a/avocado/core/nrunner/runner.py
+++ b/avocado/core/nrunner/runner.py
@@ -65,3 +65,24 @@ class BaseRunner(RunnableRunner):
             status = additional_info
         status.update({"status": status_type, "time": time.monotonic()})
         return status
+
+    def running_loop(self, condition):
+        """Produces timely running messages until end condition is found.
+
+        :param condition: a callable that will be evaluated as a
+                          condition for continuing the loop
+        """
+        most_current_execution_state_time = None
+        while not condition():
+            now = time.monotonic()
+            if most_current_execution_state_time is not None:
+                next_execution_state_mark = (
+                    most_current_execution_state_time + RUNNER_RUN_STATUS_INTERVAL
+                )
+            if (
+                most_current_execution_state_time is None
+                or now > next_execution_state_mark
+            ):
+                most_current_execution_state_time = now
+                yield self.prepare_status("running")
+            time.sleep(RUNNER_RUN_CHECK_INTERVAL)

--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -2,16 +2,11 @@ import os
 import shutil
 import subprocess
 import tempfile
-import time
 
 import pkg_resources
 
 from avocado.core.nrunner.app import BaseRunnerApp
-from avocado.core.nrunner.runner import (
-    RUNNER_RUN_CHECK_INTERVAL,
-    RUNNER_RUN_STATUS_INTERVAL,
-    BaseRunner,
-)
+from avocado.core.nrunner.runner import BaseRunner
 
 
 class ExecTestRunner(BaseRunner):
@@ -153,22 +148,6 @@ class ExecTestRunner(BaseRunner):
             env=self._get_env(runnable),
         )
 
-    def _running_loop(self, condition):
-        most_current_execution_state_time = None
-        while not condition():
-            now = time.monotonic()
-            if most_current_execution_state_time is not None:
-                next_execution_state_mark = (
-                    most_current_execution_state_time + RUNNER_RUN_STATUS_INTERVAL
-                )
-            if (
-                most_current_execution_state_time is None
-                or now > next_execution_state_mark
-            ):
-                most_current_execution_state_time = now
-                yield self.prepare_status("running")
-            time.sleep(RUNNER_RUN_CHECK_INTERVAL)
-
     def run(self, runnable):
         yield self.prepare_status("started")
 
@@ -184,7 +163,7 @@ class ExecTestRunner(BaseRunner):
         def poll_proc():
             return process.poll() is not None
 
-        yield from self._running_loop(poll_proc)
+        yield from self.running_loop(poll_proc)
 
         stdout = process.stdout.read()
         stderr = process.stderr.read()

--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -154,17 +154,17 @@ class ExecTestRunner(BaseRunner):
         )
 
     def run(self, runnable):
+        yield self.prepare_status("started")
+
         try:
             process = self._run_proc(runnable)
         except Exception as e:
-            yield self.prepare_status("started")
             yield self.prepare_status(
                 "finished", {"result": "error", "fail_reason": str(e)}
             )
             self._cleanup(runnable)
             return
 
-        yield self.prepare_status("started")
         most_current_execution_state_time = None
         timeout = RUNNER_RUN_CHECK_INTERVAL
         while process.returncode is None:

--- a/avocado/plugins/runners/tap.py
+++ b/avocado/plugins/runners/tap.py
@@ -60,7 +60,7 @@ class TAPRunner(ExecTestRunner):
         return result
 
     def _process_final_status(
-        self, process, stdout=None, stderr=None
+        self, process, runnable, stdout=None, stderr=None
     ):  # pylint: disable=W0613
         return FinishedMessage.get(
             self._get_tap_result(stdout), returncode=process.returncode


### PR DESCRIPTION
The `exec-test`, and its child `tap` runner, share a lot of code, but there are still some duplication.  Also the `golang` and `robot` runners can share more code and have a more consistent behavior when it comes to the "running" messages.

---

Changes from v1 (#5438):
* announce test "started" sooner (suggested by @richtja)