### PR TITLE
adding nvme static word to ignore in spell.ignore

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -1,3 +1,4 @@
+nvme
 nbannoth
 Naresh
 Bannoth


### PR DESCRIPTION
nvme is a static word and it is giving error for other nvme related pacthes as static check failed. so adding it to get ignore so that patches can be merged.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>