### PR TITLE
Restore support for --show=$custom_logger on avocado-instrumented [v2]

### DIFF
--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -227,9 +227,6 @@ def start_logging(config, queue):
     log.setLevel(log_level)
     log.propagate = False
 
-    # LOG_UI = 'avocado.app'
-    output.LOG_UI.addHandler(RunnerLogHandler(queue, "stdout"))
-
     sys.stdout = StreamToQueue(queue, "stdout")
     sys.stderr = StreamToQueue(queue, "stderr")
 

--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -165,10 +165,30 @@ class RunnerLogHandler(logging.Handler):
         self.queue = queue
         self.message = _supported_types[message_type]
         self.kwargs = kwargs or {}
+        self._message_only_formatter = None
+
+    @property
+    def message_only_formatter(self):
+        """
+        Property that initiates a :class:`logging.Formatter` lazily
+        """
+        if self._message_only_formatter is None:
+            self._message_only_formatter = logging.Formatter()
+        return self._message_only_formatter
 
     def emit(self, record):
         msg = self.format(record)
-        self.queue.put(self.message.get(msg, **self.kwargs))
+        if self.message is LogMessage:
+            formatted_msg = self.message_only_formatter.format(record)
+            kwargs = {
+                "log_name": record.name,
+                "log_levelname": record.levelname,
+                "log_message": formatted_msg,
+            }
+            kwargs.update(**self.kwargs)
+        else:
+            kwargs = self.kwargs
+        self.queue.put(self.message.get(msg, **kwargs))
 
 
 class StreamToQueue:

--- a/selftests/functional/test_output.py
+++ b/selftests/functional/test_output.py
@@ -436,6 +436,36 @@ class OutputPluginTest(TestCaseTmpDir):
         job_id = job_id_list[0]
         self.assertEqual(len(job_id), 40)
 
+    def test_show_custom_log(self):
+        cmd_line = (
+            f"{AVOCADO} --show=avocado.test.progress run "
+            f"--job-results-dir {self.tmpdir.name} "
+            f"--disable-sysinfo examples/tests/logging_streams.py"
+        )
+        result = process.run(cmd_line, ignore_status=True)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(
+            result.exit_status,
+            expected_rc,
+            (f"Avocado did not return rc {expected_rc}:" f"\n{result}"),
+        )
+        self.assertEqual(
+            result.stdout_text,
+            (
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: preparing soil on row 0\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: preparing soil on row 1\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: preparing soil on row 2\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: letting soil rest before throwing seeds\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: throwing seeds on row 0\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: throwing seeds on row 1\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: throwing seeds on row 2\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: waiting for Avocados to grow\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 0\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 1\n"
+                "avocado.test.progress: 1-examples/tests/logging_streams.py:Plant.test_plant_organic: harvesting organic avocados on row 2\n"
+            ),
+        )
+
     def test_silent_trumps_test(self):
         # Also verify --show=none can be supplied as run option
         cmd_line = (


### PR DESCRIPTION
The `--show` is currently failing to show live content from custom loggers within `avocado-instrumented` tests. This fixes that situation while also doing some refactors and readability improvements.

It's expected that the logging system as a whole needs to be revisited in a non-bugfix manner soon.

---

Changes from v1 (https://github.com/avocado-framework/avocado/pull/5570):
* Opted for a strictly bug fix, removing all refactors and renames commits, to preserve more compatibility this late in the sprint
* Added docstring for `message_only_formatter` property