### PR TITLE
Selftest: use a temp dir as the job's result dir

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
+++ b/optional_plugins/varianter_yaml_to_mux/tests/test_functional.py
@@ -226,6 +226,7 @@ class MultiplexTests(unittest.TestCase):
     def test_mux_inject(self):
         cmd = (
             f"{AVOCADO} run --disable-sysinfo --json - "
+            f"--job-results-dir {self.tmpdir.name} "
             f"--mux-inject foo:1 bar:2 baz:3 foo:foo:a "
             f"foo:bar:b foo:baz:c bar:bar:bar "
             f"-- examples/tests/params.py "


### PR DESCRIPTION
Most selftests do that, in order not to pollute the user's job result dir, but it's missing on this specific test.

Signed-off-by: Cleber Rosa <crosa@redhat.com>