### PR TITLE
Asset: legacy runner and duplicate tests

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -274,12 +274,6 @@ class FetchAssetJob(JobPreTests):  # pylint: disable=R0903
                         candidate = (module_path, klass, method)
                         candidates.append(candidate)
 
-                # fetch assets only on instrumented tests
-                elif isinstance(test[0], str):
-                    candidate = (test[1]["modulePath"], test[0], test[1]["methodName"])
-                    if candidate not in candidates:
-                        candidates.append(candidate)
-
         for candidate in candidates:
             fetch_assets(*candidate, logger)
 

--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -272,7 +272,8 @@ class FetchAssetJob(JobPreTests):  # pylint: disable=R0903
                         module_path, klass_method = test.uri.split(":", 1)
                         klass, method = klass_method.split(".", 1)
                         candidate = (module_path, klass, method)
-                        candidates.append(candidate)
+                        if candidate not in candidates:
+                            candidates.append(candidate)
 
         for candidate in candidates:
             fetch_assets(*candidate, logger)


### PR DESCRIPTION
Couple of changes to the Assets plugin:

* Remove code that handles legacy runner
* Only fetch assets from an unique test once