### PR TITLE
Cache interface

### DIFF
--- a/avocado/core/dependencies/requirements/cache/backends/sqlite.py
+++ b/avocado/core/dependencies/requirements/cache/backends/sqlite.py
@@ -333,3 +333,35 @@ def get_all_environments_with_requirement(
             else:
                 requirements[row[0]] = [(row[1], row[2])]
     return requirements
+
+
+def get_all_requirements():
+    """Fetches all requirements from database.
+
+    :return: Dict with all environments which has requirements.
+
+    """
+    requirements = {}
+    if not os.path.exists(CACHE_DATABASE_PATH):
+        return requirements
+
+    sql = "SELECT * FROM requirement"
+
+    with sqlite3.connect(
+        CACHE_DATABASE_PATH, detect_types=sqlite3.PARSE_DECLTYPES
+    ) as conn:
+        cursor = conn.cursor()
+        result = cursor.execute(sql)
+
+        for row in result.fetchall():
+            environment_type = row[0]
+            if environment_type not in requirements:
+                requirements[environment_type] = []
+            requirements[environment_type].append(
+                {
+                    "environment": row[1],
+                    "requirement_type": row[2],
+                    "requirement": row[3],
+                }
+            )
+    return requirements

--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -144,3 +144,8 @@ class SpawnerDispatcher(EnabledExtensionManager):
 class RunnableRunnerDispatcher(EnabledExtensionManager):
     def __init__(self):
         super().__init__("avocado.plugins.runnable.runner")
+
+
+class CacheDispatcher(EnabledExtensionManager):
+    def __init__(self):
+        super().__init__("avocado.plugins.cache")

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -451,3 +451,17 @@ class RunnableRunner(Plugin):
         :param runnable: a Runnable instance that describes what is to be run
         :type runnable: :class:`avocado.core.nrunner.Runnable`
         """
+
+
+class Cache(Plugin):
+    """Plugin for manipulating with cache interface"""
+
+    @abc.abstractmethod
+    def list(self):
+        """List all cache entries
+
+        Creates list of cache entries which represents current cache state.
+
+        :return: Human-readable list of entries which will be printed to console.
+        :rtype: str
+        """

--- a/avocado/plugins/cache.py
+++ b/avocado/plugins/cache.py
@@ -1,0 +1,74 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2022
+# Author: Jan Richter <jarichte@redhat.com>
+
+from avocado.core.dispatcher import CacheDispatcher
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.settings import settings
+
+
+class Cache(CLICmd):
+
+    """
+    Implements the avocado 'cache' subcommand
+    """
+
+    name = "cache"
+    description = "Interface for manipulating the Avocado cache"
+
+    def _list_plugin_entries(self, plugins, selected_plugins):
+        if not selected_plugins:
+            selected_plugins = [p.name for p in plugins]
+        for plugin in plugins:
+            if plugin.name in selected_plugins:
+                LOG_UI.debug("%s:", plugin.obj.name)
+                cache_list = "\t" + "\t".join(plugin.obj.list().splitlines(True))
+                LOG_UI.debug("%s\n", cache_list)
+
+    def configure(self, parser):
+        """
+        Add the subparser for the cache action.
+
+        :param parser: The Avocado command line application parser
+        :type parser: :class:`avocado.core.parser.ArgumentParser`
+        """
+        parser = super().configure(parser)
+        subcommands = parser.add_subparsers(dest="cache_subcommand")
+        subcommands.required = True
+        list_help_msg = "List entries in avocado cache"
+        list_parser = subcommands.add_parser("list", help=list_help_msg)
+        settings.register_option(
+            section="cache",
+            key="list",
+            key_type=list,
+            default=[],
+            help_msg=list_help_msg,
+        )
+
+        settings.add_argparser_to_option(
+            namespace="cache.list",
+            nargs="*",
+            metavar="CACHE_TYPE",
+            parser=list_parser,
+            long_arg=None,
+            positional_arg=True,
+            allow_multiple=True,
+        )
+
+    def run(self, config):
+        dispatcher = CacheDispatcher()
+        plugins = dispatcher.get_extentions_by_priority()
+        subcommand = config.get("cache_subcommand")
+        if subcommand == "list":
+            self._list_plugin_entries(plugins, config.get("cache.list"))

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -93,6 +93,10 @@ class Plugins(CLICmd):
                 dispatcher.RunnableRunnerDispatcher(),
                 "Plugins that run runnables (under a task and spawner) (runnable.runner): ",
             ),
+            (
+                dispatcher.CacheDispatcher(),
+                "Plugins that manipulates with avocado cache: ",
+            ),
         ]
         for plugins_active, msg in plugin_types:
             LOG_UI.info(msg)

--- a/avocado/plugins/requirement_cache.py
+++ b/avocado/plugins/requirement_cache.py
@@ -1,0 +1,51 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2022
+# Author: Jan Richter <jarichte@redhat.com>
+
+from avocado.core import output
+from avocado.core.dependencies.requirements.cache.backends import sqlite
+from avocado.core.plugin_interfaces import Cache
+from avocado.utils import astring
+
+
+class RequirementCache(Cache):
+
+    name = "requirement"
+    description = "Provides requirement cache entries"
+
+    def list(self):
+        environments = sqlite.get_all_requirements()
+        requirement_list = ""
+        for enviroment_type, requirements in environments.items():
+            requirement_list += f"{enviroment_type}:\n"
+
+            requirements_matrix = [
+                [
+                    requirement["environment"],
+                    requirement["requirement_type"],
+                    requirement["requirement"],
+                ]
+                for requirement in requirements
+            ]
+            header = (
+                output.TERM_SUPPORT.header_str("Environment"),
+                output.TERM_SUPPORT.header_str("Requirement_type"),
+                output.TERM_SUPPORT.header_str("Requirement"),
+            )
+            requirement_list += "\t" + "\t".join(
+                astring.tabular_output(
+                    requirements_matrix, header=header, strip=True
+                ).splitlines(True)
+            )
+            requirement_list += "\n\n"
+        return requirement_list

--- a/avocado/plugins/vmimage.py
+++ b/avocado/plugins/vmimage.py
@@ -4,7 +4,7 @@ import re
 
 from avocado.core import exit_codes, output
 from avocado.core.output import LOG_UI
-from avocado.core.plugin_interfaces import CLICmd
+from avocado.core.plugin_interfaces import Cache, CLICmd
 from avocado.core.settings import settings
 from avocado.utils import astring, vmimage
 
@@ -99,8 +99,7 @@ def display_images_list(images):
         output.TERM_SUPPORT.header_str("Architecture"),
         output.TERM_SUPPORT.header_str("File"),
     )
-    for line in astring.iter_tabular_output(image_matrix, header=header, strip=True):
-        LOG_UI.debug(line)
+    return astring.tabular_output(image_matrix, header=header, strip=True)
 
 
 class VMimage(CLICmd):
@@ -160,7 +159,7 @@ class VMimage(CLICmd):
         subcommand = config.get("vmimage_subcommand")
         if subcommand == "list":
             images = list_downloaded_images()
-            display_images_list(images)
+            LOG_UI.debug(display_images_list(images))
         elif subcommand == "get":
             name = config.get("vmimage.get.distro")
             version = config.get("vmimage.get.version")
@@ -171,5 +170,15 @@ class VMimage(CLICmd):
                 LOG_UI.debug("The requested image could not be downloaded")
                 return exit_codes.AVOCADO_FAIL
             LOG_UI.debug("The image was downloaded:")
-            display_images_list([image])
+            LOG_UI.debug(display_images_list([image]))
         return exit_codes.AVOCADO_ALL_OK
+
+
+class VMimageCache(Cache):
+
+    name = "vmimage"
+    description = "Provides VM images acquired from official repositories"
+
+    def list(self):
+        images = list_downloaded_images()
+        return display_images_list(images)

--- a/setup.py
+++ b/setup.py
@@ -394,6 +394,7 @@ if __name__ == "__main__":
                 "assets = avocado.plugins.assets:Assets",
                 "jobs = avocado.plugins.jobs:Jobs",
                 "replay = avocado.plugins.replay:Replay",
+                "cache = avocado.plugins.cache:Cache",
             ],
             "avocado.plugins.job.prepost": [
                 "jobscripts = avocado.plugins.jobscripts:JobScripts",

--- a/setup.py
+++ b/setup.py
@@ -452,6 +452,9 @@ if __name__ == "__main__":
                 "process = avocado.plugins.spawners.process:ProcessSpawner",
                 "podman = avocado.plugins.spawners.podman:PodmanSpawner",
             ],
+            "avocado.plugins.cache": [
+                "vmimage = avocado.plugins.vmimage:VMimageCache",
+            ],
         },
         zip_safe=False,
         test_suite="selftests",

--- a/setup.py
+++ b/setup.py
@@ -454,6 +454,7 @@ if __name__ == "__main__":
             ],
             "avocado.plugins.cache": [
                 "vmimage = avocado.plugins.vmimage:VMimageCache",
+                "requirement = avocado.plugins.requirement_cache:RequirementCache",
             ],
         },
         zip_safe=False,


### PR DESCRIPTION
This is an initial PR which crates avocado cache interface. It introduces new plugin "Cache" which will be responsible for manipulating with cache, and it's representation through avocado interface. This PR also adds vmimage cache and requirements cache to this interface.

For now, it supports only listing of cache entries, but it is possible to expand for features like prune or edit.

Reference: https://github.com/avocado-framework/avocado/issues/5453
Signed-off-by: Jan Richter <jarichte@redhat.com>