### PR TITLE
junit restults add 'file' field

### DIFF
--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -23,6 +23,7 @@ from xml.dom.minidom import Document
 from avocado.core.output import LOG_UI
 from avocado.core.parser import FileOrStdoutAction
 from avocado.core.plugin_interfaces import CLI, Init, Result
+from avocado.core.references import reference_split
 from avocado.core.settings import settings
 from avocado.core.test_id import TestID
 from avocado.utils import astring
@@ -63,8 +64,11 @@ class XUnitResult(Result):
         name = state.get("name")
         if isinstance(name, TestID):
             testcase.setAttribute("name", self._escape_attr(name.name))
+            file_path, _ = reference_split(name.name)
         else:
             testcase.setAttribute("name", self._get_attr(state, "name"))
+            file_path, _ = reference_split(self._get_attr(state, "name"))
+        testcase.setAttribute("file", self._escape_attr(file_path))
         testcase.setAttribute(
             "time", self._format_time(self._get_attr(state, "time_elapsed"))
         )

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -256,8 +256,9 @@ The default machine readable output in Avocado is `xunit
 
 xUnit is an XML format that contains test results in a structured form, and are
 used by other test automation projects, such as `jenkins
-<http://jenkins-ci.org/>`__. If you want to make Avocado to generate xunit
-output in the standard output of the runner, simply use::
+<http://jenkins-ci.org/>`__ or `GitLabCI <https://docs.gitlab.com/ee/ci/>`__.
+If you want to make Avocado to generate xunit output in the standard output of
+the runner, simply use::
 
     $ avocado run examples/tests/sleeptest.py examples/tests/failtest.py examples/tests/synctest.py --xunit -
     <?xml version="1.0" encoding="UTF-8"?>
@@ -303,6 +304,9 @@ output in the standard output of the runner, simply use::
           longer it only attaches up-to max-test-log-chars characters
           one half starting from the beginning of the content, the other
           half from the end of the content.
+
+.. note:: The avocado xunit format adds some attributes which are not a part of 
+          the official format, but they are used by `GitLabCI <https://gitlab.com/gitlab-org/gitlab/-/blob/7826c42924e3ced8ae625fda1ddd4e120492d596/lib/gitlab/ci/parsers/test/junit.rb#L83>`__.
 
 
 **2. JSON:**

--- a/selftests/.data/jenkins-junit.xsd
+++ b/selftests/.data/jenkins-junit.xsd
@@ -71,6 +71,7 @@
                 <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
             <xs:attribute name="assertions" type="xs:string" use="optional"/>
             <xs:attribute name="time" type="xs:string" use="optional"/>
             <xs:attribute name="classname" type="xs:string" use="optional"/>


### PR DESCRIPTION
This adds a test file field to the junit result format. This field is well known and used by CIs (like Gitlab)

Reference: #5229
Signed-off-by: Jan Richter <jarichte@redhat.com>