### PR TITLE
Build and publish eggs for Python 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0, 3.11]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
On 2eb51609f Python 3.11 was added, but we missed the step to build and publish eggs for that Python version during the release process.

Signed-off-by: Cleber Rosa <crosa@redhat.com>