### PR TITLE
Podman spawner: use runner plugins instead of removed generic nrunner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,21 @@ jobs:
          python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
 
 
+  podman_egg_task:
+
+    name: Podman Egg task
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Test running avocado from eggs under Podman spawner
+        run: |
+         apt update && apt -y install python3 python3-setuptools
+         python3 setup.py bdist_egg
+         mv dist/avocado_framework-*egg /tmp/avocado_framework.egg
+         python3 setup.py clean --all
+         python3 -c 'import sys; sys.path.insert(0, "/tmp/avocado_framework.egg"); from avocado.core.main import main; sys.exit(main())' run --spawner=podman --spawner-podman-image=fedora:36 --spawner-podman-avocado-egg=file:///tmp/avocado_framework.egg -- /bin/true
+
   fedora_develop_install_uninstall_task:
     name: Fedora develop install/uninstall task
     runs-on: ubuntu-latest

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -192,7 +192,10 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             runtime_task.task.status_services[0].uri = mounted_status_server_socket
 
         _, _, python_binary = await self.python_version
-        entry_point_args = [python_binary, "-m", "avocado.core.nrunner", "task-run"]
+
+        module_name = runtime_task.task.runnable.kind.replace("-", "_")
+        full_module_name = f"avocado.plugins.runners.{module_name}"
+        entry_point_args = [python_binary, "-m", full_module_name, "task-run"]
 
         test_opts = ()
         if runtime_task.task.category == "test":


### PR DESCRIPTION
On 7a8bbb250, the "avocado-runner" command and the "avocado.core.nrunner" module entrypoint were removed.  But, the Podman spawner failed to sync with this change, and kept using the "avocado.core.nrunner" module when running a task on a container.

The reason this was not caught before is that, all the tests make use of the previously release egg, and not an egg that matches the development state.  This should now be protected with a new CI check.

Signed-off-by: Cleber Rosa <crosa@redhat.com>