### PR TITLE
Travis CI: bump pyenchant version

### DIFF
--- a/requirements-selftests.txt
+++ b/requirements-selftests.txt
@@ -2,7 +2,7 @@
 
 # inspektor (static and style checks)
 isort==4.3.21
-pyenchant==2.0.0
+pyenchant==3.2.2
 pylint==2.5.0
 astroid==2.4.0
 inspektor==0.5.2


### PR DESCRIPTION
Version 2.0.0 is having trouble being install on Python 3.7, erroring
with:

   Collecting pyenchant==2.0.0
     Downloading pyenchant-2.0.0.tar.gz (64 kB)
     Preparing metadata (setup.py) ... error
     error: subprocess-exited-with-error

     × python setup.py egg_info did not run successfully.
     │ exit code: 1
     ╰─> [22 lines of output]

Reference: https://app.travis-ci.com/github/avocado-framework/avocado/jobs/577123468#L364
Signed-off-by: Cleber Rosa <crosa@redhat.com>