### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0, 3.11]
       fail-fast: false
 
     steps:
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.10.0]
+        python-version: [3.11]
     env:
       CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
 
@@ -153,7 +153,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10.0]
+        python-version: [3.9, 3.10.0, 3.11]
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
@@ -182,7 +182,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0, 3.11]
       fail-fast: false
 
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.11.0-alpha.7]
+        python-version: [3.11.0]
       fail-fast: false
     outputs:
       job_status: ${{ job.status }}
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.11.0-alpha.7]
+        python-version: [3.11.0]
       fail-fast: false
 
     steps:

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -14,7 +14,7 @@ class MockSpawner(Spawner):
 
     METHODS = [SpawnMethod.PYTHON_CLASS, SpawnMethod.STANDALONE_EXECUTABLE]
 
-    def __init__(self):
+    def __init__(self):  # pylint: disable=W0231
         self._known_tasks = {}
 
     def is_task_alive(self, runtime_task):  # pylint: disable=W0221

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -252,7 +252,7 @@ class FetchAssetJob(JobPreTests):  # pylint: disable=R0903
     name = "fetchasset"
     description = "Fetch assets before the test run"
 
-    def __init__(self, config=None):
+    def __init__(self, config=None):  # pylint: disable=W0231
         pass
 
     def pre_tests(self, job):

--- a/avocado/plugins/beaker_result.py
+++ b/avocado/plugins/beaker_result.py
@@ -31,7 +31,7 @@ class BeakerResult(ResultEvents):
     beaker_url = None
     job_id = None
 
-    def __init__(self, config=None):  # pylint: disable=W0613
+    def __init__(self, config=None):  # pylint: disable=W0613,W0231
         baseurl = os.environ.get("BEAKER_LAB_CONTROLLER_URL")
         recipeid = os.environ.get("RSTRNT_RECIPEID")
         taskid = os.environ.get("RSTRNT_TASKID")

--- a/avocado/plugins/bystatus.py
+++ b/avocado/plugins/bystatus.py
@@ -20,7 +20,7 @@ from avocado.core.plugin_interfaces import ResultEvents
 class ByStatusLink(ResultEvents):
     description = "Creates symlinks on file system grouped by status"
 
-    def __init__(self, config):
+    def __init__(self, config):  # pylint: disable=W0231
         pass
 
     def pre_tests(self, job):

--- a/avocado/plugins/diff.py
+++ b/avocado/plugins/diff.py
@@ -40,7 +40,7 @@ class Diff(CLICmd):
     name = "diff"
     description = "Shows the difference between 2 jobs."
 
-    def __init__(self):
+    def __init__(self):  # pylint: disable=W0231
         self.term = output.TERM_SUPPORT
         self.std_diff_output = True
 

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -54,7 +54,7 @@ class Human(ResultEvents):
     name = "human"
     description = "Human Interface UI"
 
-    def __init__(self, config):
+    def __init__(self, config):  # pylint: disable=W0231
         stdout_claimed_by = config.get("stdout_claimed_by", None)
         self.owns_stdout = not stdout_claimed_by
         self.omit_statuses = config.get("human_ui.omit.statuses")

--- a/avocado/plugins/journal.py
+++ b/avocado/plugins/journal.py
@@ -49,7 +49,7 @@ class JournalResult(ResultEvents):
     name = "journal"
     description = "Journal event based results implementation"
 
-    def __init__(self, config):  # pylint: disable=W0613
+    def __init__(self, config):  # pylint: disable=W0613, W0231
         """
         Creates an instance of ResultJournal.
 

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -101,7 +101,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
 
     _PYTHON_VERSIONS_CACHE = {}
 
-    def __init__(self, config=None, job=None):
+    def __init__(self, config=None, job=None):  # pylint: disable=W0231
         SpawnerMixin.__init__(self, config, job)
         self.environment = f"podman:{self.config.get('spawner.podman.image')}"
 

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -155,7 +155,7 @@ class SysInfoJob(JobPreTests, JobPostTests):
     name = "sysinfo"
     description = "Collects system information before/after the job is run"
 
-    def __init__(self, config):
+    def __init__(self, config):  # pylint: disable=W0231
         self.sysinfo = None
         self.sysinfo_enabled = config.get("sysinfo.collect.enabled")
 

--- a/avocado/plugins/tap.py
+++ b/avocado/plugins/tap.py
@@ -54,7 +54,7 @@ class TAPResult(ResultEvents):
     name = "tap"
     description = "TAP - Test Anything Protocol results"
 
-    def __init__(self, config):  # pylint: disable=W0613
+    def __init__(self, config):  # pylint: disable=W0613, W0231
         self.__logs = []
         self.__open_files = []
         self.config = config

--- a/avocado/plugins/testlogs.py
+++ b/avocado/plugins/testlogs.py
@@ -112,7 +112,7 @@ class TestLogging(ResultEvents):
 
     description = "Nrunner specific Test logs for Job"
 
-    def __init__(self, config):
+    def __init__(self, config):  # pylint: disable=W0231
         self.runner = config.get("run.test_runner")
 
     @staticmethod

--- a/avocado/plugins/teststmpdir.py
+++ b/avocado/plugins/teststmpdir.py
@@ -28,7 +28,7 @@ class TestsTmpDir(JobPre, JobPost):
     name = "teststmpdir"
     description = "Creates a temporary directory for tests consumption"
 
-    def __init__(self):
+    def __init__(self):  # pylint: disable=W0231
         self._varname = test.COMMON_TMPDIR_NAME
         self._dirname = None
 

--- a/optional_plugins/resultsdb/avocado_resultsdb/resultsdb.py
+++ b/optional_plugins/resultsdb/avocado_resultsdb/resultsdb.py
@@ -35,7 +35,7 @@ class ResultsdbResultEvent(ResultEvents):
     name = "resultsdb"
     description = "Resultsdb result support"
 
-    def __init__(self, config):
+    def __init__(self, config):  # pylint: disable=W0231
         self.rdbapi = None
         resultsdb_api_url = config.get("plugins.resultsdb.api_url")
         if resultsdb_api_url is not None:

--- a/setup.py
+++ b/setup.py
@@ -336,6 +336,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
         ],
         packages=find_packages(exclude=("selftests*",)),
         include_package_data=True,


### PR DESCRIPTION
Update the github actions to test also Python 3.11 and add python 3.11 as supported versions.

Reference: https://github.com/avocado-framework/avocado/issues/5503
Signed-off-by: Jan Richter <jarichte@redhat.com>