### PR TITLE
vmimage: double the download timeout

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -590,7 +590,7 @@ class Image:
             cache_dirs=cache_dirs,
             expire=None,
             metadata=metadata,
-        ).fetch()
+        ).fetch(timeout=asset.DOWNLOAD_TIMEOUT * 2)
 
         if archive.is_archive(asset_path):
             uncompressed_path = os.path.splitext(asset_path)[0]


### PR DESCRIPTION
The files downloaded by avocado.utils.vmimage can be on the large side.  For instance, FreeBSD images are around 600MiB.

In my experience, the servers hosting those images seem to enforce connection bandwidth limits.  Testing the download from multiple sources with adequate bandwith resulted in timeout errors for the current 5 minutes limit.  A manual download (without using vmimage) took around 6 minutes.

To be on the safe side, let's double the download timeout.

Signed-off-by: Cleber Rosa <crosa@redhat.com>