### PR TITLE
Podman spawner: fix outputdir preservation

### DIFF
--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -222,10 +222,9 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
 
         output_opts = ()
         if test_output:
-            podman_output = runtime_task.task.runnable.output_dir
             output_opts = (
                 "-v",
-                (f"{test_output}:" f"{os.path.expanduser(podman_output)}"),
+                f"{test_output}:{runtime_task.task.runnable.output_dir}",
             )
 
         image, _ = self._get_image_from_cache(runtime_task)
@@ -288,7 +287,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
 
     def create_task_output_dir(self, runtime_task):
         output_dir_path = self.task_output_dir(runtime_task)
-        output_podman_path = "~/avocado/job-results/spawner/task"
+        output_podman_path = "/tmp/.avocado_task_output_dir"
 
         os.makedirs(output_dir_path, exist_ok=True)
         runtime_task.task.setup_output_dir(output_podman_path)


### PR DESCRIPTION
The Podman spawner creates a volume that serves to preserve a test's "outputdir" (aka "data") directory.  But, because of possible (and probable) mismatches between users in the "host" and in the container itself, the current choice of location for the "outputdir" can prove ineffective.
    
This changes the directory used as the outputdir to an absolute location, that does not depend on the user.
    
Fixes: https://github.com/avocado-framework/avocado/issues/5556