### PR TITLE
`Black` static checks update

### DIFF
--- a/selftests/style.sh
+++ b/selftests/style.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 echo "** Running black..."
 
-black --check .
+black --check --diff --color .


### PR DESCRIPTION
This will add `--diff` attribute to the `black` command. With the diff
attribute will be more clear what is the style issue and how it might be
fixed.

Reference: #5441
Signed-off-by: Jan Richter <jarichte@redhat.com>