### PR TITLE
Restore support for --show=$custom_logger on avocado-instrumented

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -12,6 +12,7 @@
 # Copyright: Red Hat Inc. 2021
 # Authors: Jan Richter <jarichte@redhat.com>
 
+import logging
 import os
 import time
 
@@ -334,6 +335,15 @@ class LogMessageHandler(BaseRunningMessageHandler):
                 task.metadata["task_path"], "debug.log"
             )
         self._save_to_default_file(message, task)
+
+        # For messages from specific loggers, we preserve their names
+        # and levels so that they are handled appropriately based on
+        # the Avocado job logging configuration
+        log_name = message.get("log_name")
+        if log_name is not None:
+            logger = logging.getLogger(log_name)
+            level = logging.getLevelName(message.get("log_levelname"))
+            logger.log(level, message.get("log_message"))
 
 
 class StdoutMessageHandler(BaseRunningMessageHandler):

--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -1,7 +1,7 @@
 import time
 
 
-class GenericMessage:
+class GenericFactory:
     message_status = None
 
     @classmethod
@@ -33,17 +33,17 @@ class GenericMessage:
         return cls._prepare_message(additional_info=kwargs)
 
 
-class StartedMessage(GenericMessage):
+class StartedFactory(GenericFactory):
     message_status = "started"
 
 
-class RunningMessage(GenericMessage):
+class RunningFactory(GenericFactory):
     """Creates running message without any additional info."""
 
     message_status = "running"
 
 
-class FinishedMessage(GenericMessage):
+class FinishedFactory(GenericFactory):
     message_status = "finished"
 
     @classmethod
@@ -65,7 +65,7 @@ class FinishedMessage(GenericMessage):
         )
 
 
-class GenericRunningMessage(GenericMessage):
+class GenericRunningFactory(GenericFactory):
     message_status = "running"
     message_type = None
 
@@ -98,35 +98,35 @@ class GenericRunningMessage(GenericMessage):
         return super().get(**kwargs)
 
 
-class LogMessage(GenericRunningMessage):
+class LogFactory(GenericRunningFactory):
     message_type = "log"
 
 
-class StdoutMessage(GenericRunningMessage):
+class StdoutFactory(GenericRunningFactory):
     """Creates stdout message with all necessary information."""
 
     message_type = "stdout"
 
 
-class StderrMessage(GenericRunningMessage):
+class StderrFactory(GenericRunningFactory):
     """Creates stderr message with all necessary information."""
 
     message_type = "stderr"
 
 
-class WhiteboardMessage(GenericRunningMessage):
+class WhiteboardFactory(GenericRunningFactory):
     """Creates whiteboard message with all necessary information."""
 
     message_type = "whiteboard"
 
 
-class OutputMessage(GenericRunningMessage):
+class OutputFactory(GenericRunningFactory):
     """Creates output message with all necessary information."""
 
     message_type = "output"
 
 
-class FileMessage(GenericRunningMessage):
+class FileFactory(GenericRunningFactory):
     """Creates file message with all necessary information."""
 
     message_type = "file"
@@ -137,10 +137,10 @@ class FileMessage(GenericRunningMessage):
 
 
 SUPPORTED_TYPES = {
-    LogMessage.message_type: LogMessage,
-    StdoutMessage.message_type: StdoutMessage,
-    StderrMessage.message_type: StderrMessage,
-    WhiteboardMessage.message_type: WhiteboardMessage,
-    OutputMessage.message_type: OutputMessage,
-    FileMessage.message_type: FileMessage,
+    LogFactory.message_type: LogFactory,
+    StdoutFactory.message_type: StdoutFactory,
+    StderrFactory.message_type: StderrFactory,
+    WhiteboardFactory.message_type: WhiteboardFactory,
+    OutputFactory.message_type: OutputFactory,
+    FileFactory.message_type: FileFactory,
 }

--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -134,13 +134,3 @@ class FileFactory(GenericRunningFactory):
     @classmethod
     def get(cls, msg, path):  # pylint: disable=W0221
         return super().get(msg=msg, path=path)
-
-
-SUPPORTED_TYPES = {
-    LogFactory.message_type: LogFactory,
-    StdoutFactory.message_type: StdoutFactory,
-    StderrFactory.message_type: StderrFactory,
-    WhiteboardFactory.message_type: WhiteboardFactory,
-    OutputFactory.message_type: OutputFactory,
-    FileFactory.message_type: FileFactory,
-}

--- a/avocado/plugins/runners/avocado_instrumented.py
+++ b/avocado/plugins/runners/avocado_instrumented.py
@@ -227,20 +227,20 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
 
             state = instance.get_state()
             fail_reason = state.get("fail_reason")
-            queue.put(messages.WhiteboardMessage.get(state["whiteboard"]))
+            queue.put(messages.WhiteboardFactory.get(state["whiteboard"]))
             queue.put(
-                messages.FinishedMessage.get(
+                messages.FinishedFactory.get(
                     state["status"].lower(), fail_reason=fail_reason
                 )
             )
         except Exception as e:
-            queue.put(messages.StderrMessage.get(traceback.format_exc()))
-            queue.put(messages.FinishedMessage.get("error", fail_reason=str(e)))
+            queue.put(messages.StderrFactory.get(traceback.format_exc()))
+            queue.put(messages.FinishedFactory.get("error", fail_reason=str(e)))
 
     def run(self, runnable):
         # pylint: disable=W0201
         self.runnable = runnable
-        yield messages.StartedMessage.get()
+        yield messages.StartedFactory.get()
         try:
             queue = multiprocessing.SimpleQueue()
             process = multiprocessing.Process(
@@ -267,10 +267,10 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
                         or now > next_execution_state_mark
                     ):
                         most_current_execution_state_time = now
-                        yield messages.RunningMessage.get()
+                        yield messages.RunningFactory.get()
                     if (now - time_started) > timeout:
                         process.terminate()
-                        yield messages.FinishedMessage.get("interrupted", "timeout")
+                        yield messages.FinishedFactory.get("interrupted", "timeout")
                         break
                 else:
                     message = queue.get()
@@ -281,8 +281,8 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
                     if message.get("status") == "finished":
                         break
         except Exception as e:
-            yield messages.StderrMessage.get(traceback.format_exc())
-            yield messages.FinishedMessage.get("error", fail_reason=str(e))
+            yield messages.StderrFactory.get(traceback.format_exc())
+            yield messages.FinishedFactory.get("error", fail_reason=str(e))
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/runners/avocado_instrumented.py
+++ b/avocado/plugins/runners/avocado_instrumented.py
@@ -21,7 +21,7 @@ from avocado.core.varianter import is_empty_variant
 
 
 class RunnerLogHandler(logging.Handler):
-    def __init__(self, queue, message_factory, kwargs=None):
+    def __init__(self, queue, message_factory, **kwargs):
         """
         Runner logger which will put every log to the runner queue
 
@@ -33,7 +33,7 @@ class RunnerLogHandler(logging.Handler):
         super().__init__()
         self.queue = queue
         self.message_factory = message_factory
-        self.kwargs = kwargs or {}
+        self.kwargs = kwargs
 
     def emit(self, record):
         msg = self.format(record)
@@ -163,7 +163,7 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
             enabled_loggers, log_level
         ):
             store_stream_handler = RunnerLogHandler(
-                queue, messages.FileFactory, {"path": enabled_logger}
+                queue, messages.FileFactory, path=enabled_logger
             )
             store_stream_handler.setFormatter(formatter)
             output_logger = logging.getLogger(enabled_logger)

--- a/avocado/plugins/runners/avocado_instrumented.py
+++ b/avocado/plugins/runners/avocado_instrumented.py
@@ -140,9 +140,6 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
         log.setLevel(log_level)
         log.propagate = False
 
-        # LOG_UI = 'avocado.app'
-        output.LOG_UI.addHandler(RunnerLogHandler(queue, messages.StdoutFactory))
-
         sys.stdout = StreamToQueue(queue, messages.StdoutFactory)
         sys.stderr = StreamToQueue(queue, messages.StderrFactory)
 

--- a/avocado/plugins/runners/avocado_instrumented.py
+++ b/avocado/plugins/runners/avocado_instrumented.py
@@ -1,19 +1,63 @@
+import logging
 import multiprocessing
 import os
+import sys
 import tempfile
 import time
 import traceback
 
+from avocado.core import output
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.nrunner.runner import (
     RUNNER_RUN_CHECK_INTERVAL,
     RUNNER_RUN_STATUS_INTERVAL,
     BaseRunner,
 )
+from avocado.core.streams import BUILTIN_STREAMS
 from avocado.core.test import TestID
 from avocado.core.tree import TreeNodeEnvOnly
 from avocado.core.utils import loader, messages
 from avocado.core.varianter import is_empty_variant
+
+
+class RunnerLogHandler(logging.Handler):
+    def __init__(self, queue, message_type, kwargs=None):
+        """
+        Runner logger which will put every log to the runner queue
+
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        :param message_type: type of the log
+        :type message_type: string
+        """
+        super().__init__()
+        self.queue = queue
+        self.message = messages.SUPPORTED_TYPES[message_type]
+        self.kwargs = kwargs or {}
+
+    def emit(self, record):
+        msg = self.format(record)
+        self.queue.put(self.message.get(msg, **self.kwargs))
+
+
+class StreamToQueue:
+    def __init__(self, queue, message_type):
+        """
+        Runner Stream which will transfer data to the runner queue
+
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        :param message_type: type of the log
+        :type message_type: string
+        """
+        self.queue = queue
+        self.message = messages.SUPPORTED_TYPES[message_type]
+
+    def write(self, buf):
+        self.queue.put(self.message.get(buf))
+
+    def flush(self):
+        pass
 
 
 class AvocadoInstrumentedTestRunner(BaseRunner):
@@ -60,7 +104,81 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
             return tree_nodes, paths
 
     @staticmethod
-    def _run_avocado(runnable, queue):
+    def _start_logging(config, queue):
+        """Helper method for connecting the avocado logging with avocado messages.
+
+        It will add the log Handlers to the :mod:`avocado.core.output` loggers,
+        which will convert the logs to the avocado messages and sent them to
+        processing queue.
+
+        :param config: avocado configuration
+        :type config: dict
+        :param queue: queue for the runner messages
+        :type queue: multiprocessing.SimpleQueue
+        """
+
+        def split_loggers_and_levels(enabled_loggers, default_level):
+            for logger_level_split in map(lambda x: x.split(":"), enabled_loggers):
+                logger_name, *level = logger_level_split
+                yield logger_name, level[0] if len(level) > 0 else default_level
+
+        log_level = config.get("job.output.loglevel", logging.DEBUG)
+        log_handler = RunnerLogHandler(queue, "log")
+        fmt = "%(asctime)s %(name)s %(levelname)-5.5s| %(message)s"
+        formatter = logging.Formatter(fmt=fmt)
+        log_handler.setFormatter(formatter)
+
+        # main log = 'avocado'
+        logger = logging.getLogger("avocado")
+        logger.addHandler(log_handler)
+        logger.setLevel(log_level)
+        logger.propagate = False
+
+        # LOG_JOB = 'avocado.test'
+        log = output.LOG_JOB
+        log.addHandler(log_handler)
+        log.setLevel(log_level)
+        log.propagate = False
+
+        # LOG_UI = 'avocado.app'
+        output.LOG_UI.addHandler(RunnerLogHandler(queue, "stdout"))
+
+        sys.stdout = StreamToQueue(queue, "stdout")
+        sys.stderr = StreamToQueue(queue, "stderr")
+
+        # output custom test loggers
+        enabled_loggers = config.get("core.show")
+        output_handler = RunnerLogHandler(queue, "output")
+        output_handler.setFormatter(logging.Formatter(fmt="%(name)s: %(message)s"))
+        user_streams = [
+            user_streams
+            for user_streams in enabled_loggers
+            if user_streams not in BUILTIN_STREAMS
+        ]
+        for user_stream, level in split_loggers_and_levels(user_streams, log_level):
+            custom_logger = logging.getLogger(user_stream)
+            custom_logger.addHandler(output_handler)
+            custom_logger.setLevel(level)
+
+        # store custom test loggers
+        enabled_loggers = config.get("job.run.store_logging_stream")
+        for enabled_logger, level in split_loggers_and_levels(
+            enabled_loggers, log_level
+        ):
+            store_stream_handler = RunnerLogHandler(
+                queue, "file", {"path": enabled_logger}
+            )
+            store_stream_handler.setFormatter(formatter)
+            output_logger = logging.getLogger(enabled_logger)
+            output_logger.addHandler(store_stream_handler)
+            output_logger.setLevel(level)
+
+            if not enabled_logger.startswith("avocado."):
+                output_logger.addHandler(log_handler)
+                output_logger.propagate = False
+
+    @classmethod
+    def _run_avocado(cls, runnable, queue):
         try:
             # This assumes that a proper resolution (see resolver module)
             # was performed, and that a URI contains:
@@ -89,7 +207,7 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
                 },
             ]
 
-            messages.start_logging(runnable.config, queue)
+            cls._start_logging(runnable.config, queue)
 
             if "COVERAGE_RUN" in os.environ:
                 from coverage import Coverage

--- a/avocado/plugins/runners/package.py
+++ b/avocado/plugins/runners/package.py
@@ -109,7 +109,7 @@ class PackageRunner(BaseRunner):
     def run(self, runnable):
         # pylint: disable=W0201
         self.runnable = runnable
-        yield messages.StartedMessage.get()
+        yield messages.StartedFactory.get()
         # check if there is a valid 'action' argument
         cmd = self.runnable.kwargs.get("action", "install")
         # avoid invalid arguments
@@ -117,8 +117,8 @@ class PackageRunner(BaseRunner):
             stderr = (
                 f"Invalid action {cmd}. Use one of 'install', 'check' " f"or 'remove'"
             )
-            yield messages.StderrMessage.get(stderr.encode())
-            yield messages.FinishedMessage.get("error")
+            yield messages.StderrFactory.get(stderr.encode())
+            yield messages.FinishedFactory.get("error")
             return
 
         package = self.runnable.kwargs.get("name")
@@ -135,7 +135,7 @@ class PackageRunner(BaseRunner):
 
             while queue.empty():
                 time.sleep(RUNNER_RUN_STATUS_INTERVAL)
-                yield messages.RunningMessage.get()
+                yield messages.RunningFactory.get()
 
             output = queue.get()
             result = output["result"]
@@ -149,9 +149,9 @@ class PackageRunner(BaseRunner):
                 'Package name should be passed as kwargs using name="package_name".'
             )
 
-        yield messages.StdoutMessage.get(stdout.encode())
-        yield messages.StderrMessage.get(stderr.encode())
-        yield messages.FinishedMessage.get(result)
+        yield messages.StdoutFactory.get(stdout.encode())
+        yield messages.StderrFactory.get(stderr.encode())
+        yield messages.FinishedFactory.get(result)
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/runners/podman_image.py
+++ b/avocado/plugins/runners/podman_image.py
@@ -43,22 +43,22 @@ class PodmanImageRunner(BaseRunner):
             )
 
     def run(self, runnable):
-        yield messages.StartedMessage.get()
+        yield messages.StartedFactory.get()
 
         if not runnable.uri:
             reason = "uri identifying the podman image is required"
-            yield messages.FinishedMessage.get("error", reason)
+            yield messages.FinishedFactory.get("error", reason)
         else:
             queue = SimpleQueue()
             process = Process(target=self._run_podman_pull, args=(runnable.uri, queue))
             process.start()
             while queue.empty():
                 time.sleep(RUNNER_RUN_STATUS_INTERVAL)
-                yield messages.RunningMessage.get()
+                yield messages.RunningFactory.get()
 
             output = queue.get()
             result = output.pop("result")
-            yield messages.FinishedMessage.get(result, **output)
+            yield messages.FinishedFactory.get(result, **output)
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/runners/tap.py
+++ b/avocado/plugins/runners/tap.py
@@ -2,7 +2,7 @@ import io
 
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.tapparser import TapParser, TestResult
-from avocado.core.utils.messages import FinishedMessage
+from avocado.core.utils.messages import FinishedFactory
 from avocado.plugins.runners.exec_test import ExecTestRunner
 
 
@@ -62,7 +62,7 @@ class TAPRunner(ExecTestRunner):
     def _process_final_status(
         self, process, runnable, stdout=None, stderr=None
     ):  # pylint: disable=W0613
-        return FinishedMessage.get(
+        return FinishedFactory.get(
             self._get_tap_result(stdout), returncode=process.returncode
         )
 

--- a/optional_plugins/ansible/avocado_ansible/module.py
+++ b/optional_plugins/ansible/avocado_ansible/module.py
@@ -43,11 +43,11 @@ class AnsibleModuleRunner(BaseRunner):
         queue.put({"result": result, "stdout": stdout, "stderr": stderr})
 
     def run(self, runnable):
-        yield messages.StartedMessage.get()
+        yield messages.StartedFactory.get()
 
         if not runnable.uri:
             reason = "uri identifying the ansible module is required"
-            yield messages.FinishedMessage.get("error", reason)
+            yield messages.FinishedFactory.get("error", reason)
             return
 
         queue = SimpleQueue()
@@ -56,9 +56,9 @@ class AnsibleModuleRunner(BaseRunner):
         yield from self.running_loop(lambda: not queue.empty())
 
         status = queue.get()
-        yield messages.StdoutMessage.get(status["stdout"])
-        yield messages.StderrMessage.get(status["stderr"])
-        yield messages.FinishedMessage.get(status["result"])
+        yield messages.StdoutFactory.get(status["stdout"])
+        yield messages.StderrFactory.get(status["stderr"])
+        yield messages.FinishedFactory.get(status["result"])
 
 
 class RunnerApp(BaseRunnerApp):

--- a/optional_plugins/golang/avocado_golang/runner.py
+++ b/optional_plugins/golang/avocado_golang/runner.py
@@ -45,7 +45,7 @@ class GolangRunner(BaseRunner):
             )
             return
 
-        yield messages.StartedMessage.get()
+        yield messages.StartedFactory.get()
         module_test = self.runnable.uri.split(":", 1)
         module = module_test[0]
         try:
@@ -71,9 +71,9 @@ class GolangRunner(BaseRunner):
         yield from self.running_loop(poll_proc)
 
         result = "pass" if process.returncode == 0 else "fail"
-        yield messages.StdoutMessage.get(process.stdout.read())
-        yield messages.StderrMessage.get(process.stderr.read())
-        yield messages.FinishedMessage.get(result, returncode=process.returncode)
+        yield messages.StdoutFactory.get(process.stdout.read())
+        yield messages.StderrFactory.get(process.stderr.read())
+        yield messages.FinishedFactory.get(result, returncode=process.returncode)
 
 
 class RunnerApp(BaseRunnerApp):

--- a/optional_plugins/robot/avocado_robot/runner.py
+++ b/optional_plugins/robot/avocado_robot/runner.py
@@ -86,7 +86,7 @@ class RobotRunner(BaseRunner):
         file_name, suite_name, test_name = self._uri_to_file_suite_test()
         if not all([file_name, suite_name, test_name]):
 
-            yield messages.FinishedMessage.get("error", fail_reason="Invalid URI given")
+            yield messages.FinishedFactory.get("error", fail_reason="Invalid URI given")
             return
 
         queue = multiprocessing.SimpleQueue()
@@ -94,13 +94,13 @@ class RobotRunner(BaseRunner):
             target=self._run, args=(file_name, suite_name, test_name, queue)
         )
         process.start()
-        yield messages.StartedMessage.get()
+        yield messages.StartedFactory.get()
         yield from self.running_loop(lambda: not queue.empty())
 
         status = queue.get()
-        yield messages.StdoutMessage.get(status["stdout"])
-        yield messages.StderrMessage.get(status["stderr"])
-        yield messages.FinishedMessage.get(status["result"])
+        yield messages.StdoutFactory.get(status["stdout"])
+        yield messages.StderrFactory.get(status["stderr"])
+        yield messages.FinishedFactory.get(status["result"])
 
 
 class RunnerApp(BaseRunnerApp):

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -436,6 +436,36 @@ class OutputPluginTest(TestCaseTmpDir):
         job_id = job_id_list[0]
         self.assertEqual(len(job_id), 40)
 
+    def test_show_custom_log(self):
+        cmd_line = (
+            f"{AVOCADO} --show=avocado.test.progress run "
+            f"--job-results-dir {self.tmpdir.name} "
+            f"--disable-sysinfo examples/tests/logging_streams.py"
+        )
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(
+            result.exit_status,
+            expected_rc,
+            (f"Avocado did not return rc {expected_rc}:" f"\n{result}"),
+        )
+        self.assertEqual(
+            result.stdout_text,
+            (
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: preparing soil on row 0\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: preparing soil on row 1\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: preparing soil on row 2\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: letting soil rest before throwing seeds\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: throwing seeds on row 0\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: throwing seeds on row 1\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: throwing seeds on row 2\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: waiting for Avocados to grow\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 0\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 1\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 2\n"
+            ),
+        )
+
     def test_silent_trumps_test(self):
         # Also verify --show=none can be supplied as run option
         cmd_line = (


### PR DESCRIPTION
The `--show` is currently failing to show live content from custom loggers within `avocado-instrumented` tests. This fixes that situation while also doing some refactors and readability improvements.

It's expected that the logging system as a whole needs to be revisited in a non-bugfix manner soon.