### PR TITLE
bystatus.py: Use relative path to create symbolic link

### DIFF
--- a/avocado/plugins/bystatus.py
+++ b/avocado/plugins/bystatus.py
@@ -39,4 +39,6 @@ class ByStatusLink(ResultEvents):
         link = state.get("logdir")
         where = os.path.join(os.path.dirname(link), "by-status", state.get("status"))
         os.makedirs(where, exist_ok=True)
-        os.symlink(link, os.path.join(where, os.path.basename(link)))
+        os.symlink(
+            os.path.relpath(link, where), os.path.join(where, os.path.basename(link))
+        )

--- a/selftests/functional/plugin/test_bystatus.py
+++ b/selftests/functional/plugin/test_bystatus.py
@@ -21,5 +21,8 @@ class ByStatusTest(TestCaseTmpDir):
             status = test["status"]
             where = os.path.dirname(logdir)
             basename = os.path.basename(logdir)
-            link = os.path.join(where, "by-status", status, basename)
-            self.assertTrue(os.path.exists(os.readlink(link)))
+            status_dir = os.path.join(where, "by-status", status)
+            link = os.path.join(status_dir, basename)
+            sym_link = os.readlink(link)
+            self.assertTrue(os.path.exists(os.path.join(status_dir, sym_link)))
+            self.assertTrue(os.path.samefile(logdir, link))


### PR DESCRIPTION
bystatus.py: Use relative path to create symbolic link

The current design uses an absolute path to create symbolic link, this
means no matter where the log files are moved/uploaded, the soft link
always link to the original directory. This doesn't make sense, so
replace it to use relative path, make them link to the correct path.
    
Signed-off-by: Yihuang Yu <yihyu@redhat.com>
