### PR TITLE
Job: fix the start time

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -606,7 +606,7 @@ class Job:
             self.post_tests()
             if self._time_end is None:
                 self._time_end = time.monotonic()
-                self.time_elapsed = self._time_end - self._time_start
+            self.time_elapsed = self._time_end - self._time_start
             self.render_results()
             pre_post_dispatcher.map_method("post", self)
 

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -18,6 +18,7 @@ Job module - describes a sequence of automated test operations.
 """
 
 
+import datetime
 import logging
 import os
 import pprint
@@ -565,6 +566,7 @@ class Job:
                  :mod:`avocado.core.exit_codes` for more information.
         """
         assert self.tmpdir is not None, "Job.setup() not called"
+        self.result.job_start_date_time = datetime.datetime.now()
         if self._time_start is None:
             self._time_start = time.monotonic()
         try:

--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -166,15 +166,15 @@ class Job:
         self._timeout = None
         self._unique_id = None
 
-        #: The time at which the job has started or `-1` if it has not been
-        #: started by means of the `run()` method.
-        self.time_start = -1
-        #: The time at which the job has finished or `-1` if it has not been
-        #: started by means of the `run()` method.
-        self.time_end = -1
+        # The time at which the job has started or `None` if it has not been
+        # started by means of the `run()` method.
+        self._time_start = None
+        # The time at which the job has finished or `None` if it has not been
+        # started by means of the `run()` method.
+        self._time_end = None
         #: The total amount of time the job took from start to finish,
-        #: or `-1` if it has not been started by means of the `run()` method
-        self.time_elapsed = -1
+        #: or None if it has not been started by means of the `run()` method
+        self.time_elapsed = None
         self.funcatexit = CallbackRegister(f"JobExit {self.unique_id}", LOG_JOB)
         self._stdout_stderr = None
         self.replay_sourcejob = self.config.get("replay_sourcejob")
@@ -565,8 +565,8 @@ class Job:
                  :mod:`avocado.core.exit_codes` for more information.
         """
         assert self.tmpdir is not None, "Job.setup() not called"
-        if self.time_start == -1:
-            self.time_start = time.monotonic()
+        if self._time_start is None:
+            self._time_start = time.monotonic()
         try:
             self.result.tests_total = self.size
             pre_post_dispatcher = dispatcher.JobPrePostDispatcher()
@@ -604,9 +604,9 @@ class Job:
             return self.exitcode
         finally:
             self.post_tests()
-            if self.time_end == -1:
-                self.time_end = time.monotonic()
-                self.time_elapsed = self.time_end - self.time_start
+            if self._time_end is None:
+                self._time_end = time.monotonic()
+                self.time_elapsed = self._time_end - self._time_start
             self.render_results()
             pre_post_dispatcher.map_method("post", self)
 

--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -24,7 +24,7 @@ class Result:
     Result class, holder for job (and its tests) result information.
     """
 
-    def __init__(self, job_unique_id, job_logfile):
+    def __init__(self, job_unique_id, job_logfile, job_start_date_time=None):
         """
         Creates an instance of Result.
 
@@ -32,9 +32,11 @@ class Result:
                               :attr:`avocado.core.job.Job.unique_id`
         :param job_logfile: the job's unique ID, usually from
                             :attr:`avocado.core.job.Job.logfile`
+        :param job_start_date_time: the date and time a job started running
         """
         self.job_unique_id = job_unique_id
         self.logfile = job_logfile
+        self.job_start_date_time = job_start_date_time
         self.tests_total = 0
         self.tests_run = 0
         self.tests_total_time = 0.0

--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -151,15 +151,10 @@ class Jobs(CLICmd):
         for filename in jobs_results.values():
             with open(filename, "r", encoding="utf-8") as fp:
                 job = json.load(fp)
-                try:
-                    started_ts = job["tests"][0]["start"]
-                    started = datetime.fromtimestamp(started_ts)
-                except IndexError:
-                    continue
                 LOG_UI.info(
                     "%-40s %-26s %3s (%s/%s/%s/%s)",
                     job["job_id"],
-                    str(started),
+                    job["start"],
                     job["total"],
                     job["pass"],
                     job["skip"],

--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -74,6 +74,7 @@ class JSONResult(Result):
             "warn": result.warned,
             "interrupt": result.interrupted,
             "time": result.tests_total_time,
+            "start": str(result.job_start_date_time),
         }
         return json.dumps(content, sort_keys=True, indent=4, separators=(",", ": "))
 

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -232,25 +232,25 @@ class JobTest(unittest.TestCase):
         logging.disable(logging.ERROR)
         self.job.run()
         logging.disable(logging.NOTSET)
-        self.assertNotEqual(self.job.time_start, -1)
-        self.assertNotEqual(self.job.time_end, -1)
-        self.assertNotEqual(self.job.time_elapsed, -1)
+        self.assertNotEqual(self.job._time_start, None)
+        self.assertNotEqual(self.job._time_end, None)
+        self.assertNotEqual(self.job.time_elapsed, None)
 
     def test_job_self_account_time(self):
         config = {"core.show": ["none"], "run.results_dir": self.tmpdir.name}
         self.job = job.Job(config)
         self.job.setup()
-        self.job.time_start = 10.0
+        self.job._time_start = 10.0
         # temporarily disable logging on console
         logging.disable(logging.ERROR)
         self.job.run()
         logging.disable(logging.NOTSET)
-        self.job.time_end = 20.0
+        self.job._time_end = 20.0
         # forcing a different value to check if it's not being
         # calculated when time_start or time_end are manually set
         self.job.time_elapsed = 100.0
-        self.assertEqual(self.job.time_start, 10.0)
-        self.assertEqual(self.job.time_end, 20.0)
+        self.assertEqual(self.job._time_start, 10.0)
+        self.assertEqual(self.job._time_end, 20.0)
         self.assertEqual(self.job.time_elapsed, 100.0)
 
     def test_job_suites_config(self):

--- a/selftests/unit/test_job.py
+++ b/selftests/unit/test_job.py
@@ -253,6 +253,20 @@ class JobTest(unittest.TestCase):
         self.assertEqual(self.job._time_end, 20.0)
         self.assertEqual(self.job.time_elapsed, 100.0)
 
+    def test_job_elapsed_time(self):
+        config = {"core.show": ["none"], "run.results_dir": self.tmpdir.name}
+        self.job = job.Job(config)
+        self.job.setup()
+        self.job._time_start = 10.0
+        self.job._time_end = 25.0
+        # temporarily disable logging on console
+        logging.disable(logging.ERROR)
+        self.job.run()
+        logging.disable(logging.NOTSET)
+        # forcing a different value to check if it's not being
+        # calculated when time_start or time_end are manually set
+        self.assertEqual(self.job.time_elapsed, 15.0)
+
     def test_job_suites_config(self):
         config = {
             "run.results_dir": self.tmpdir.name,


### PR DESCRIPTION
Currently, an `avocado jobs list` command will usually return something like:

```
0d6874b8902f29d2498e4af1a6449213b261d68 1969-12-31 23:04:52.077601   3 (1/0/0/1)
eab993bf69f5bdc0edd6c8d72cf34ed3c83db6a2 1969-12-31 23:05:11.940534   3 (3/0/0/0)
ec7ca92458b77083334c6775d0011561bc277170 1970-01-01 21:55:22.576918   1 (1/0/0/0)
3ea5516b1bfc398495e340745126396add2bdb91 1970-01-01 21:56:37.293293   1 (1/0/0/0)
```

The date and times are way off.  The reason is the use of the first test's "time", which is a monotonic time and can not be used for an actual date and time. 