### PR TITLE
Remove triage tag from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug, triage
+labels: bug
 assignees: ''
 
 ---


### PR DESCRIPTION
Since we moved to the new project board, we don't need tag for triaging issues, because we have special status for that in new project board.

Reference: https://github.com/orgs/avocado-framework/projects/1
Signed-off-by: Jan Richter <jarichte@redhat.com>