### PR TITLE
exec-test: allow the use of runnable's output dir for stdout/stderr

### DIFF
--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -140,11 +140,18 @@ class ExecTestRunner(BaseRunner):
         return env
 
     def _run_proc(self, runnable):
+        if runnable.output_dir is not None:
+            stdout = open(os.path.join(runnable.output_dir, "stdout"), "xb")
+            stderr = open(os.path.join(runnable.output_dir, "stderr"), "xb")
+        else:
+            stdout = subprocess.PIPE
+            stderr = subprocess.PIPE
+
         return subprocess.Popen(
             [runnable.uri] + list(runnable.args),
             stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=stdout,
+            stderr=stderr,
             env=self._get_env(runnable),
         )
 
@@ -165,8 +172,19 @@ class ExecTestRunner(BaseRunner):
 
         yield from self.running_loop(poll_proc)
 
-        stdout = process.stdout.read()
-        stderr = process.stderr.read()
+        if process.stdout is not None:
+            stdout = process.stdout.read()
+        else:
+            stdout_path = os.path.join(runnable.output_dir, "stdout")
+            with open(stdout_path, "rb") as stdout_file:
+                stdout = stdout_file.read()
+
+        if process.stderr is not None:
+            stderr = process.stderr.read()
+        else:
+            stderr_path = os.path.join(runnable.output_dir, "stderr")
+            with open(stderr_path, "rb") as stderr_file:
+                stderr = stderr_file.read()
 
         yield self.prepare_status("running", {"type": "stdout", "log": stdout})
         yield self.prepare_status("running", {"type": "stderr", "log": stderr})

--- a/selftests/.data/exec_test_std/exec_test_1mib.py
+++ b/selftests/.data/exec_test_std/exec_test_1mib.py
@@ -1,0 +1,9 @@
+#!/bin/env python3
+
+import sys
+
+if __name__ == "__main__":
+    data = b"1" * 1024 * 1024
+    sys.stdout.write(data.decode())
+    data = b"2" * 1024 * 1024
+    sys.stderr.write(data.decode())

--- a/selftests/.data/exec_test_std/exec_test_64kib.py
+++ b/selftests/.data/exec_test_std/exec_test_64kib.py
@@ -1,0 +1,9 @@
+#!/bin/env python3
+
+import sys
+
+if __name__ == "__main__":
+    data = b"1" * 1024
+    sys.stdout.write(data.decode())
+    data = b"2" * 1024
+    sys.stderr.write(data.decode())

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -133,6 +133,49 @@ class RunnableRun(unittest.TestCase):
         self.assertEqual(res.exit_status, 0)
 
 
+class ExecTestStdOutErr(unittest.TestCase):
+    def test_64kib(self):
+        path = os.path.join(
+            BASEDIR, "selftests", ".data", "exec_test_std", "exec_test_64kib.py"
+        )
+        res = process.run(
+            f"avocado-runner-exec-test runnable-run -u {path}", ignore_status=True
+        )
+        self.assertIn(b"'type': 'stdout'", res.stdout)
+        self.assertIn(b"'type': 'stderr'", res.stdout)
+        self.assertIn(b"'result': 'pass'", res.stdout)
+        self.assertIn(b"'returncode': 0", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+
+class ExecTestStdOutErrOutputDir(TestCaseTmpDir):
+    def test_1mib(self):
+        path = os.path.join(
+            BASEDIR, "selftests", ".data", "exec_test_std", "exec_test_1mib.py"
+        )
+        res = process.run(
+            f"avocado-runner-exec-test runnable-run -u {path} output_dir={self.tmpdir.name}",
+            ignore_status=True,
+        )
+        self.assertIn(b"'type': 'stdout'", res.stdout)
+        self.assertIn(b"'type': 'stderr'", res.stdout)
+        self.assertIn(b"'result': 'pass'", res.stdout)
+        self.assertIn(b"'returncode': 0", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+    def test_error_existing_stdout_stderr(self):
+        self.test_1mib()
+        path = os.path.join(
+            BASEDIR, "selftests", ".data", "exec_test_std", "exec_test_1mib.py"
+        )
+        res = process.run(
+            f"avocado-runner-exec-test runnable-run -u {path} output_dir={self.tmpdir.name}",
+            ignore_status=True,
+        )
+        self.assertIn(b"'result': 'error'", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+
 class TaskRun(unittest.TestCase):
     def test_noop(self):
         res = process.run(


### PR DESCRIPTION
Most of the information that generic executables (exec-test) tests generate will be done with their STDOUT and STDERR.

Avocado, since 0a8178ded, inadvertently reduced the size capacity when keeping and storing the STDOUT and STDERR.  Still, limits will always exist, either in memory buffer sizes, network buffer sizes, or even filesystem file size limits or overall storage resources.

This change increases considerably the limits of an "exec-test" by using, when available, the given "output_dir" parameter to a runnable or task.  Whenever a test is run under "avocado run", a task will be used, and a task always has an "output_dir", so, unless one is running "avocado-runner-exec-test" manually and *not* providing an output_dir, the STDOUT and STDERR limits are now the filesystem limits.

The tests document the existing limits:

 * 64kib when using PIPEs
 * Considerably larger limits (filesystem ones) when using an output_dir

It also "documents" a new behavior introduced here that produces an error if an output_dir is attempted to be reused, to avoid overwriting unintended stdout/stderr files.

Fixes: https://github.com/avocado-framework/avocado/issues/5521
Signed-off-by: Cleber Rosa <crosa@redhat.com>