### PR TITLE
avocado.utils.vmimage timeout: further increase timeout and cover lock

### DIFF
--- a/avocado/utils/asset.py
+++ b/avocado/utils/asset.py
@@ -144,7 +144,7 @@ class Asset:
             # To avoid parallel downloads of the same asset, and errors during
             # the write after download, let's get the lock before start the
             # download.
-            with FileLock(asset_path, 120):
+            with FileLock(asset_path, timeout):
                 try:
                     self.find_asset_file(create_metadata=True)
                     return True

--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -590,7 +590,7 @@ class Image:
             cache_dirs=cache_dirs,
             expire=None,
             metadata=metadata,
-        ).fetch(timeout=asset.DOWNLOAD_TIMEOUT * 2)
+        ).fetch(timeout=asset.DOWNLOAD_TIMEOUT * 3)
 
         if archive.is_archive(asset_path):
             uncompressed_path = os.path.splitext(asset_path)[0]


### PR DESCRIPTION
On cfb691e95, the download timeout for vmimage was doubled.  But, as can be seen in some CI jobs, the downloads for some officially supported images can get easily exceed even the new timeout:

 vmimage.py:ImageFunctional.test_get;run-architectures-x86_64-distro-freebsd-version-12.2-9d3c: PASS (590.04 s)

This further increases the timeout to cope with those actual times.

Additionally, it substitutes the magic "120" seconds timeout for the lock with the timeout given.  By then, the file should either have downloaded successfully by the other (possible parallel actor) or timed out.

Reference: https://github.com/clebergnu/avocado/actions/runs/3875993920/jobs/6609284678#step:4:510
Signed-off-by: Cleber Rosa <crosa@redhat.com>