### PR TITLE
[82lts] Packit HTML deps

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -103,6 +103,8 @@ these days a framework) to perform automated testing.
 %if (0%{?fedora} && 0%{?fedora} < 29) || 0%{?rhel}
 sed -e "s/'PyYAML>=4.2b2'/'PyYAML>=3.12'/" -i optional_plugins/varianter_yaml_to_mux/setup.py
 %endif
+sed -e "s/'markupsafe<2.0.0'/'markupsafe'/" -i optional_plugins/html/setup.py
+sed -e "s/'jinja2<3.0.0'/'jinja2'/" -i optional_plugins/html/setup.py
 %py3_build
 pushd optional_plugins/html
 %py3_build
@@ -431,6 +433,8 @@ Again Shell code (and possibly other similar shells).
 %changelog
 * Tue Aug 16 2022 Cleber Rosa <crosa@redhat.com> - 82.1-2
 - Removed empty conditional block
+- Allow for any version of markupsafe and jinja2 to fulfill
+  requirement
 
 * Fri Oct  8 2021 Cleber Rosa <cleber@redhat.com> - 82.1-1
 - New release

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -34,7 +34,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-%{srcname}
 Version: 82.1
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.github.io/
@@ -102,8 +102,6 @@ these days a framework) to perform automated testing.
 %build
 %if (0%{?fedora} && 0%{?fedora} < 29) || 0%{?rhel}
 sed -e "s/'PyYAML>=4.2b2'/'PyYAML>=3.12'/" -i optional_plugins/varianter_yaml_to_mux/setup.py
-%endif
-%if 0%{?rhel}
 %endif
 %py3_build
 pushd optional_plugins/html
@@ -431,6 +429,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Tue Aug 16 2022 Cleber Rosa <crosa@redhat.com> - 82.1-2
+- Removed empty conditional block
+
 * Fri Oct  8 2021 Cleber Rosa <cleber@redhat.com> - 82.1-1
 - New release
 


### PR DESCRIPTION
The versions available on the current target distros are either equal or superior to the ones defined in setup.py.
    
This was tested with Fedora rawhide (F38) packages and the resulting RPMs generated HTML reports just fine.