### PR TITLE
Missing renames of nrunner.* configuration options

### DIFF
--- a/examples/jobs/unix_status_server.py
+++ b/examples/jobs/unix_status_server.py
@@ -11,9 +11,9 @@ status_server_dir = tempfile.TemporaryDirectory()
 status_server = os.path.join(status_server_dir.name, "status_server.socket")
 
 config = {
-    "nrunner.status_server_auto": False,
-    "nrunner.status_server_listen": status_server,
-    "nrunner.status_server_uri": status_server,
+    "run.status_server_auto": False,
+    "run.status_server_listen": status_server,
+    "run.status_server_uri": status_server,
     "resolver.references": ["examples/tests/passtest.py"],
 }
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -646,7 +646,7 @@ def create_suites(args):  # pylint: disable=W0621
     # ========================================================================
     config_nrunner_requirement = {
         "resolver.references": ["selftests/functional/serial/test_requirements.py"],
-        "nrunner.max_parallel_tasks": 1,
+        "run.max_parallel_tasks": 1,
         "run.dict_variants": [
             {"spawner": "process"},
             {"spawner": "podman"},
@@ -693,7 +693,7 @@ def create_suites(args):  # pylint: disable=W0621
         config_check_functional_serial["resolver.references"] = [
             "selftests/functional/serial/"
         ]
-        config_check_functional_serial["nrunner.max_parallel_tasks"] = 1
+        config_check_functional_serial["run.max_parallel_tasks"] = 1
         suites.append(
             TestSuite.from_config(config_check_functional_serial, "functional-serial")
         )
@@ -795,7 +795,7 @@ def main(args):  # pylint: disable=W0621
         max_parallel = int(multiprocessing.cpu_count() / 2)
         for suite in suites:
             if suite.name == "functional-parallel":
-                suite.config["nrunner.max_parallel_tasks"] = max_parallel
+                suite.config["run.max_parallel_tasks"] = max_parallel
 
     with Job(config, suites) as j:
         exit_code = j.run()

--- a/selftests/functional/plugin/spawners/test_podman.py
+++ b/selftests/functional/plugin/spawners/test_podman.py
@@ -69,7 +69,7 @@ class PodmanSpawnerTest(TestCaseTmpDir):
                 "resolver.references": [test.path],
                 "run.results_dir": self.tmpdir.name,
                 "task.timeout.running": 2,
-                "nrunner.spawner": "podman",
+                "run.spawner": "podman",
                 "spawner.podman.image": "fedora:36",
             }
 

--- a/selftests/jobs/status_server_auto
+++ b/selftests/jobs/status_server_auto
@@ -10,9 +10,9 @@ from avocado.core.suite import TestSuite
 status_server = '/path/to/a/very/bad/non-existing/location'
 
 config = {
-    "nrunner.status_server_auto": True,
-    "nrunner.status_server_listen": status_server,
-    "nrunner.status_server_uri": status_server,
+    "run.status_server_auto": True,
+    "run.status_server_listen": status_server,
+    "run.status_server_uri": status_server,
     "resolver.references": ["examples/tests/passtest.py"],
 }
 

--- a/selftests/jobs/status_server_different_uri_listen
+++ b/selftests/jobs/status_server_different_uri_listen
@@ -15,9 +15,9 @@ assert status_server_listen != status_server_uri
 os.symlink(status_server_listen, status_server_uri)
 
 config = {
-    "nrunner.status_server_auto": False,
-    "nrunner.status_server_listen": status_server_listen,
-    "nrunner.status_server_uri": status_server_uri,
+    "run.status_server_auto": False,
+    "run.status_server_listen": status_server_listen,
+    "run.status_server_uri": status_server_uri,
     "resolver.references": ["examples/tests/passtest.py"],
 }
 

--- a/selftests/pre_release/jobs/pre_release.py
+++ b/selftests/pre_release/jobs/pre_release.py
@@ -19,13 +19,13 @@ parallel_1 = {
         os.path.join("selftests", "functional"),
     ],
     "filter.by_tags.tags": ["parallel:1"],
-    "nrunner.max_parallel_tasks": 1,
+    "run.max_parallel_tasks": 1,
 }
 
 vmimage = {
     "resolver.references": [os.path.join(TESTS_DIR, "vmimage.py")],
     "yaml_to_mux.files": [os.path.join(TESTS_DIR, "vmimage.py.data", "variants.yml")],
-    "nrunner.max_parallel_tasks": 1,
+    "run.max_parallel_tasks": 1,
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
Commit 8db957992 dropped the "--nrunner-" command line prefixes, and changed the configuration option names from "nrunner." to "run.".

These are leftover renames that were missing in that changeset.

Signed-off-by: Cleber Rosa <crosa@redhat.com>