### PR TITLE
Fixed the volume group creation error

### DIFF
--- a/avocado/utils/lv_utils.py
+++ b/avocado/utils/lv_utils.py
@@ -338,14 +338,13 @@ def vg_create(vg_name, pv_list, force=False):
     """
     if vg_check(vg_name):
         raise LVException(f"Volume group '{vg_name}' already exist")
-    cmd = "vgcreate"
     if isinstance(pv_list, list):
         pv_list = " ".join(pv_list)
     else:
         pv_list = str(pv_list)
-    cmd += f" {vg_name} {pv_list}"
+    cmd = f"vgcreate {vg_name} {pv_list}"
     if force:
-        cmd += f"{cmd} -f -y"
+        cmd = f"{cmd} -f -y"
     process.run(cmd, sudo=True)
 
 


### PR DESCRIPTION
The volume group name and logical volume device parameters passed for vgcreate command were not properly handled
I have fixed the creation of the command to be executed with correct conditional statements

Signed-off-by: Pavaman Subramaniyam <pavsubra@linux.vnet.ibm.com>