### PR TITLE
Selftests: pin Fedora version used on podman spawner

### DIFF
--- a/selftests/functional/plugin/spawners/test_podman.py
+++ b/selftests/functional/plugin/spawners/test_podman.py
@@ -39,7 +39,7 @@ class PodmanSpawnerTest(TestCaseTmpDir):
                 f"{AVOCADO} run "
                 f"--job-results-dir {self.tmpdir.name} "
                 f"--disable-sysinfo --nrunner-spawner=podman "
-                f"--spawner-podman-image=fedora:latest -- "
+                f"--spawner-podman-image=fedora:36 -- "
                 f"{test}",
                 ignore_status=True,
             )
@@ -52,7 +52,7 @@ class PodmanSpawnerTest(TestCaseTmpDir):
             f"{AVOCADO} run "
             f"--job-results-dir {self.tmpdir.name} "
             f"--disable-sysinfo --nrunner-spawner=podman "
-            f"--spawner-podman-image=fedora:latest -- "
+            f"--spawner-podman-image=fedora:36 -- "
             f"/bin/true",
             ignore_status=True,
         )
@@ -70,7 +70,7 @@ class PodmanSpawnerTest(TestCaseTmpDir):
                 "run.results_dir": self.tmpdir.name,
                 "task.timeout.running": 2,
                 "nrunner.spawner": "podman",
-                "spawner.podman.image": "fedora:latest",
+                "spawner.podman.image": "fedora:36",
             }
 
             with Job.from_config(job_config=config) as job:

--- a/selftests/functional/serial/test_requirements.py
+++ b/selftests/functional/serial/test_requirements.py
@@ -117,7 +117,7 @@ class BasicTest(Test):
         spawner_command = ""
         if spawner == "podman":
             spawner_command = (
-                "--nrunner-spawner=podman --spawner-podman-image=fedora:latest"
+                "--nrunner-spawner=podman --spawner-podman-image=fedora:36"
             )
         return f"{AVOCADO} run {spawner_command} {path}"
 


### PR DESCRIPTION
Because of the release of Fedora 37, the default distro has Python 3.11. The problem with that is there are no "setuptools" (or Avocado eggs for that matter) available for Python 3.11 yet.

This caused a brekage in the selftests run in CI (or in any environment where a reference to fedora:latest was refreshed and resolved to fedora:37).

Because there are tests, it's better to *not* have them changing behavior because of external events.

This still keeps the default behavior of the spawner to use the latest fedora if a distro matching the host can not be detected.

Reference: https://github.com/avocado-framework/avocado/issues/5525
Signed-off-by: Cleber Rosa <crosa@redhat.com>