### PR TITLE
Post test plugins

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -75,6 +75,19 @@ class TestPreDispatcher(EnabledExtensionManager):
         super().__init__("avocado.plugins.test.pre")
 
 
+class TestPostDispatcher(EnabledExtensionManager):
+
+    """
+    Calls extensions after Test execution
+
+    Automatically adds all the extension with entry points registered under
+    'avocado.plugins.test.post'
+    """
+
+    def __init__(self):
+        super().__init__("avocado.plugins.test.post")
+
+
 class ResultDispatcher(EnabledExtensionManager):
     def __init__(self):
         super().__init__("avocado.plugins.result")

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -178,6 +178,23 @@ class PreTest(Plugin):
         """
 
 
+class PostTest(Plugin):
+    """Base plugin interface for adding tasks after a test run.
+
+    This interface helps to create `avocado.core.nrunner.Task` for running
+    additional actions inside spawner environment after Test.
+    """
+
+    @abc.abstractmethod
+    def post_test_runnables(self, test_runnable, test_results):
+        """Entry point for creating runnables, which will be run after test.
+        :param test_runnable: Runnable of the Test itself.
+        :param test_results: Results of the Test itself.
+        :return: PreTest task runnables created by plugin.
+        :rtype: list of :class:`avocado.core.nrunner.Runnable`
+        """
+
+
 class ResultEvents(JobPreTests, JobPostTests):
     """Base plugin interface for event based (stream-able) results.
 

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -169,10 +169,11 @@ class PreTest(Plugin):
     """
 
     @abc.abstractmethod
-    def pre_test_runnables(self, test_runnable):
+    def pre_test_runnables(self, test_runnable, suite_config=None):
         """Entry point for creating runnables, which will be run before test.
 
         :param test_runnable: Runnable of the Test itself.
+        :param suite_config: Configuration dict relevant for the whole suite.
         :return: PreTest task runnables created by plugin.
         :rtype: list of :class:`avocado.core.nrunner.Runnable`
         """
@@ -186,10 +187,11 @@ class PostTest(Plugin):
     """
 
     @abc.abstractmethod
-    def post_test_runnables(self, test_runnable, test_results):
+    def post_test_runnables(self, test_runnable, test_results, suite_config=None):
         """Entry point for creating runnables, which will be run after test.
         :param test_runnable: Runnable of the Test itself.
         :param test_results: Results of the Test itself.
+        :param suite_config: Configuration dict relevant for the whole suite.
         :return: PreTest task runnables created by plugin.
         :rtype: list of :class:`avocado.core.nrunner.Runnable`
         """

--- a/avocado/plugins/dependency.py
+++ b/avocado/plugins/dependency.py
@@ -26,6 +26,7 @@ class DependencyResolver(PreTest):
 
     name = "dependency"
     description = "Dependency resolver for tests with dependencies"
+    is_cacheable = True
 
     @staticmethod
     def pre_test_runnables(test_runnable, suite_config=None):  # pylint: disable=W0221

--- a/avocado/plugins/dependency.py
+++ b/avocado/plugins/dependency.py
@@ -28,7 +28,7 @@ class DependencyResolver(PreTest):
     description = "Dependency resolver for tests with dependencies"
 
     @staticmethod
-    def pre_test_runnables(test_runnable):  # pylint: disable=W0221
+    def pre_test_runnables(test_runnable, suite_config=None):  # pylint: disable=W0221
         if not test_runnable.dependencies:
             return []
         dependency_runnables = []

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -66,6 +66,10 @@ class Plugins(CLICmd):
                 "Plugins that run before the execution of each test (test.pre):",
             ),
             (
+                dispatcher.TestPostDispatcher(),
+                "Plugins that run after the execution of each test (test.post):",
+            ),
+            (
                 dispatcher.ResultDispatcher(),
                 "Plugins that generate job result in different formats (result):",
             ),

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -280,6 +280,7 @@ class Runner(RunnerInterface):
             test_suite.name,
             self.status_server.uri,
             job.unique_id,
+            test_suite.config,
         )
         # pylint: disable=W0201
         self.runtime_tasks = graph.get_tasks_in_topological_order()

--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -213,6 +213,18 @@ priority. For example the default order is [plugin1, plugin2, plugin3, plugin4]
 the ``plugins.$type.order`` is [plugin2, plugin4] then the real order will be
 [plugin2, plugin4, plugin1, plugin3]
 
+Cacheable plugins
+================
+The results of Pre-test and Post-test plugins defined in :class:`avocado.core.plugin_interfaces.PreTest`
+and :class:`avocado.core.plugin_interfaces.PostTest` can be saved in cache. This is 
+very useful If the results can be used by other tests or even other avocado executions. 
+As an example of such plugin is `Dependency resolver` in :ref:`managing-requirements` 
+which installs dependencies for test into the test environment.
+
+As a default, all pre- / post-plugins are noncacheable. To make plugin cacheable you 
+have to set plugin variable `is_cacheable` to `True`, like this:
+
+.. literalinclude:: ../../../../../examples/plugins/test-pre-post/hello/hello.py
 
 New test type plugin example
 ============================

--- a/examples/plugins/test-pre-post/hello/hello.py
+++ b/examples/plugins/test-pre-post/hello/hello.py
@@ -1,0 +1,15 @@
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import PostTest, PreTest
+
+
+class HelloWorld(PreTest, PostTest):
+
+    name = "hello"
+    description = "The classical Hello World! plugin example."
+    is_cacheable = True
+
+    def pre_test_runnables(self, test_runnable, suite_config=None):
+        LOG_UI.info(self.description)
+
+    def post_test_runnables(self, test_runnable, test_results, suite_config=None):
+        LOG_UI.info(self.description)

--- a/examples/plugins/test-pre-post/hello/setup.py
+++ b/examples/plugins/test-pre-post/hello/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup(
+        name="avocado-hello-world-pre-post-test",
+        version="1.0",
+        description="Avocado Hello World pre and post test plugin",
+        py_modules=["hello"],
+        entry_points={
+            "avocado.plugins.test.pre": ["hello_pre = hello:HelloWorld"],
+            "avocado.plugins.test.post": ["hello_post = hello:HelloWorld"],
+        },
+    )

--- a/selftests/unit/test_task_runtime.py
+++ b/selftests/unit/test_task_runtime.py
@@ -4,7 +4,11 @@ from unittest import TestCase
 from avocado.core.nrunner.runnable import Runnable
 from avocado.core.nrunner.task import Task
 from avocado.core.suite import TestSuite
-from avocado.core.task.runtime import RuntimeTask, RuntimeTaskGraph
+from avocado.core.task.runtime import (
+    PostRuntimeTaskPrototype,
+    RuntimeTask,
+    RuntimeTaskGraph,
+)
 from avocado.utils import script
 from selftests.utils import TestCaseTmpDir
 
@@ -67,7 +71,12 @@ class DependencyGraph(TestCaseTmpDir):
             suite = TestSuite.from_config(config=config)
             tests = suite.get_test_variants()
             graph = RuntimeTaskGraph(tests, suite.name, 1, "")
-            runtime_tests = graph.get_tasks_in_topological_order()
+            runtime_tests = list(
+                filter(
+                    lambda x: type(x) is not PostRuntimeTaskPrototype,
+                    graph.get_tasks_in_topological_order(),
+                )
+            )
             self.assertTrue(runtime_tests[0].task.identifier.name.endswith("test_a"))
             self.assertTrue(runtime_tests[1].task.identifier.name.endswith("hello"))
             self.assertTrue(runtime_tests[2].task.identifier.name.endswith("test_b"))
@@ -83,7 +92,12 @@ class DependencyGraph(TestCaseTmpDir):
             suite = TestSuite.from_config(config=config)
             tests = suite.get_test_variants()
             graph = RuntimeTaskGraph(tests, suite.name, 1, "")
-            runtime_tests = graph.get_tasks_in_topological_order()
+            runtime_tests = list(
+                filter(
+                    lambda x: type(x) is not PostRuntimeTaskPrototype,
+                    graph.get_tasks_in_topological_order(),
+                )
+            )
             self.assertTrue(runtime_tests[0].task.identifier.name.endswith("hello"))
             self.assertTrue(runtime_tests[1].task.identifier.name.endswith("test_a"))
             self.assertTrue(runtime_tests[2].task.identifier.name.endswith("test_b"))

--- a/setup.py
+++ b/setup.py
@@ -403,6 +403,10 @@ if __name__ == "__main__":
             ],
             "avocado.plugins.test.pre": [
                 "dependency = avocado.plugins.dependency:DependencyResolver",
+                "sysinfo = avocado.plugins.sysinfo:SysInfoTest",
+            ],
+            "avocado.plugins.test.post": [
+                "sysinfo = avocado.plugins.sysinfo:SysInfoTest",
             ],
             "avocado.plugins.result": [
                 "xunit = avocado.plugins.xunit:XUnitResult",


### PR DESCRIPTION
Infrastructure for creating post-test plugins. Such plugin will
be able to add tasks after the test task. 

Introduces first post test plugin which is using this infrastructure the sysinfo plugin.
It adds sysinfo gathering into the suite run. It creates pre and
post sysinfo tasks in a suite which will be run before and after the
testing. Those tasks will gather sysinfo by sysinfo-runner and save it
into the test-results folder.

Reference: #5204, #3877
Signed-off-by: Jan Richter <jarichte@redhat.com>