### PR TITLE
Add missing prefix for static ip configuration

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -450,7 +450,7 @@ class NetworkInterface:
             }
             if current_distro.name == "SuSE":
                 ifcfg_dict = {
-                    "IPADDR": ipaddr,
+                    "IPADDR": f"{ipaddr}/{prefix}",
                     "BOOTPROTO": "static",
                     "STARTMODE": "auto",
                 }


### PR DESCRIPTION
A standard format to configure static ip is to add netmask as prefix to the IP address/24, it is missed in previous change

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>