### PR TITLE
Multiple suite example job

### DIFF
--- a/examples/jobs/multiple_suites_from_config.py
+++ b/examples/jobs/multiple_suites_from_config.py
@@ -19,7 +19,7 @@ RANDOM_CONFIG = {
         "/bin/true",
         "/bin/last",
     ],
-    "nrunner.shuffle": True,
+    "run.shuffle": True,
     "run.max_parallel_tasks": 3,
 }
 

--- a/examples/jobs/multiple_suites_from_config.py
+++ b/examples/jobs/multiple_suites_from_config.py
@@ -20,7 +20,7 @@ RANDOM_CONFIG = {
         "/bin/last",
     ],
     "run.shuffle": True,
-    "run.max_parallel_tasks": 3,
+    "run.max_parallel_tasks": 1,
 }
 
 with Job(


### PR DESCRIPTION
On 8db957992, "nrunner.shuffle" was renamed to "run.shuffle".  Let's match this example job accordingly and make the behavior of that option more apparent to users.