### PR TITLE
[LTS] Fixes for release 92.1: COPR check

### DIFF
--- a/contrib/containers/ci/selftests/check-copr-rpm-version.docker
+++ b/contrib/containers/ci/selftests/check-copr-rpm-version.docker
@@ -1,0 +1,7 @@
+# This container is used in selftests/pre_release/tests/check-copr-rpm-version.sh
+FROM fedora:36
+LABEL description "Fedora image used on COPR RPM version check"
+RUN dnf -y module disable avocado:latest
+RUN dnf -y install 'dnf-command(copr)'
+RUN dnf -y copr enable @avocado/avocado-latest
+RUN dnf -y clean all

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -16,7 +16,7 @@ DISTRO_VERSION=36
 
 RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
 
-PODMAN=$(which podman)
+PODMAN=$(which podman 2>/dev/null || which docker)
 PODMAN_IMAGE=quay.io/avocado-framework/check-copr-rpm-version
 
 $PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y install ${RPM_NVR}"

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -9,7 +9,7 @@ git fetch $ORIGIN
 
 ORIGIN_MASTER_COMMIT=$(git log --pretty=format:'%h' -n 1 $ORIGIN/master)
 VERSION=$(python setup.py --version 2>/dev/null)
-COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
+COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1 $ORIGIN/master)
 SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/master)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
 DISTRO_VERSION=36

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -12,12 +12,11 @@ VERSION=$(python setup.py --version 2>/dev/null)
 COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
 SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/master)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
-DISTRO=fedora
-DISTRO_VERSION=34
+DISTRO_VERSION=36
 
 RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
 
 PODMAN=$(which podman)
-PODMAN_IMAGE="${DISTRO}:${DISTRO_VERSION}"
+PODMAN_IMAGE=quay.io/avocado-framework/check-copr-rpm-version
 
-$PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y module disable avocado && dnf -y install 'dnf-command(copr)' && dnf -y copr enable @avocado/avocado-latest && dnf -y install ${RPM_NVR}"
+$PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y install ${RPM_NVR}"

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -7,10 +7,10 @@ ORIGIN=origin
 
 git fetch $ORIGIN
 
-ORIGIN_MASTER_COMMIT=$(git log --pretty=format:'%h' -n 1 $ORIGIN/master)
+ORIGIN_MASTER_COMMIT=$(git log --pretty=format:'%h' -n 1 $ORIGIN/92lts)
 VERSION=$(python setup.py --version 2>/dev/null)
-COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1 $ORIGIN/master)
-SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/master)
+COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1 $ORIGIN/92lts)
+SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/92lts)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
 DISTRO_VERSION=36
 

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+# This script accepts a package NVR as its first argument.  If not given,
+# it will default to a NVR based on the info of the repository given
+
 # Put here the name of your GIT remote that tracks the official
 # repo, that is, https://github.com/avocado-framework/avocado
 # (or the git:// url version of the same repo)
@@ -14,7 +17,8 @@ SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/92lts)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
 DISTRO_VERSION=36
 
-RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
+DEFAULT_RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
+RPM_NVR="${1:-$DEFAULT_RPM_NVR}"
 
 PODMAN=$(which podman 2>/dev/null || which docker)
 PODMAN_IMAGE=quay.io/avocado-framework/check-copr-rpm-version


### PR DESCRIPTION
This brings backports and one branch adjustment to address the pre-release "Check the right RPM packages are available in COPR" job.