### PR TITLE
Python path environment bomb fix

### DIFF
--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -434,7 +434,7 @@ class Runnable:
         # When running Avocado Python modules, the interpreter on the new
         # process needs to know where Avocado can be found.
         env = os.environ.copy()
-        env["PYTHONPATH"] = ":".join(p for p in sys.path)
+        env["PYTHONPATH"] = ":".join(p for p in set(sys.path))
 
         standalone_executable_cmd = [f"avocado-runner-{kind}"]
         if Runnable.is_kind_supported_by_runner_command(

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -35,7 +35,7 @@ class ProcessSpawner(Spawner, SpawnerMixin):
         # When running Avocado Python modules, the interpreter on the new
         # process needs to know where Avocado can be found.
         env = os.environ.copy()
-        env["PYTHONPATH"] = ":".join(p for p in sys.path)
+        env["PYTHONPATH"] = ":".join(p for p in set(sys.path))
 
         # pylint: disable=E1133
         try:


### PR DESCRIPTION
The current setting of PYTHONPATH values is necessary, but as it's implemented, it is similar to a fork bomb.  On each new execution, new values are appended to the global PYTHONPATH environment variable.  In jobs with many tests, this can grow out of the existing limits (besides adding unnecessary memory overhead).

This was actually caught by failures on COPR builds.

Signed-off-by: Cleber Rosa <crosa@redhat.com>