### PR TITLE
Containers: add fedora-36-latest-copr.docker

### DIFF
--- a/contrib/containers/fedora-36-latest-copr.docker
+++ b/contrib/containers/fedora-36-latest-copr.docker
@@ -1,0 +1,6 @@
+FROM fedora:36
+LABEL description "Fedora image with the latest Avocado COPR build"
+RUN dnf -y install dnf-plugins-core
+RUN dnf -y copr enable @avocado/avocado-latest
+RUN dnf -y install python3-avocado python3-avocado-bash python3-avocado-common python3-avocado-examples python3-avocado-plugins-golang python3-avocado-plugins-output-html python3-avocado-plugins-result-upload python3-avocado-plugins-varianter-cit python3-avocado-plugins-varianter-pict python3-avocado-plugins-varianter-yaml-to-mux
+RUN dnf -y clean all


### PR DESCRIPTION
Many times it's useful to have Avocado fully installed (all packages)
from RPM packages.  This container image will have installed all of
the latest Avocado COPR builds packages, triggered on every commit of
the master branch.

It will be available from:

  quay.io/avocado-framework/avocado-fedora-36-latest-copr

Signed-off-by: Cleber Rosa <crosa@redhat.com>