### PR TITLE
rpm.py: change prepare_source function built_option

### DIFF
--- a/avocado/utils/software_manager/backends/rpm.py
+++ b/avocado/utils/software_manager/backends/rpm.py
@@ -188,7 +188,7 @@ class RpmBackend(BaseBackend):
         :return path: build directory
         """
 
-        build_option = "-bp"
+        build_option = "-bc"
         if dest_path is not None:
             build_option += f" --define '_builddir {dest_path}'"
         else:


### PR DESCRIPTION
Change prepare_source function built_option from -bp to -bc. Function named 'prepare_source' used for compiling and testing the distribution provided packages.
Current way of doing:
    Download source package
    rpmbuild -bp <package name>
    Configure using 'configure' with out any options
    Compile
    Run the unit test cases
the above way is not considering the distribution provided configuration options.
Changing the build option from '-bp' to '-bc' will help in compiling with distribution provided config options.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>