### PR TITLE
Deprecate nrunner prefix from options

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -271,7 +271,9 @@ def register_core_options():
         '"avocado plugins" and find the list of valid runners '
         'under the "Plugins that run test suites on a job '
         '(runners) section.  Defaults to "nrunner", which is '
-        "the new runner and only runner supported at this moment."
+        "the new runner and only runner supported at this moment. "
+        "This option name is currently DEPRECATED and will be "
+        'renamed to "run.suite_runner" on Avocado 100.0 and later.'
     )
     stgs.register_option(
         section="run", key="test_runner", default="nrunner", help_msg=help_msg

--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -222,7 +222,6 @@ class List(CLICmd):
         verbose = config.get("core.verbose")
         write_to_json_file = config.get("list.write_to_json_file")
         config["run.ignore_missing_references"] = True
-        config["run.test_runner"] = "nrunner"
         try:
             suite = TestSuite.from_config(config)
             matrix = self._get_resolution_matrix(suite)

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -100,11 +100,34 @@ class Run(CLICmd):
             short_arg="-p",
         )
 
+        help_msg = (
+            "Selects the runner implementation from one of the "
+            "installed and active implementations.  You can run "
+            '"avocado plugins" and find the list of valid runners '
+            'under the "Plugins that run test suites on a job '
+            '(runners) section.  Defaults to "nrunner", which is '
+            "the new runner and only runner supported at this moment. "
+        )
+        settings.add_argparser_to_option(
+            namespace="run.test_runner",
+            parser=parser,
+            long_arg="--suite-runner",
+            metavar="SUITE_RUNNER",
+            help_msg=help_msg,
+        )
+
+        help_msg = (
+            "This option name is currently DEPRECATED and will be "
+            "removed on Avocado 100.0 and later.  Please use "
+            '"--suite-runner" instead.'
+        )
         settings.add_argparser_to_option(
             namespace="run.test_runner",
             parser=parser,
             long_arg="--test-runner",
             metavar="TEST_RUNNER",
+            help_msg=help_msg,
+            allow_multiple=True,
         )
 
         help_msg = "Instead of running the test only list them and log their params."

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -69,8 +69,8 @@ class RunnerInit(Init):
         )
 
         help_msg = (
-            'URI for listing the status server. Usually a "HOST:PORT" string. '
-            'This is only effective if "status_server_auto" is disabled'
+            'URI where status server will listen on. Usually a "HOST:PORT" '
+            'string. This is only effective if "status_server_auto" is disabled'
         )
         settings.register_option(
             section=section,

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -155,43 +155,122 @@ class RunnerCLI(CLI):
         settings.add_argparser_to_option(
             namespace="nrunner.shuffle",
             parser=parser,
+            long_arg="--shuffle",
+            action="store_true",
+        )
+
+        help_msg = (
+            "This option is currently DEPRECATED and will not be available "
+            'on Avocado 100.0 and later.  Please use "--shuffle" instead.'
+        )
+        settings.add_argparser_to_option(
+            namespace="nrunner.shuffle",
+            parser=parser,
             long_arg="--nrunner-shuffle",
             action="store_true",
+            help_msg=help_msg,
+            allow_multiple=True,
         )
 
         settings.add_argparser_to_option(
             namespace="nrunner.status_server_auto",
             parser=parser,
+            long_arg="--status-server-disable-auto",
+            action="store_false",
+        )
+
+        help_msg = (
+            "This option is currently DEPRECATED and will not be available "
+            'on Avocado 100.0 and later.  Please use "--status-server-disable-auto '
+            "instead."
+        )
+        settings.add_argparser_to_option(
+            namespace="nrunner.status_server_auto",
+            parser=parser,
             long_arg="--nrunner-status-server-disable-auto",
             action="store_false",
+            help_msg=help_msg,
+            allow_multiple=True,
         )
 
         settings.add_argparser_to_option(
             namespace="nrunner.status_server_listen",
             parser=parser,
+            long_arg="--status-server-listen",
+            metavar="HOST_PORT",
+        )
+
+        help_msg = (
+            "This option is currently DEPRECATED and will not be available "
+            'on Avocado 100.0 and later.  Please use "--status-server-listen" instead.'
+        )
+        settings.add_argparser_to_option(
+            namespace="nrunner.status_server_listen",
+            parser=parser,
             long_arg="--nrunner-status-server-listen",
             metavar="HOST_PORT",
+            help_msg=help_msg,
+            allow_multiple=True,
         )
 
         settings.add_argparser_to_option(
             namespace="nrunner.status_server_uri",
             parser=parser,
+            long_arg="--status-server-uri",
+            metavar="HOST_PORT",
+        )
+
+        help_msg = (
+            "This option is currently DEPRECATED and will not be available "
+            'on Avocado 100.0 and later.  Please use "--status-server-uri" instead.'
+        )
+        settings.add_argparser_to_option(
+            namespace="nrunner.status_server_uri",
+            parser=parser,
             long_arg="--nrunner-status-server-uri",
             metavar="HOST_PORT",
+            help_msg=help_msg,
+            allow_multiple=True,
         )
 
         settings.add_argparser_to_option(
             namespace="nrunner.max_parallel_tasks",
             parser=parser,
+            long_arg="--max-parallel-tasks",
+            metavar="NUMBER_OF_TASKS",
+        )
+
+        help_msg = (
+            "This option is currently DEPRECATED and will not be available "
+            'on Avocado 100.0 and later.  Please use "--max-parallel-tasks" instead.'
+        )
+        settings.add_argparser_to_option(
+            namespace="nrunner.max_parallel_tasks",
+            parser=parser,
             long_arg="--nrunner-max-parallel-tasks",
             metavar="NUMBER_OF_TASKS",
+            help_msg=help_msg,
+            allow_multiple=True,
         )
 
         settings.add_argparser_to_option(
             namespace="nrunner.spawner",
             parser=parser,
+            long_arg="--spawner",
+            metavar="SPAWNER",
+        )
+
+        help_msg = (
+            "This option is currently DEPRECATED and will not be available "
+            'on Avocado 100.0 and later.  Please use "--spawner" instead.'
+        )
+        settings.add_argparser_to_option(
+            namespace="nrunner.spawner",
+            parser=parser,
             long_arg="--nrunner-spawner",
             metavar="SPAWNER",
+            help_msg=help_msg,
+            allow_multiple=True,
         )
 
     def run(self, config):

--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -349,13 +349,8 @@ Running magic tests
 -------------------
 
 The common way of running Avocado tests is to run them through
-``avocado run``.  In this case, we're discussing tests for the
-"nrunner" architecture, so the common way of running these "magic"
-tests is through a command starting with ``avocado
-run --test-runner=nrunner``.
-
-To run both the ``pass`` and ``fail`` magic tests, you'd run
-``avocado run -- pass fail``::
+``avocado run``.  To run both the ``pass`` and ``fail`` magic tests,
+you'd run ``avocado run -- pass fail``::
 
   $ avocado run -- pass fail
   JOB ID     : 86fd45f8c1f2fe766c252eefbcac2704c2106db9

--- a/docs/source/guides/user/chapters/dependencies.rst
+++ b/docs/source/guides/user/chapters/dependencies.rst
@@ -117,7 +117,7 @@ Podman Image
 Support pulling podman images ahead of test execution time.  This
 should only be used explicitly if a test interacts with ``podman``
 directly, say by executing containers on its own.  If you are using
-the ``podman`` spawner (``--nrunner-spawner=podman``) this will have no
+the ``podman`` spawner (``--spawner=podman``) this will have no
 effect on the spawner.
 
  * `type`: `podman-image`

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -101,10 +101,10 @@ soon as possible.
 Due to our current runner architecture, tests are executed in parallel by
 default.  The ``--failfast`` option work on the best effort to cancel tests
 that have not started yet. To replicate the same behavior as the legacy runner,
-use ``--nrunner-max-parallel-tasks=1`` to limit the number of tasks executed in
+use ``--max-parallel-tasks=1`` to limit the number of tasks executed in
 parallel::
 
-    $ avocado run --failfast --nrunner-max-parallel-tasks=1 /bin/true /bin/false /bin/true /bin/true
+    $ avocado run --failfast --max-parallel-tasks=1 /bin/true /bin/false /bin/true /bin/true
     JOB ID     : 76bfe0e5cfa5efac3ab6881ee501cc5d4b69f913
     JOB LOG    : $HOME/avocado/job-results/job-2021-09-27T16.41-76bfe0e/job.log
      (1/4) /bin/true: STARTED

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -182,21 +182,50 @@ Options for subcommand `run` (`avocado run --help`)::
                             Load the Variants from a JSON serialized file
 
     nrunner specific options:
-      --nrunner-shuffle     Shuffle the tasks to be executed
+      --shuffle             Shuffle the tasks to be executed
+      --nrunner-shuffle     This option is currently DEPRECATED and will not be
+                            available on Avocado 100.0 and later. Please use "--
+                            shuffle" instead.
+      --status-server-disable-auto
+                            If the status server should automatically choose a
+                            "status_server_listen" and "status_server_uri"
+                            configuration. Default is to auto configure a status
+                            server.
+      --nrunner-status-server-disable-auto
+                            This option is currently DEPRECATED and will not be
+                            available on Avocado 100.0 and later. Please use "--
+                            status-server-disable-auto instead.
+      --status-server-listen HOST_PORT
+                            URI where status server will listen on. Usually a
+                            "HOST:PORT" string. This is only effective if
+                            "status_server_auto" is disabled
       --nrunner-status-server-listen HOST_PORT
-                            URI for listing the status server. Usually a
-                            "HOST:PORT" string
-      --nrunner-status-server-uri HOST_PORT
+                            This option is currently DEPRECATED and will not be
+                            available on Avocado 100.0 and later. Please use "--
+                            status-server-listen" instead.
+      --status-server-uri HOST_PORT
                             URI for connecting to the status server, usually a
                             "HOST:PORT" string. Use this if your status server is
-                            in another host, or different port
-      --nrunner-max-parallel-tasks NUMBER_OF_TASKS
+                            in another host, or different port. This is only
+                            effective if "status_server_auto" is disabled
+      --nrunner-status-server-uri HOST_PORT
+                            This option is currently DEPRECATED and will not be
+                            available on Avocado 100.0 and later. Please use "--
+                            status-server-uri" instead.
+      --max-parallel-tasks NUMBER_OF_TASKS
                             Number of maximum number tasks running in parallel.
                             You can disable parallel execution by setting this to
                             1. Defaults to the amount of CPUs on this machine.
-      --nrunner-spawner SPAWNER
-                            Spawn tasks in a specific spawner. Available spawners:
+      --nrunner-max-parallel-tasks NUMBER_OF_TASKS
+                            This option is currently DEPRECATED and will not be
+                            available on Avocado 100.0 and later. Please use "--
+                            max-parallel-tasks" instead.
+      --spawner SPAWNER     Spawn tasks in a specific spawner. Available spawners:
                             'process' and 'podman'
+      --nrunner-spawner SPAWNER
+                            This option is currently DEPRECATED and will not be
+                            available on Avocado 100.0 and later. Please use "--
+                            spawner" instead.
 
     podman spawner specific options:
       --spawner-podman-bin PODMAN_BIN


### PR DESCRIPTION
The `--nrunner-$option`s made sense when the old runner was available. Nowadays, it's just more typing and confusion to users.

Also, this PR makes Avocado favor the `--suite-runner` instead of the `--test-runner` command line option, but still allowing for the later as a deprecated option.