### PR TITLE
Loader unexpected keyword argument 'run.results_dir' fix.

### DIFF
--- a/avocado/core/utils/loader.py
+++ b/avocado/core/utils/loader.py
@@ -30,6 +30,8 @@ def load_test(test_factory):
     :return: an instance of :class:`avocado.core.test.Test`.
     """
     test_class, test_parameters = test_factory
+    if "run.results_dir" in test_parameters:
+        test_parameters["base_logdir"] = test_parameters.pop("run.results_dir")
     if "modulePath" in test_parameters:
         test_path = test_parameters.pop("modulePath")
     else:
@@ -60,8 +62,6 @@ def load_test(test_factory):
                 if issubclass(obj, test.Test):
                     test_class = obj
                     break
-    if "run.results_dir" in test_parameters:
-        test_parameters["base_logdir"] = test_parameters.pop("run.results_dir")
     test_instance = test_class(**test_parameters)
 
     return test_instance


### PR DESCRIPTION
The loader has to pass  'run.results_dir' as `base_logdir` to test class. Let's add this change at the beginning of the `load_test` method. It will avoid problems with handling loader errors, because any loader error was overwritten by unexpected keyword argument 'run.results_dir' error in test class. It fixes #5459

Reference: #5459
Signed-off-by: Jan Richter <jarichte@redhat.com>