### PR TITLE
[82lts] Update Travis CI distro version to focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: focal
 language: python
 cache: pip
 arch: amd64

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ ifndef AVOCADO_OPTIONAL_PLUGINS_TESTS
 AVOCADO_OPTIONAL_PLUGINS_TESTS=$(patsubst %,%/tests/, $(AVOCADO_OPTIONAL_PLUGINS))
 endif
 
-ifeq ($(TRAVIS_CI_ARCH), arm64)
+ifdef TRAVIS
 PARALLEL_ARG=--nrunner-max-parallel-tasks=1
 else
 PARALLEL_ARG=

--- a/selftests/unit/test_utils_network.py
+++ b/selftests/unit/test_utils_network.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import unittest.mock
 
@@ -53,6 +54,8 @@ def get_all_local_addrs():
 
 class FreePort(unittest.TestCase):
 
+    @unittest.skipIf(os.getenv('TRAVIS'),
+                     'TRAVIS Environment is unsuitable for this test')
     @unittest.skipUnless(HAS_NETIFACES,
                          "netifaces library not available")
     def test_is_port_free(self):


### PR DESCRIPTION
Travis CI images based on xenial have been bitrotting, and Python 3.7.1 installed on top of it is particularly broken.
    
With this bump, the number of sucessfull jobs in Travis go from 2 (Python 3.5 and 3.6) to 5 (Python 3.5, 3.6, 3.7, 3.8 and Code Coverage).