### PR TITLE
Utils: iso9660 and disk test skips

### DIFF
--- a/selftests/unit/utils/test_iso9660.py
+++ b/selftests/unit/utils/test_iso9660.py
@@ -89,11 +89,6 @@ class BaseIso9660:
         process.has_capability("cap_sys_admin"),
         "Capability to mount is required (cap_sys_admin)",
     )
-    @unittest.skipIf(
-        os.getenv("TRAVIS")
-        and os.getenv("TRAVIS_CPU_ARCH") in ["arm64", "ppc64le", "s390x"],
-        "TRAVIS Environment is unsuitable for these tests",
-    )
     def test_mnt_dir_workflow(self):
         """
         Check the mnt_dir functionality
@@ -158,11 +153,6 @@ class IsoMount(BaseIso9660, unittest.TestCase):
     @unittest.skipUnless(
         process.has_capability("cap_sys_admin"),
         "Capability to mount is required (cap_sys_admin)",
-    )
-    @unittest.skipIf(
-        os.getenv("TRAVIS")
-        and os.getenv("TRAVIS_CPU_ARCH") in ["arm64", "ppc64le", "s390x"],
-        "TRAVIS Environment is unsuitable for these tests",
     )
     def setUp(self):
         super().setUp()

--- a/selftests/unit/utils/test_iso9660.py
+++ b/selftests/unit/utils/test_iso9660.py
@@ -70,13 +70,6 @@ class BaseIso9660:
         prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
-    @unittest.skipIf(
-        os.uname()[4] == "s390x",
-        (
-            "Endianess issues on pycdlib, see "
-            "https://github.com/clalancette/pycdlib/issues/39"
-        ),
-    )
     def test_basic_workflow(self):
         """
         Check the basic Iso9660 workflow

--- a/selftests/unit/utils/test_partition.py
+++ b/selftests/unit/utils/test_partition.py
@@ -48,11 +48,6 @@ class Base(unittest.TestCase):
         process.has_capability("cap_sys_admin"),
         "Capability to mount is required (cap_sys_admin)",
     )
-    @unittest.skipIf(
-        os.getenv("TRAVIS")
-        and os.getenv("TRAVIS_CPU_ARCH") in ["arm64", "ppc64le", "s390x"],
-        "TRAVIS Environment is unsuitable for these tests",
-    )
     def setUp(self):
         prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)


### PR DESCRIPTION
This removes some outdated skips from `iso9960` and `disk` utility modules.  