### PR TITLE
avocado/utils/vmimage.py: Fedora 35 and earlier are archived

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -212,7 +212,7 @@ class FedoraImageProviderBase(ImageProviderBase):
         else:
             cloud = "CloudImages"
 
-        if self.url_old_images and int(self.version) <= 31:
+        if self.url_old_images and int(self.version) <= 35:
             self.url_versions = self.url_old_images
 
         self.url_images = self.url_versions + "{version}/" + cloud + "/{arch}/images/"


### PR DESCRIPTION
So the URL for all versions equal or earlier than 35, need to be fetched from the archives.

Reference: https://dl.fedoraproject.org/pub/fedora/linux/releases/35/README
Signed-off-by: Cleber Rosa <crosa@redhat.com>