### PR TITLE
Cache clear

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -465,3 +465,10 @@ class Cache(Plugin):
         :return: Human-readable list of entries which will be printed to console.
         :rtype: str
         """
+
+    @abc.abstractmethod
+    def clear(self):
+        """Clear all cache entries
+
+        It removes every cache entire.
+        """

--- a/avocado/plugins/requirement_cache.py
+++ b/avocado/plugins/requirement_cache.py
@@ -12,6 +12,8 @@
 # Copyright: Red Hat Inc. 2022
 # Author: Jan Richter <jarichte@redhat.com>
 
+import os
+
 from avocado.core import output
 from avocado.core.dependencies.requirements.cache.backends import sqlite
 from avocado.core.plugin_interfaces import Cache
@@ -49,3 +51,7 @@ class RequirementCache(Cache):
             )
             requirement_list += "\n\n"
         return requirement_list
+
+    def clear(self):
+        if os.path.exists(sqlite.CACHE_DATABASE_PATH):
+            os.remove(sqlite.CACHE_DATABASE_PATH)

--- a/avocado/plugins/vmimage.py
+++ b/avocado/plugins/vmimage.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 
 from avocado.core import exit_codes, output
 from avocado.core.output import LOG_UI
@@ -182,3 +183,9 @@ class VMimageCache(Cache):
     def list(self):
         images = list_downloaded_images()
         return display_images_list(images)
+
+    def clear(self):
+        images = list_downloaded_images()
+        for image in images:
+            if os.path.exists(image["file"]):
+                shutil.rmtree(os.path.dirname(image["file"]))

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -267,11 +267,19 @@ class CentOSImageProvider(ImageProviderBase):
         self.url_images = self.url_versions + "{version}/images/"
         self.image_pattern = "CentOS-(?P<version>{version})-(?P<arch>{arch})-GenericCloud-(?P<build>{build}).qcow2.xz$"
 
-    def get_image_url(self):
+    def _set_patterns(self):
         if int(self.version) >= 8:
             self.build = r"[\d\.\-]+"
             self.url_images = self.url_versions + "{version}/{arch}/images/"
             self.image_pattern = "CentOS-(?P<version>{version})-GenericCloud-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
+
+    @property
+    def file_name(self):
+        self._set_patterns()
+        return super().file_name
+
+    def get_image_url(self):
+        self._set_patterns()
         return super().get_image_url()
 
 

--- a/docs/source/guides/user/chapters/dependencies.rst
+++ b/docs/source/guides/user/chapters/dependencies.rst
@@ -24,7 +24,8 @@ it will be reused by other tests.
 
 Also, the dependency will stay in cache after the Avocado run, so the second
 run of the tests will use dependencies from cache, which will make tests more
-efficient.
+efficient. If you want to know the sate of cache, you can use cache interface
+with `$avocado cache list`.
 
 .. warning::
 
@@ -32,7 +33,7 @@ efficient.
         (packages being uninstalled, podman images removed, etc), the 
         dependency resolution behavior is undefined and will probably crash. 
         If such a change is made to the environment, it's recommended to clear 
-        the dependencies cache file.
+        the dependencies cache with `$avocado cache clear`.
 
 Defining a test dependency
 ---------------------------


### PR DESCRIPTION
This adds a clear feature to cache interface. With this feature, users
will be able to remove entries from cache base on their cache type.

Reference: https://github.com/avocado-framework/avocado/issues/5453
Signed-off-by: Jan Richter <jarichte@redhat.com>