### PR TITLE
Selftests user's default results directory cleanup

### DIFF
--- a/selftests/check.py
+++ b/selftests/check.py
@@ -798,7 +798,15 @@ def main(args):  # pylint: disable=W0621
                 suite.config["run.max_parallel_tasks"] = max_parallel
 
     with Job(config, suites) as j:
+        pre_job_test_result_dirs = set(os.listdir(os.path.dirname(j.logdir)))
         exit_code = j.run()
+        post_job_test_result_dirs = set(os.listdir(os.path.dirname(j.logdir)))
+        if len(pre_job_test_result_dirs) != len(post_job_test_result_dirs):
+            if exit_code == 0:
+                exit_code = 1
+            print("check.py didn't clean test results.")
+            print("uncleaned directories:")
+            print(post_job_test_result_dirs.difference(pre_job_test_result_dirs))
     return exit_code
 
 

--- a/selftests/functional/plugin/test_logs.py
+++ b/selftests/functional/plugin/test_logs.py
@@ -18,11 +18,12 @@ class TestLogsUI(TestCaseTmpDir):
 
     def test(self):
         cmd_line = (
-            "%s --config=%s run -- examples/tests/passtest.py "
-            "examples/tests/failtest.py "
-            "examples/tests/canceltest.py "
+            f"{AVOCADO} --config={os.path.join(self.tmpdir.name, 'config')} "
+            f"run --job-results-dir {self.tmpdir.name} "
+            f"-- examples/tests/passtest.py "
+            f"examples/tests/failtest.py "
+            f"examples/tests/canceltest.py "
         )
-        cmd_line %= (AVOCADO, os.path.join(self.tmpdir.name, "config"))
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(
             result.exit_status,

--- a/selftests/functional/serial/test_requirements.py
+++ b/selftests/functional/serial/test_requirements.py
@@ -117,7 +117,9 @@ class BasicTest(Test):
         spawner_command = ""
         if spawner == "podman":
             spawner_command = "--spawner=podman --spawner-podman-image=fedora:36"
-        return f"{AVOCADO} run {spawner_command} {path}"
+        return (
+            f"{AVOCADO} run {spawner_command} --job-results-dir {self.workdir} {path}"
+        )
 
     @skipUnless(os.getenv("CI"), skip_package_manager_message)
     def test_single_success(self):

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -9,10 +9,11 @@ from selftests.utils import AVOCADO, BASEDIR, TestCaseTmpDir, skipUnlessPathExis
 RUNNER = "avocado-runner-noop"
 
 
-class NRunnerFeatures(unittest.TestCase):
+class NRunnerFeatures(TestCaseTmpDir):
     @skipUnlessPathExists("/bin/false")
     def test_custom_exit_codes(self):
         config = {
+            "run.results_dir": self.tmpdir.name,
             "resolver.references": ["/bin/false"],
             "runner.exectest.exitcodes.skip": [1],
         }
@@ -23,6 +24,7 @@ class NRunnerFeatures(unittest.TestCase):
     @skipUnlessPathExists("/bin/true")
     def test_failfast(self):
         config = {
+            "run.results_dir": self.tmpdir.name,
             "resolver.references": [
                 "/bin/true",
                 "/bin/false",

--- a/selftests/jobs/example_passjob
+++ b/selftests/jobs/example_passjob
@@ -1,1 +1,0 @@
-../../examples/jobs/passjob.py

--- a/selftests/jobs/example_passjob_cit_varianter
+++ b/selftests/jobs/example_passjob_cit_varianter
@@ -1,1 +1,0 @@
-../../examples/jobs/passjob_cit_varianter.py

--- a/selftests/jobs/example_passjob_html
+++ b/selftests/jobs/example_passjob_html
@@ -1,1 +1,0 @@
-../../examples/jobs/passjob_html.py

--- a/selftests/jobs/example_sleepjob_dict_varianter
+++ b/selftests/jobs/example_sleepjob_dict_varianter
@@ -1,1 +1,0 @@
-../../examples/jobs/sleepjob_dict_varianter.py

--- a/selftests/jobs/example_sleepjob_json_varianter
+++ b/selftests/jobs/example_sleepjob_json_varianter
@@ -1,1 +1,0 @@
-../../examples/jobs/sleepjob_json_varianter.py

--- a/selftests/jobs/example_unix_status_server
+++ b/selftests/jobs/example_unix_status_server
@@ -1,1 +1,0 @@
-../../examples/jobs/unix_status_server.py

--- a/selftests/jobs/passjob.py
+++ b/selftests/jobs/passjob.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import sys
+import tempfile
+
+from avocado.core.job import Job
+
+test_results_dir = tempfile.TemporaryDirectory()
+
+job_config = {
+    "run.results_dir": test_results_dir.name,
+    "resolver.references": ["examples/tests/passtest.py:PassTest.test"],
+}
+
+# Automatic helper method (Avocado will try to discovery things from config
+# dicts. Since there is magic here, we don't need to pass suite names or suites,
+# and test/task id will be prepend with the suite index (in this case 1 and 2)
+
+with Job.from_config(job_config=job_config) as job:
+    exit_code = job.run()
+    test_results_dir.cleanup()
+    sys.exit(exit_code)

--- a/selftests/jobs/passjob_cit_varianter.py
+++ b/selftests/jobs/passjob_cit_varianter.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-# Minimal job that runs an also minimal executable test
-
-import os
 import sys
 import tempfile
 
@@ -13,11 +10,9 @@ test_results_dir = tempfile.TemporaryDirectory()
 
 config = {
     "run.results_dir": test_results_dir.name,
-    'resolver.references': [
-        os.path.join(os.path.dirname(__file__), 'tests', 'pass'),
-        os.path.join(os.path.dirname(__file__), 'tests', 'passtest.py')
-        ]
-    }
+    "resolver.references": ["examples/tests/passtest.py:PassTest.test"],
+    "cit_parameter_file": "examples/varianter_cit/test_params.cit",
+}
 
 suite = TestSuite.from_config(config)
 with Job(config, [suite]) as j:

--- a/selftests/jobs/passjob_html.py
+++ b/selftests/jobs/passjob_html.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-# Minimal job that runs an also minimal executable test
-
-import os
 import sys
 import tempfile
 
@@ -13,11 +10,9 @@ test_results_dir = tempfile.TemporaryDirectory()
 
 config = {
     "run.results_dir": test_results_dir.name,
-    'resolver.references': [
-        os.path.join(os.path.dirname(__file__), 'tests', 'pass'),
-        os.path.join(os.path.dirname(__file__), 'tests', 'passtest.py')
-        ]
-    }
+    "resolver.references": ["examples/tests/passtest.py:PassTest.test"],
+    "job.run.result.html.enabled": True,
+}
 
 suite = TestSuite.from_config(config)
 with Job(config, [suite]) as j:

--- a/selftests/jobs/sleepjob_dict_varianter.py
+++ b/selftests/jobs/sleepjob_dict_varianter.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-# Minimal job that runs an also minimal executable test
-
-import os
 import sys
 import tempfile
 
@@ -13,11 +10,9 @@ test_results_dir = tempfile.TemporaryDirectory()
 
 config = {
     "run.results_dir": test_results_dir.name,
-    'resolver.references': [
-        os.path.join(os.path.dirname(__file__), 'tests', 'pass'),
-        os.path.join(os.path.dirname(__file__), 'tests', 'passtest.py')
-        ]
-    }
+    "resolver.references": ["examples/tests/sleeptest.py:SleepTest.test"],
+    "run.dict_variants": [{"sleep_length": "0.5"}, {"sleep_length": "1.0"}],
+}
 
 suite = TestSuite.from_config(config)
 with Job(config, [suite]) as j:

--- a/selftests/jobs/sleepjob_json_varianter.py
+++ b/selftests/jobs/sleepjob_json_varianter.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-# Minimal job that runs an also minimal executable test
-
-import os
 import sys
 import tempfile
 
@@ -13,11 +10,9 @@ test_results_dir = tempfile.TemporaryDirectory()
 
 config = {
     "run.results_dir": test_results_dir.name,
-    'resolver.references': [
-        os.path.join(os.path.dirname(__file__), 'tests', 'pass'),
-        os.path.join(os.path.dirname(__file__), 'tests', 'passtest.py')
-        ]
-    }
+    "resolver.references": ["examples/tests/sleeptest.py:SleepTest.test"],
+    "json.variants.load": "examples/tests/sleeptest.py.data/sleeptest.json",
+}
 
 suite = TestSuite.from_config(config)
 with Job(config, [suite]) as j:

--- a/selftests/jobs/status_server_auto
+++ b/selftests/jobs/status_server_auto
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+import tempfile
 
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
@@ -9,7 +10,10 @@ from avocado.core.suite import TestSuite
 # configuration
 status_server = '/path/to/a/very/bad/non-existing/location'
 
+test_results_dir = tempfile.TemporaryDirectory()
+
 config = {
+    "run.results_dir": test_results_dir.name,
     "run.status_server_auto": True,
     "run.status_server_listen": status_server,
     "run.status_server_uri": status_server,
@@ -19,7 +23,7 @@ config = {
 suite = TestSuite.from_config(config, name="1")
 with Job(config, [suite]) as j:
     result = j.run()
-
+    test_results_dir.cleanup()
 # Check that one test actually ran and results were recorded. The
 # test's success will be checked by the job execution result
 assert len(j.result.tests) == 1

--- a/selftests/jobs/unix_status_server.py
+++ b/selftests/jobs/unix_status_server.py
@@ -8,30 +8,26 @@ from avocado.core.job import Job
 from avocado.core.suite import TestSuite
 
 status_server_dir = tempfile.TemporaryDirectory()
-status_server_listen = os.path.join(status_server_dir.name, "status_server.socket")
-status_server_uri = os.path.join(status_server_dir.name, "client_link_to_server_socket")
-
-assert status_server_listen != status_server_uri
-os.symlink(status_server_listen, status_server_uri)
+status_server = os.path.join(status_server_dir.name, "status_server.socket")
 
 test_results_dir = tempfile.TemporaryDirectory()
 
 config = {
     "run.results_dir": test_results_dir.name,
     "run.status_server_auto": False,
-    "run.status_server_listen": status_server_listen,
-    "run.status_server_uri": status_server_uri,
+    "run.status_server_listen": status_server,
+    "run.status_server_uri": status_server,
     "resolver.references": ["examples/tests/passtest.py"],
 }
 
 suite = TestSuite.from_config(config, name="1")
 with Job(config, [suite]) as j:
     result = j.run()
+    test_results_dir.cleanup()
 
 # Check that one test actually ran and results were recorded. The
 # test's success will be checked by the job execution result
 assert len(j.result.tests) == 1
 
 status_server_dir.cleanup()
-test_results_dir.cleanup()
 sys.exit(result)


### PR DESCRIPTION
This will update selftests to not store temporary results in user's
default results directory.

Reference: https://github.com/avocado-framework/avocado/issues/5554
Signed-off-by: Jan Richter <jarichte@redhat.com>