### PR TITLE
Podman Spawner: better document the avocado egg parameter

### DIFF
--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -50,7 +50,8 @@ class PodmanSpawnerInit(Init):
             "Avocado egg path to be used during initial bootstrap "
             "of avocado inside the isolated environment. By default, "
             "Avocado will try to download (or get from cache) an "
-            "egg from its repository."
+            "egg from its repository. Please use a valid URL, including "
+            'the protocol (for local files, use the "file:///" prefix).'
         )
 
         settings.register_option(


### PR DESCRIPTION
The --spawner-podman-avocado-egg parameter takes an URL, but that is not obvious from the documentation.  Let's add one explicit example using file:///, which is the easist use case to miss.

Fixes: https://github.com/avocado-framework/avocado/issues/5389
Signed-off-by: Cleber Rosa <crosa@redhat.com>