### PR TITLE
Travis: add exclusion condition for SysInfo html test

### DIFF
--- a/selftests/functional/test_sysinfo.py
+++ b/selftests/functional/test_sysinfo.py
@@ -81,8 +81,9 @@ class SysInfoTest(TestCaseTmpDir):
 
         # Try to find some strings on HTML
         self.assertNotEqual(output.find('Filesystem'), -1)
-        self.assertNotEqual(output.find('root='), -1)
         self.assertNotEqual(output.find('MemAvailable'), -1)
+        if not (os.getenv('TRAVIS') and os.getenv('TRAVIS_CPU_ARCH') == 'arm64'):
+            self.assertNotEqual(output.find('root='), -1)
 
     def run_sysinfo_interrupted(self, sleep, timeout, exp_duration):
         commands_path = os.path.join(self.tmpdir.name, "commands")


### PR DESCRIPTION
The virtualization type used on Travis for arm64 (aarch64) is LXD,
which normally does not have a root device in the "/proc/cmdline"
file.

Reference: https://docs.travis-ci.com/user/reference/overview/#which-one-do-i-use
Signed-off-by: Cleber Rosa <crosa@redhat.com>