### PR TITLE
Drop nrunner prefix from options [v2]

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -256,13 +256,11 @@ def register_core_options():
         "installed and active implementations.  You can run "
         '"avocado plugins" and find the list of valid runners '
         'under the "Plugins that run test suites on a job '
-        '(runners) section.  Defaults to "nrunner", which is '
-        "the new runner and only runner supported at this moment. "
-        "This option name is currently DEPRECATED and will be "
-        'renamed to "run.suite_runner" on Avocado 100.0 and later.'
+        '(runners)" section.  Defaults to "nrunner", which is '
+        "the only runner that ships with core Avocado at this moment."
     )
     stgs.register_option(
-        section="run", key="test_runner", default="nrunner", help_msg=help_msg
+        section="run", key="suite_runner", default="nrunner", help_msg=help_msg
     )
 
 

--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -124,9 +124,9 @@ class VarianterDispatcher(EnabledExtensionManager):
         )
 
 
-class RunnerDispatcher(EnabledExtensionManager):
+class SuiteRunnerDispatcher(EnabledExtensionManager):
     def __init__(self):
-        super().__init__("avocado.plugins.runner")
+        super().__init__("avocado.plugins.suite.runner")
 
 
 class InitDispatcher(EnabledExtensionManager):

--- a/avocado/core/nrunner/task.py
+++ b/avocado/core/nrunner/task.py
@@ -119,9 +119,7 @@ class Task:
         self.category = category
         self.job_id = job_id
         self.status_services = []
-        status_uris = status_uris or self.runnable.config.get(
-            "nrunner.status_server_uri"
-        )
+        status_uris = status_uris or self.runnable.config.get("run.status_server_uri")
         if status_uris is not None:
             if type(status_uris) is not list:
                 status_uris = [status_uris]

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -278,11 +278,11 @@ class Discoverer(Plugin, ResolverMixin):
         """
 
 
-class Runner(Plugin):
-    """Base plugin interface for test runners.
+class SuiteRunner(Plugin):
+    """Base plugin interface for runners for suites.
 
-    This is the interface a job uses to drive the tests execution via
-    compliant test runners.
+    This is the interface a job uses to drive the tests execution in a
+    suite.
 
     NOTE: This interface is not to be confused with the internal
     interface or idiosyncrasies of the :ref:`nrunner`.

--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -26,7 +26,7 @@ class StatusServer:
         return self._uri
 
     async def create_server(self):
-        limit = settings.as_dict().get("nrunner.status_server_buffer_size")
+        limit = settings.as_dict().get("run.status_server_buffer_size")
         if ":" in self._uri:
             host, port = self._uri.split(":")
             port = int(port)

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -16,7 +16,7 @@ import os
 from enum import Enum
 from uuid import uuid4
 
-from avocado.core.dispatcher import RunnerDispatcher
+from avocado.core.dispatcher import SuiteRunnerDispatcher
 from avocado.core.exceptions import (
     JobTestSuiteReferenceResolutionError,
     OptionValidationError,
@@ -144,7 +144,7 @@ class TestSuite:
         return self.size
 
     def _convert_to_dry_run(self):
-        if self.config.get("run.test_runner") == "nrunner":
+        if self.config.get("run.suite_runner") == "nrunner":
             for runnable in self.tests:
                 runnable.kind = "dry-run"
 
@@ -201,9 +201,9 @@ class TestSuite:
     @property
     def runner(self):
         if self._runner is None:
-            runner_name = self.config.get("run.test_runner")
+            runner_name = self.config.get("run.suite_runner")
             try:
-                runner_extension = RunnerDispatcher()[runner_name]
+                runner_extension = SuiteRunnerDispatcher()[runner_name]
                 self._runner = runner_extension.obj
             except KeyError:
                 raise TestSuiteError("Runner not implemented.")
@@ -219,7 +219,7 @@ class TestSuite:
     @property
     def stats(self):
         """Return a statistics dict with the current tests."""
-        runner_name = self.config.get("run.test_runner")
+        runner_name = self.config.get("run.suite_runner")
         if runner_name == "nrunner":
             return self._get_stats_from_nrunner()
         return {}
@@ -238,7 +238,7 @@ class TestSuite:
     @property
     def tags_stats(self):
         """Return a statistics dict with the current tests tags."""
-        runner_name = self.config.get("run.test_runner")
+        runner_name = self.config.get("run.suite_runner")
         if runner_name == "nrunner":
             return self._get_tags_stats_from_nrunner()
         return {}
@@ -334,7 +334,7 @@ class TestSuite:
         if job_config:
             config.update(job_config)
         config.update(suite_config)
-        runner = config.get("run.test_runner")
+        runner = config.get("run.suite_runner")
         if runner == "nrunner":
             suite = cls._from_config_with_resolver(config, name)
         else:

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -204,7 +204,7 @@ class Jobs(CLICmd):
 
         spawners = {"process": ProcessSpawner, "podman": PodmanSpawner}
 
-        spawner_name = config_data.get("nrunner.spawner")
+        spawner_name = config_data.get("run.spawner")
         spawner = spawners.get(spawner_name)
 
         if spawner is None:
@@ -246,7 +246,7 @@ class Jobs(CLICmd):
         data = {
             "JOB ID": job_id,
             "JOB LOG": results_data.get("debuglog"),
-            "SPAWNER": config_data.get("nrunner.spawner", "unknown"),
+            "SPAWNER": config_data.get("run.spawner", "unknown"),
         }
 
         # We could improve this soon with more data and colors

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -82,8 +82,8 @@ class Plugins(CLICmd):
             ),
             (Resolver(), "Plugins that resolve test references (resolver): "),
             (
-                dispatcher.RunnerDispatcher(),
-                "Plugins that run test suites on a job (runners): ",
+                dispatcher.SuiteRunnerDispatcher(),
+                "Plugins that run test suites on a job (suite.runner): ",
             ),
             (
                 dispatcher.SpawnerDispatcher(),

--- a/avocado/plugins/run.py
+++ b/avocado/plugins/run.py
@@ -100,34 +100,11 @@ class Run(CLICmd):
             short_arg="-p",
         )
 
-        help_msg = (
-            "Selects the runner implementation from one of the "
-            "installed and active implementations.  You can run "
-            '"avocado plugins" and find the list of valid runners '
-            'under the "Plugins that run test suites on a job '
-            '(runners) section.  Defaults to "nrunner", which is '
-            "the new runner and only runner supported at this moment. "
-        )
         settings.add_argparser_to_option(
-            namespace="run.test_runner",
+            namespace="run.suite_runner",
             parser=parser,
             long_arg="--suite-runner",
             metavar="SUITE_RUNNER",
-            help_msg=help_msg,
-        )
-
-        help_msg = (
-            "This option name is currently DEPRECATED and will be "
-            "removed on Avocado 100.0 and later.  Please use "
-            '"--suite-runner" instead.'
-        )
-        settings.add_argparser_to_option(
-            namespace="run.test_runner",
-            parser=parser,
-            long_arg="--test-runner",
-            metavar="TEST_RUNNER",
-            help_msg=help_msg,
-            allow_multiple=True,
         )
 
         help_msg = "Instead of running the test only list them and log their params."

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -29,8 +29,7 @@ from avocado.core.messages import MessageHandler
 from avocado.core.nrunner.runnable import Runnable
 from avocado.core.nrunner.runner import check_runnables_runner_requirements
 from avocado.core.output import LOG_JOB
-from avocado.core.plugin_interfaces import CLI, Init
-from avocado.core.plugin_interfaces import Runner as RunnerInterface
+from avocado.core.plugin_interfaces import CLI, Init, SuiteRunner
 from avocado.core.settings import settings
 from avocado.core.status.repo import StatusRepo
 from avocado.core.status.server import StatusServer
@@ -277,7 +276,7 @@ class RunnerCLI(CLI):
         pass
 
 
-class Runner(RunnerInterface):
+class Runner(SuiteRunner):
 
     name = "nrunner"
     description = "nrunner based implementation of job compliant runner"

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -43,7 +43,7 @@ class RunnerInit(Init):
     description = "nrunner initialization"
 
     def initialize(self):
-        section = "nrunner"
+        section = "run"
         help_msg = "Shuffle the tasks to be executed"
         settings.register_option(
             section=section,
@@ -152,124 +152,45 @@ class RunnerCLI(CLI):
 
         parser = parser.add_argument_group("nrunner specific options")
         settings.add_argparser_to_option(
-            namespace="nrunner.shuffle",
+            namespace="run.shuffle",
             parser=parser,
             long_arg="--shuffle",
             action="store_true",
         )
 
-        help_msg = (
-            "This option is currently DEPRECATED and will not be available "
-            'on Avocado 100.0 and later.  Please use "--shuffle" instead.'
-        )
         settings.add_argparser_to_option(
-            namespace="nrunner.shuffle",
-            parser=parser,
-            long_arg="--nrunner-shuffle",
-            action="store_true",
-            help_msg=help_msg,
-            allow_multiple=True,
-        )
-
-        settings.add_argparser_to_option(
-            namespace="nrunner.status_server_auto",
+            namespace="run.status_server_auto",
             parser=parser,
             long_arg="--status-server-disable-auto",
             action="store_false",
         )
 
-        help_msg = (
-            "This option is currently DEPRECATED and will not be available "
-            'on Avocado 100.0 and later.  Please use "--status-server-disable-auto '
-            "instead."
-        )
         settings.add_argparser_to_option(
-            namespace="nrunner.status_server_auto",
-            parser=parser,
-            long_arg="--nrunner-status-server-disable-auto",
-            action="store_false",
-            help_msg=help_msg,
-            allow_multiple=True,
-        )
-
-        settings.add_argparser_to_option(
-            namespace="nrunner.status_server_listen",
+            namespace="run.status_server_listen",
             parser=parser,
             long_arg="--status-server-listen",
             metavar="HOST_PORT",
         )
 
-        help_msg = (
-            "This option is currently DEPRECATED and will not be available "
-            'on Avocado 100.0 and later.  Please use "--status-server-listen" instead.'
-        )
         settings.add_argparser_to_option(
-            namespace="nrunner.status_server_listen",
-            parser=parser,
-            long_arg="--nrunner-status-server-listen",
-            metavar="HOST_PORT",
-            help_msg=help_msg,
-            allow_multiple=True,
-        )
-
-        settings.add_argparser_to_option(
-            namespace="nrunner.status_server_uri",
+            namespace="run.status_server_uri",
             parser=parser,
             long_arg="--status-server-uri",
             metavar="HOST_PORT",
         )
 
-        help_msg = (
-            "This option is currently DEPRECATED and will not be available "
-            'on Avocado 100.0 and later.  Please use "--status-server-uri" instead.'
-        )
         settings.add_argparser_to_option(
-            namespace="nrunner.status_server_uri",
-            parser=parser,
-            long_arg="--nrunner-status-server-uri",
-            metavar="HOST_PORT",
-            help_msg=help_msg,
-            allow_multiple=True,
-        )
-
-        settings.add_argparser_to_option(
-            namespace="nrunner.max_parallel_tasks",
+            namespace="run.max_parallel_tasks",
             parser=parser,
             long_arg="--max-parallel-tasks",
             metavar="NUMBER_OF_TASKS",
         )
 
-        help_msg = (
-            "This option is currently DEPRECATED and will not be available "
-            'on Avocado 100.0 and later.  Please use "--max-parallel-tasks" instead.'
-        )
         settings.add_argparser_to_option(
-            namespace="nrunner.max_parallel_tasks",
-            parser=parser,
-            long_arg="--nrunner-max-parallel-tasks",
-            metavar="NUMBER_OF_TASKS",
-            help_msg=help_msg,
-            allow_multiple=True,
-        )
-
-        settings.add_argparser_to_option(
-            namespace="nrunner.spawner",
+            namespace="run.spawner",
             parser=parser,
             long_arg="--spawner",
             metavar="SPAWNER",
-        )
-
-        help_msg = (
-            "This option is currently DEPRECATED and will not be available "
-            'on Avocado 100.0 and later.  Please use "--spawner" instead.'
-        )
-        settings.add_argparser_to_option(
-            namespace="nrunner.spawner",
-            parser=parser,
-            long_arg="--nrunner-spawner",
-            metavar="SPAWNER",
-            help_msg=help_msg,
-            allow_multiple=True,
         )
 
     def run(self, config):
@@ -298,7 +219,7 @@ class Runner(SuiteRunner):
             runnable.config = Runnable.filter_runnable_config(runnable.kind, config)
 
     def _determine_status_server(self, test_suite, config_key):
-        if test_suite.config.get("nrunner.status_server_auto"):
+        if test_suite.config.get("run.status_server_auto"):
             # no UNIX domain sockets on Windows
             if platform.system() != "Windows":
                 if self.status_server_dir is None:
@@ -309,9 +230,7 @@ class Runner(SuiteRunner):
         return test_suite.config.get(config_key)
 
     def _create_status_server(self, test_suite, job):
-        listen = self._determine_status_server(
-            test_suite, "nrunner.status_server_listen"
-        )
+        listen = self._determine_status_server(test_suite, "run.status_server_listen")
         # pylint: disable=W0201
         self.status_repo = StatusRepo(job.unique_id)
         # pylint: disable=W0201
@@ -371,7 +290,7 @@ class Runner(SuiteRunner):
         graph = RuntimeTaskGraph(
             test_suite.get_test_variants(),
             test_suite.name,
-            self._determine_status_server(test_suite, "nrunner.status_server_uri"),
+            self._determine_status_server(test_suite, "run.status_server_uri"),
             job.unique_id,
         )
         # pylint: disable=W0201
@@ -380,7 +299,7 @@ class Runner(SuiteRunner):
         # Start the status server
         asyncio.ensure_future(self.status_server.serve_forever())
 
-        if test_suite.config.get("nrunner.shuffle"):
+        if test_suite.config.get("run.shuffle"):
             random.shuffle(self.runtime_tasks)
         test_ids = [
             rt.task.identifier
@@ -388,10 +307,10 @@ class Runner(SuiteRunner):
             if rt.task.category == "test"
         ]
         tsm = TaskStateMachine(self.runtime_tasks, self.status_repo)
-        spawner_name = test_suite.config.get("nrunner.spawner")
+        spawner_name = test_suite.config.get("run.spawner")
         spawner = SpawnerDispatcher(test_suite.config, job)[spawner_name].obj
         max_running = min(
-            test_suite.config.get("nrunner.max_parallel_tasks"), len(self.runtime_tasks)
+            test_suite.config.get("run.max_parallel_tasks"), len(self.runtime_tasks)
         )
         timeout = test_suite.config.get("task.timeout.running")
         failfast = test_suite.config.get("run.failfast")

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -160,7 +160,7 @@ interfaces such scripts must implement are the ``runnable-run`` and
 
 Once all the ``Runnable(s)`` (within the ``ReferenceResolution(s)``)
 are created by :mod:`avocado.core.resolver`, the ``avocado
-run --test-runner=nrunner`` implementation follows roughly the
+run --suite-runner=nrunner`` implementation follows roughly the
 following steps:
 
 1. Creates a status server that binds to a TCP port and waits for

--- a/docs/source/guides/user/chapters/advanced.rst
+++ b/docs/source/guides/user/chapters/advanced.rst
@@ -74,12 +74,12 @@ described and pluggable interface.  This means that users can choose
 Runner choices can be seen by running ``avocado plugins``::
 
   ...
-  Plugins that run test suites on a job (runners):
+  Plugins that run test suites on a job (suite.runner):
   nrunner nrunner based implementation of job compliant runner
 
 And to select a different test runner (if another one exists)::
 
-  avocado run --test-runner=other_runner_plugin ...
+  avocado run --suite-runner=other_runner_plugin ...
 
 Running tests with an external runner
 -------------------------------------

--- a/examples/jobs/multiple_suites_from_config.py
+++ b/examples/jobs/multiple_suites_from_config.py
@@ -7,7 +7,7 @@ from avocado.core.suite import TestSuite
 
 ORDERLY_CONFIG = {
     "resolver.references": ["/bin/true", "/bin/true", "/bin/last"],
-    "nrunner.max_parallel_tasks": 1,
+    "run.max_parallel_tasks": 1,
 }
 
 RANDOM_CONFIG = {
@@ -20,7 +20,7 @@ RANDOM_CONFIG = {
         "/bin/last",
     ],
     "nrunner.shuffle": True,
-    "nrunner.max_parallel_tasks": 3,
+    "run.max_parallel_tasks": 3,
 }
 
 with Job(

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -183,49 +183,26 @@ Options for subcommand `run` (`avocado run --help`)::
 
     nrunner specific options:
       --shuffle             Shuffle the tasks to be executed
-      --nrunner-shuffle     This option is currently DEPRECATED and will not be
-                            available on Avocado 100.0 and later. Please use "--
-                            shuffle" instead.
       --status-server-disable-auto
                             If the status server should automatically choose a
                             "status_server_listen" and "status_server_uri"
                             configuration. Default is to auto configure a status
                             server.
-      --nrunner-status-server-disable-auto
-                            This option is currently DEPRECATED and will not be
-                            available on Avocado 100.0 and later. Please use "--
-                            status-server-disable-auto instead.
       --status-server-listen HOST_PORT
                             URI where status server will listen on. Usually a
                             "HOST:PORT" string. This is only effective if
                             "status_server_auto" is disabled
-      --nrunner-status-server-listen HOST_PORT
-                            This option is currently DEPRECATED and will not be
-                            available on Avocado 100.0 and later. Please use "--
-                            status-server-listen" instead.
       --status-server-uri HOST_PORT
                             URI for connecting to the status server, usually a
                             "HOST:PORT" string. Use this if your status server is
                             in another host, or different port. This is only
                             effective if "status_server_auto" is disabled
-      --nrunner-status-server-uri HOST_PORT
-                            This option is currently DEPRECATED and will not be
-                            available on Avocado 100.0 and later. Please use "--
-                            status-server-uri" instead.
       --max-parallel-tasks NUMBER_OF_TASKS
                             Number of maximum number tasks running in parallel.
                             You can disable parallel execution by setting this to
                             1. Defaults to the amount of CPUs on this machine.
-      --nrunner-max-parallel-tasks NUMBER_OF_TASKS
-                            This option is currently DEPRECATED and will not be
-                            available on Avocado 100.0 and later. Please use "--
-                            max-parallel-tasks" instead.
       --spawner SPAWNER     Spawn tasks in a specific spawner. Available spawners:
                             'process' and 'podman'
-      --nrunner-spawner SPAWNER
-                            This option is currently DEPRECATED and will not be
-                            available on Avocado 100.0 and later. Please use "--
-                            spawner" instead.
 
     podman spawner specific options:
       --spawner-podman-bin PODMAN_BIN

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -82,7 +82,7 @@ Options for subcommand `run` (`avocado run --help`)::
                             This option format must be given in the NAME=VALUE
                             format, and may be given any number of times, or per
                             parameter.
-      --test-runner TEST_RUNNER
+      --suite-runner SUITE_RUNNER
                             Selects the runner implementation from one of the
                             installed and active implementations.  You can run
                             "avocado plugins" and find the list of valid runners

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -373,7 +373,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                 "assert": True,
                 "reference": ["/bin/false", "/bin/true"],
                 "exit_code": 9,
-                "extra_job_config": {"nrunner.max_parallel_tasks": 1},
+                "extra_job_config": {"run.max_parallel_tasks": 1},
             },
             {
                 "namespace": "run.ignore_missing_references",

--- a/selftests/functional/plugin/spawners/test_podman.py
+++ b/selftests/functional/plugin/spawners/test_podman.py
@@ -38,7 +38,7 @@ class PodmanSpawnerTest(TestCaseTmpDir):
             result = process.run(
                 f"{AVOCADO} run "
                 f"--job-results-dir {self.tmpdir.name} "
-                f"--disable-sysinfo --nrunner-spawner=podman "
+                f"--disable-sysinfo --spawner=podman "
                 f"--spawner-podman-image=fedora:36 -- "
                 f"{test}",
                 ignore_status=True,
@@ -51,7 +51,7 @@ class PodmanSpawnerTest(TestCaseTmpDir):
         result = process.run(
             f"{AVOCADO} run "
             f"--job-results-dir {self.tmpdir.name} "
-            f"--disable-sysinfo --nrunner-spawner=podman "
+            f"--disable-sysinfo --spawner=podman "
             f"--spawner-podman-image=fedora:36 -- "
             f"/bin/true",
             ignore_status=True,

--- a/selftests/functional/serial/test_requirements.py
+++ b/selftests/functional/serial/test_requirements.py
@@ -116,9 +116,7 @@ class BasicTest(Test):
         spawner = self.params.get("spawner", default="process")
         spawner_command = ""
         if spawner == "podman":
-            spawner_command = (
-                "--nrunner-spawner=podman --spawner-podman-image=fedora:36"
-            )
+            spawner_command = "--spawner=podman --spawner-podman-image=fedora:36"
         return f"{AVOCADO} run {spawner_command} {path}"
 
     @skipUnless(os.getenv("CI"), skip_package_manager_message)

--- a/selftests/functional/test_basic.py
+++ b/selftests/functional/test_basic.py
@@ -209,7 +209,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             f"--job-results-dir {self.tmpdir.name} "
             f"examples/tests/passtest.py examples/tests/failtest.py "
             f"examples/tests/passtest.py --failfast "
-            f"--nrunner-max-parallel-tasks=1"
+            f"--max-parallel-tasks=1"
         )
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b"Interrupting job (failfast).", result.stdout)
@@ -227,7 +227,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             f"--job-results-dir {self.tmpdir.name} "
             f"examples/tests/passtest.py examples/tests/errortest.py "
             f"examples/tests/passtest.py --failfast "
-            f"--nrunner-max-parallel-tasks=1"
+            f"--max-parallel-tasks=1"
         )
         result = process.run(cmd_line, ignore_status=True)
         self.assertIn(b"Interrupting job (failfast).", result.stdout)

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -30,8 +30,8 @@ class NRunnerFeatures(unittest.TestCase):
                 "/bin/true",
             ],
             "run.failfast": True,
-            "nrunner.shuffle": False,
-            "nrunner.max_parallel_tasks": 1,
+            "run.shuffle": False,
+            "run.max_parallel_tasks": 1,
         }
         with Job.from_config(job_config=config) as job:
             self.assertEqual(job.run(), 9)

--- a/selftests/functional/test_teststmpdir.py
+++ b/selftests/functional/test_teststmpdir.py
@@ -58,7 +58,7 @@ class TestsTmpDirTests(TestCaseTmpDir):
         """
         cmd_line = (
             f"{AVOCADO} run --disable-sysinfo "
-            f"--nrunner-max-parallel-tasks=1 "
+            f"--max-parallel-tasks=1 "
             f"--job-results-dir {self.tmpdir.name} "
             f"{self.simple_test} {self.instrumented_test}"
         )

--- a/setup.py
+++ b/setup.py
@@ -430,7 +430,7 @@ if __name__ == "__main__":
                 "avocado-instrumented = avocado.plugins.resolvers:AvocadoInstrumentedResolver",
                 "tap = avocado.plugins.resolvers:TapResolver",
             ],
-            "avocado.plugins.runner": [
+            "avocado.plugins.suite.runner": [
                 "nrunner = avocado.plugins.runner_nrunner:Runner",
             ],
             "avocado.plugins.runnable.runner": [


### PR DESCRIPTION
Note: This PR is marked as Draft only because it's intended to be merged only after Avocado 99.0 is released.

---

The --nrunner-$options made sense when the old runner was available. Nowadays, it's just more typing and confusion to users.

Also, this renames the Runner interface and --test-runner option to SuiteRunner and --suite-runner, to more accurately represent what they do.

Changes from v1 (https://github.com/avocado-framework/avocado/pull/5449):
 * Misc commits and the deprecation messages merged in a separate PR (#5493)