### PR TITLE
[92lts] nrunner: fix behavior of status server "uri" and "listen"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
 
 install:
     - pip install -r requirements-dev.txt
+    - python3 setup.py develop
 
 script:
     - make check

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -65,7 +65,8 @@ class RunnerInit(Init):
                                  help_msg=help_msg)
 
         help_msg = ('URI for listing the status server. Usually '
-                    'a "HOST:PORT" string')
+                    'a "HOST:PORT" string. This is only effective '
+                    'if "status_server_auto" is disabled')
         settings.register_option(section=section,
                                  key='status_server_listen',
                                  default='127.0.0.1:8888',
@@ -74,7 +75,8 @@ class RunnerInit(Init):
 
         help_msg = ('URI for connecting to the status server, usually '
                     'a "HOST:PORT" string. Use this if your status server '
-                    'is in another host, or different port')
+                    'is in another host, or different port. This is only '
+                    'effective if "status_server_auto" is disabled')
         settings.register_option(section=section,
                                  key='status_server_uri',
                                  default='127.0.0.1:8888',

--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -13,9 +13,16 @@
 # Copyright: Red Hat Inc. 2016
 # Author: Cleber Rosa <crosa@redhat.com>
 
+import sys
+
 from setuptools import find_packages, setup
 
 VERSION = open("VERSION", "r").read().strip()
+
+if sys.version_info < (3, 7):
+    markupsafe = 'markupsafe==2.0.1'
+else:
+    markupsafe = 'markupsafe'
 
 setup(name='avocado-framework-plugin-result-html',
       description='Avocado HTML Report for Jobs',
@@ -25,7 +32,7 @@ setup(name='avocado-framework-plugin-result-html',
       url='http://avocado-framework.github.io/',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['avocado-framework==%s' % VERSION, 'jinja2'],
+      install_requires=['avocado-framework==%s' % VERSION, markupsafe, 'jinja2'],
       entry_points={
           'avocado.plugins.cli': [
               'html = avocado_result_html:HTML',

--- a/optional_plugins/html/tests/test_html_result.py
+++ b/optional_plugins/html/tests/test_html_result.py
@@ -29,8 +29,9 @@ class HtmlResultTest(unittest.TestCase):
 
         # Try to find some strings on HTML
         self.assertNotEqual(output.find('Filesystem'), -1)
-        self.assertNotEqual(output.find('root='), -1)
         self.assertNotEqual(output.find('MemAvailable'), -1)
+        if not (os.getenv('TRAVIS') and os.getenv('TRAVIS_CPU_ARCH') == 'arm64'):
+            self.assertNotEqual(output.find('root='), -1)
 
     def check_output_files(self, debug_log):
         base_dir = os.path.dirname(debug_log)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 # inspektor (static and style checks)
 isort==5.8.0
 pyenchant==3.2.0
+pycodestyle==2.8.0
 pylint==2.8.3
 inspektor==0.5.2
 autopep8==1.5.7

--- a/selftests/jobs/status_server_auto
+++ b/selftests/jobs/status_server_auto
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import sys
+
+from avocado.core.job import Job
+from avocado.core.suite import TestSuite
+
+# This bad location serves to test the "status_server_auto"
+# configuration
+status_server = '/path/to/a/very/bad/non-existing/location'
+
+config = {
+    "run.test_runner": "nrunner",
+    "nrunner.status_server_auto": True,
+    "nrunner.status_server_listen": status_server,
+    "nrunner.status_server_uri": status_server,
+    "run.references": ["examples/tests/passtest.py"],
+}
+
+suite = TestSuite.from_config(config, name="1")
+with Job(config, [suite]) as j:
+    result = j.run()
+
+# Check that one test actually ran and results were recorded. The
+# test's success will be checked by the job execution result
+assert len(j.result.tests) == 1
+
+sys.exit(result)

--- a/selftests/jobs/status_server_different_uri_listen
+++ b/selftests/jobs/status_server_different_uri_listen
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import tempfile
+
+from avocado.core.job import Job
+from avocado.core.suite import TestSuite
+
+status_server_dir = tempfile.TemporaryDirectory()
+status_server_listen = os.path.join(status_server_dir.name, "status_server.socket")
+status_server_uri = os.path.join(status_server_dir.name, "client_link_to_server_socket")
+
+assert status_server_listen != status_server_uri
+os.symlink(status_server_listen, status_server_uri)
+
+config = {
+    "run.test_runner": "nrunner",
+    "nrunner.status_server_auto": False,
+    "nrunner.status_server_listen": status_server_listen,
+    "nrunner.status_server_uri": status_server_uri,
+    "run.references": ["examples/tests/passtest.py"],
+}
+
+suite = TestSuite.from_config(config, name="1")
+with Job(config, [suite]) as j:
+    result = j.run()
+
+# Check that one test actually ran and results were recorded. The
+# test's success will be checked by the job execution result
+assert len(j.result.tests) == 1
+
+status_server_dir.cleanup()
+sys.exit(result)


### PR DESCRIPTION
The independence of `--nrunner-status-server-uri` and `--nrunner-status-server-listen` is not being respected.
    
Because `Tasks` are being created with whatever is the current status server URI (either determined automatically, or with the "listen" config), the "uri" config goes unused.