### PR TITLE
exec-test: allow the use of runnable's output dir for stdout/stderr [v2]

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -340,56 +340,66 @@ class StdoutMessageHandler(BaseRunningMessageHandler):
     """
     Handler for stdout message.
 
-    It will save the stdout to the stdout and debug file in the task directory.
+    It will save the stdout to the debug file in the task directory,
+    and optionally (depending on "log_only" value) to the stdout file.
 
     :param status: 'running'
     :param type: 'stdout'
     :param log: stdout message
     :type log: bytes
+    :param log_only: whether to save the "log" message only to the standard
+                     test log (and not to the "stdout" file)
+    :type log_only: bool
     :param encoding: optional value for decoding messages
     :type encoding: str
     :param time: Time stamp of the message
     :type time: float
 
     example: {'status': 'running', 'type': 'stdout', 'log': 'stdout message',
-             'time': 18405.55351474}
+              'log_only': False, 'time': 18405.55351474}
     """
 
     _tag = b"[stdout] "
 
     def handle(self, message, task, job):
         self._save_to_default_file(message, task)
-        self._save_message_to_file(
-            "stdout", message["log"], task, message.get("encoding", None)
-        )
+        if not message.get("log_only", False):
+            self._save_message_to_file(
+                "stdout", message["log"], task, message.get("encoding", None)
+            )
 
 
 class StderrMessageHandler(BaseRunningMessageHandler):
     """
     Handler for stderr message.
 
-    It will save the stderr to the stderr and debug file in the task directory.
+    It will save the stderr to the debug file in the task directory,
+    and optionally (depending on "log_only" value) to the stderr file.
 
     :param status: 'running'
     :param type: 'stderr'
     :param log: stderr message
     :type log: bytes
+    :param log_only: whether to save the "log" message only to the standard
+                     test log (and not to the "stderr" file)
+    :type log_only: bool
     :param encoding: optional value for decoding messages
     :type encoding: str
     :param time: Time stamp of the message
     :type time: float
 
     example: {'status': 'running', 'type': 'stderr', 'log': 'stderr message',
-             'time': 18405.55351474}
+              'log_only': False, 'time': 18405.55351474}
     """
 
     _tag = b"[stderr] "
 
     def handle(self, message, task, job):
         self._save_to_default_file(message, task)
-        self._save_message_to_file(
-            "stderr", message["log"], task, message.get("encoding", None)
-        )
+        if not message.get("log_only", False):
+            self._save_message_to_file(
+                "stderr", message["log"], task, message.get("encoding", None)
+            )
 
 
 class WhiteboardMessageHandler(BaseRunningMessageHandler):

--- a/selftests/.data/exec_test_std/exec_test_1mib.py
+++ b/selftests/.data/exec_test_std/exec_test_1mib.py
@@ -1,0 +1,9 @@
+#!/bin/env python3
+
+import sys
+
+if __name__ == "__main__":
+    data = b"1" * 1024 * 1024
+    sys.stdout.write(data.decode())
+    data = b"2" * 1024 * 1024
+    sys.stderr.write(data.decode())

--- a/selftests/.data/exec_test_std/exec_test_64kib.py
+++ b/selftests/.data/exec_test_std/exec_test_64kib.py
@@ -1,0 +1,9 @@
+#!/bin/env python3
+
+import sys
+
+if __name__ == "__main__":
+    data = b"1" * 1024 * 64
+    sys.stdout.write(data.decode())
+    data = b"2" * 1024 * 64
+    sys.stderr.write(data.decode())

--- a/selftests/functional/test_nrunner.py
+++ b/selftests/functional/test_nrunner.py
@@ -133,6 +133,49 @@ class RunnableRun(unittest.TestCase):
         self.assertEqual(res.exit_status, 0)
 
 
+class ExecTestStdOutErr(unittest.TestCase):
+    def test_64kib(self):
+        path = os.path.join(
+            BASEDIR, "selftests", ".data", "exec_test_std", "exec_test_64kib.py"
+        )
+        res = process.run(
+            f"avocado-runner-exec-test runnable-run -u {path}", ignore_status=True
+        )
+        self.assertIn(b"'type': 'stdout'", res.stdout)
+        self.assertIn(b"'type': 'stderr'", res.stdout)
+        self.assertIn(b"'result': 'pass'", res.stdout)
+        self.assertIn(b"'returncode': 0", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+
+class ExecTestStdOutErrOutputDir(TestCaseTmpDir):
+    def test_1mib(self):
+        path = os.path.join(
+            BASEDIR, "selftests", ".data", "exec_test_std", "exec_test_1mib.py"
+        )
+        res = process.run(
+            f"avocado-runner-exec-test runnable-run -u {path} output_dir={self.tmpdir.name}",
+            ignore_status=True,
+        )
+        self.assertIn(b"'type': 'stdout'", res.stdout)
+        self.assertIn(b"'type': 'stderr'", res.stdout)
+        self.assertIn(b"'result': 'pass'", res.stdout)
+        self.assertIn(b"'returncode': 0", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+    def test_error_existing_stdout_stderr(self):
+        self.test_1mib()
+        path = os.path.join(
+            BASEDIR, "selftests", ".data", "exec_test_std", "exec_test_1mib.py"
+        )
+        res = process.run(
+            f"avocado-runner-exec-test runnable-run -u {path} output_dir={self.tmpdir.name}",
+            ignore_status=True,
+        )
+        self.assertIn(b"'result': 'error'", res.stdout)
+        self.assertEqual(res.exit_status, 0)
+
+
 class TaskRun(unittest.TestCase):
     def test_noop(self):
         res = process.run(


### PR DESCRIPTION
Most of the information that generic executables (exec-test) tests generate will be done with their STDOUT and STDERR.

Avocado, since 0a8178ded, inadvertently reduced the size capacity when keeping and storing the STDOUT and STDERR.  Still, limits will always exist, either in memory buffer sizes, network buffer sizes, or even filesystem file size limits or overall storage resources.

This change increases considerably the limits of an "exec-test" by using, when available, the given "output_dir" parameter to a runnable or task.  Whenever a test is run under "avocado run", a task will be used, and a task always has an "output_dir", so, unless one is running "avocado-runner-exec-test" manually and *not* providing an output_dir, the STDOUT and STDERR limits are now the filesystem limits.

The tests document the existing limits:

 * 64kib when using PIPEs
 * Considerably larger limits (filesystem ones) when using an output_dir

It also "documents" a new behavior introduced here that produces an error if an output_dir is attempted to be reused, to avoid overwriting unintended stdout/stderr files.

Fixes: https://github.com/avocado-framework/avocado/issues/5521
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#5565):
* Do not duplicate `stdout` and `stderr` file content
* Fixed amount of data produced by `selftests/.data/exec_test_std/exec_test_64kib.py`