### PR TITLE
Fixed the volume group creation error

### DIFF
--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -332,9 +332,10 @@ def vg_create(vg_name, pv_list, force=False):
         pv_list = " ".join(pv_list)
     else:
         pv_list = str(pv_list)
-    cmd += " %s %s" % (vg_name, pv_list)
     if force:
-        cmd += "%s -f -y" % cmd
+        cmd += " %s %s -f -y" % (vg_name, pv_list)
+    else:
+        cmd += " %s %s " % (vg_name, pv_list)
     process.run(cmd, sudo=True)
 
 


### PR DESCRIPTION
The volume group name and logical volume device parameters passed for vgcreate command were not properly handled
I have fixed the creation of the command to be executed with correct conditional statements

Signed-off-by: Pavaman Subramaniyam <pavsubra@linux.vnet.ibm.com>