### PR TITLE
Egg support: be more precise when adding egg location to PYTHONPATH

### DIFF
--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -10,6 +10,7 @@ import pkg_resources
 
 from avocado.core.nrunner.config import ConfigDecoder, ConfigEncoder
 from avocado.core.settings import settings
+from avocado.core.utils.eggenv import get_python_path_env_if_egg
 
 LOG = logging.getLogger(__name__)
 
@@ -443,11 +444,6 @@ class Runnable:
         if runner_cmd is not None:
             return runner_cmd
 
-        # When running Avocado Python modules, the interpreter on the new
-        # process needs to know where Avocado can be found.
-        env = os.environ.copy()
-        env["PYTHONPATH"] = ":".join(p for p in set(sys.path))
-
         standalone_executable_cmd = [f"avocado-runner-{kind}"]
         if Runnable.is_kind_supported_by_runner_command(
             kind, standalone_executable_cmd
@@ -464,7 +460,7 @@ class Runnable:
             full_module_name = f"avocado.plugins.runners.{module_name}"
             candidate_cmd = [sys.executable, "-m", full_module_name]
             if Runnable.is_kind_supported_by_runner_command(
-                kind, candidate_cmd, env=env
+                kind, candidate_cmd, env=get_python_path_env_if_egg()
             ):
                 runners_registry[kind] = candidate_cmd
                 return candidate_cmd

--- a/avocado/core/utils/eggenv.py
+++ b/avocado/core/utils/eggenv.py
@@ -1,0 +1,30 @@
+import os
+
+import pkg_resources
+
+
+def get_python_path_env_if_egg():
+    """
+    Returns an environment mapping with an extra PYTHONPATH for the egg or None
+
+    When running Avocado Python modules, the interpreter on the new
+    process needs to know where Avocado can be found.  This is usually
+    handled by the Avocado installation being available to the
+    standard Python installation, but if Avocado is running from an
+    uninstalled egg, it needs extra help.
+
+    :returns: environment mapping with an extra PYTHONPATH for the egg or None
+    :rtype: os.environ mapping or None
+    """
+    dist = pkg_resources.get_distribution("avocado-framework")
+    if not (dist.location.endswith(".egg") and os.path.isfile(dist.location)):
+        return None
+
+    python_path = os.environ.get("PYTHONPATH", "")
+    python_path_entries = python_path.split(":")
+    if dist.location in python_path_entries:
+        return None
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{dist.location}:{python_path}"
+    return env

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -1,12 +1,12 @@
 import asyncio
 import os
 import socket
-import sys
 
 from avocado.core.dependencies.requirements import cache
 from avocado.core.plugin_interfaces import Spawner
 from avocado.core.spawners.common import SpawnerMixin, SpawnMethod
 from avocado.core.teststatus import STATUSES_NOT_OK
+from avocado.core.utils.eggenv import get_python_path_env_if_egg
 
 ENVIRONMENT_TYPE = "local"
 ENVIRONMENT = socket.gethostname()
@@ -32,10 +32,6 @@ class ProcessSpawner(Spawner, SpawnerMixin):
         runner = task.runnable.runner_command()
         args = runner[1:] + ["task-run"] + task.get_command_args()
         runner = runner[0]
-        # When running Avocado Python modules, the interpreter on the new
-        # process needs to know where Avocado can be found.
-        env = os.environ.copy()
-        env["PYTHONPATH"] = ":".join(p for p in set(sys.path))
 
         # pylint: disable=E1133
         try:
@@ -44,7 +40,7 @@ class ProcessSpawner(Spawner, SpawnerMixin):
                 *args,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
-                env=env
+                env=get_python_path_env_if_egg(),
             )
         except (FileNotFoundError, PermissionError):
             return False

--- a/spell.ignore
+++ b/spell.ignore
@@ -756,3 +756,4 @@ pathconf
 fedoraproject
 ansible
 ansible-module
+environ


### PR DESCRIPTION
When running Avocado Python modules, the interpreter on the new process needs to know where Avocado can be found.  This is usually handled by the Avocado installation being available to the standard Python installation, but if Avocado is running from an uninstalled egg, it needs extra help.

Previously, the content of the set created from the sys.path content which is not ordered by nature, meant that the order of entries on the PYTHONPATH would change unpredictably.

Because of the changes in the spawner, and the much smaller intrusion on PYTHONPATH (and thus on the "import" machinery), the safeloader.sh test issue goes away.

Fixes: https://github.com/avocado-framework/avocado/issues/5378
Signed-off-by: Cleber Rosa <crosa@redhat.com>