### PR TITLE
GitHub Actions: bump macOS version away from deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
   smokecheck-osx:
 
     name: OS X with Python ${{ matrix.python-version }}
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     strategy:
       matrix:


### PR DESCRIPTION
macOS 10.15 is deprecated.  Let's bump the image used to the next available version.

Reference: https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job#choosing-github-hosted-runners
Signed-off-by: Cleber Rosa <crosa@redhat.com>