### PR TITLE
Unicode handling: rely on sys.getdefaultencoding()

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -205,15 +205,6 @@ def register_core_options():
         section="runner.output", key="color", default="auto", help_msg=help_msg
     )
 
-    help_msg = "Use UTF8 encoding (True or False)"
-    stgs.register_option(
-        section="runner.output",
-        key="utf8",
-        key_type=bool,
-        help_msg=help_msg,
-        default=True,
-    )
-
     help_msg = (
         "Suppress notification about broken plugins in the app "
         "standard error. Add the name of each broken plugin you "

--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -228,11 +228,6 @@ def register_core_options():
         help_msg=help_msg,
     )
 
-    help_msg = "The encoding used by default on all data input"
-    stgs.register_option(
-        section="core", key="input_encoding", default="utf-8", help_msg=help_msg
-    )
-
     # All settings starting with 'runner.' will be passed to runner
     # exec-test runner config
     help_msg = (

--- a/avocado/plugins/variants.py
+++ b/avocado/plugins/variants.py
@@ -164,7 +164,6 @@ class Variants(CLICmd):
         except (IOError, ValueError) as details:
             LOG_UI.error("Unable to parse varianter: %s", details)
             sys.exit(exit_codes.AVOCADO_FAIL)
-        use_utf8 = config.get("runner.output.utf8")
         # Parse obsolete options (unsafe to combine them with new args)
         if tree:
             variants = 0
@@ -188,7 +187,11 @@ class Variants(CLICmd):
                 sys.exit(exit_codes.AVOCADO_FAIL)
 
         # Produce the output
-        lines = varianter.to_str(summary=summary, variants=variants, use_utf8=use_utf8)
+        lines = varianter.to_str(
+            summary=summary,
+            variants=variants,
+            use_utf8=sys.getdefaultencoding() == "utf-8",
+        )
         for line in lines.splitlines():
             LOG_UI.debug(line)
 


### PR DESCRIPTION
The two configuration items removed here can be better served by the systems' automatic locale configuration.