### PR TITLE
Xunit results missing attributes

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -166,9 +166,13 @@ class FinishMessageHandler(BaseMessageHandler):
     :type result: `avocado.core.teststatus.STATUSES`
     :param time: end time of the test
     :type time: float
-    :param fail_reason: Optional parameter for brief specification, of the
-                       failed result.
+    :param fail_reason: Parameter for brief specification, of the
+                        failed result. [Optional]
     :type fail_reason: string
+    :param returncode: Exit status of runner. [Optional]
+    :type returncode: int
+    :param class_name: class name of the test. [Optional]
+    :type class_name: string
 
     example: {'status': 'finished', 'result': 'pass', 'time': 16444.819830573}
     """

--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -173,6 +173,12 @@ class FinishMessageHandler(BaseMessageHandler):
     :type returncode: int
     :param class_name: class name of the test. [Optional]
     :type class_name: string
+    :param returncode: Exit status of runner. [Optional]
+    :type returncode: int
+    :param fail_class: Exception class of the failure. [Optional]
+    :type fail_class: string
+    :param traceback: Traceback of the exception. [Optional]
+    :type traceback: string
 
     example: {'status': 'finished', 'result': 'pass', 'time': 16444.819830573}
     """

--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -52,7 +52,9 @@ class FinishedMessage(GenericMessage):
     message_status = "finished"
 
     @classmethod
-    def get(cls, result, fail_reason=None, returncode=None):  # pylint: disable=W0221
+    def get(
+        cls, result, fail_reason=None, returncode=None, class_name=None
+    ):  # pylint: disable=W0221
         """Creates finished message with all necessary information.
 
         :param result: test result
@@ -62,11 +64,16 @@ class FinishedMessage(GenericMessage):
                             result.
         :type fail_reason: str
         :param returncode: exit status of runner
+        :param class_name: class name of the test
+        :type class_name: str
         :return: finished message
         :rtype: dict
         """
         return super().get(
-            result=result, fail_reason=fail_reason, returncode=returncode
+            result=result,
+            fail_reason=fail_reason,
+            returncode=returncode,
+            class_name=class_name,
         )
 
 

--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -53,7 +53,13 @@ class FinishedMessage(GenericMessage):
 
     @classmethod
     def get(
-        cls, result, fail_reason=None, returncode=None, class_name=None
+        cls,
+        result,
+        fail_reason=None,
+        returncode=None,
+        class_name=None,
+        fail_class=None,
+        traceback=None,
     ):  # pylint: disable=W0221
         """Creates finished message with all necessary information.
 
@@ -66,6 +72,10 @@ class FinishedMessage(GenericMessage):
         :param returncode: exit status of runner
         :param class_name: class name of the test
         :type class_name: str
+        :param fail_class: Exception class of the failure
+        :type fail_class: str
+        :param traceback: Traceback of the exception
+        :type traceback: str
         :return: finished message
         :rtype: dict
         """
@@ -74,6 +84,8 @@ class FinishedMessage(GenericMessage):
             fail_reason=fail_reason,
             returncode=returncode,
             class_name=class_name,
+            fail_class=fail_class,
+            traceback=traceback,
         )
 
 

--- a/avocado/plugins/runners/avocado_instrumented.py
+++ b/avocado/plugins/runners/avocado_instrumented.py
@@ -112,12 +112,23 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
             queue.put(messages.WhiteboardMessage.get(state["whiteboard"]))
             queue.put(
                 messages.FinishedMessage.get(
-                    state["status"].lower(), fail_reason=fail_reason, class_name=klass
+                    state["status"].lower(),
+                    fail_reason=fail_reason,
+                    class_name=klass,
+                    fail_class=state.get("fail_class"),
+                    traceback=state.get("traceback"),
                 )
             )
         except Exception as e:
             queue.put(messages.StderrMessage.get(traceback.format_exc()))
-            queue.put(messages.FinishedMessage.get("error", fail_reason=str(e)))
+            queue.put(
+                messages.FinishedMessage.get(
+                    "error",
+                    fail_reason=str(e),
+                    fail_class=e.__class__.__name__,
+                    traceback=traceback.format_exc(),
+                )
+            )
 
     def run(self, runnable):
         # pylint: disable=W0201
@@ -164,7 +175,12 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
                         break
         except Exception as e:
             yield messages.StderrMessage.get(traceback.format_exc())
-            yield messages.FinishedMessage.get("error", fail_reason=str(e))
+            yield messages.FinishedMessage.get(
+                "error",
+                fail_reason=str(e),
+                fail_class=e.__class__.__name__,
+                traceback=traceback.format_exc(),
+            )
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/runners/avocado_instrumented.py
+++ b/avocado/plugins/runners/avocado_instrumented.py
@@ -112,7 +112,7 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
             queue.put(messages.WhiteboardMessage.get(state["whiteboard"]))
             queue.put(
                 messages.FinishedMessage.get(
-                    state["status"].lower(), fail_reason=fail_reason
+                    state["status"].lower(), fail_reason=fail_reason, class_name=klass
                 )
             )
         except Exception as e:

--- a/selftests/functional/plugin/test_xunit.py
+++ b/selftests/functional/plugin/test_xunit.py
@@ -30,3 +30,53 @@ class JsonResultTest(TestCaseTmpDir):
         self.assertEqual(els[0].attributes["file"].value, "examples/tests/passtest.py")
         els = dom.getElementsByTagName("failure")
         self.assertEqual(len(els), 0)
+
+    def test_fail_reason(self):
+        cmd_line = (
+            f"{AVOCADO} run examples/tests/failtest.py "
+            f"--job-results-dir {self.tmpdir.name} --disable-sysinfo"
+        )
+        process.run(cmd_line, ignore_status=True)
+        xunit_path = path.join(self.tmpdir.name, "latest", "results.xml")
+
+        with open(xunit_path, "rb") as fp:
+            xml = fp.read()
+        try:
+            dom = minidom.parseString(xml)
+        except Exception as details:
+            raise ValueError(f"Error parsing XML: '{details}'.\nXML Contents:\n{xml}")
+        self.assertTrue(dom)
+        els = dom.getElementsByTagName("failure")
+        self.assertEqual(len(els), 1)
+        self.assertEqual(els[0].attributes["type"].value, "TestFail")
+        self.assertEqual(
+            els[0].attributes["message"].value, "This test is supposed to fail"
+        )
+        for child in els[0].childNodes:
+            if child.nodeType is child.CDATA_SECTION_NODE:
+                self.assertIn("Traceback (most recent call last):", child.nodeValue)
+
+    def test_error_reason(self):
+        cmd_line = (
+            f"{AVOCADO} run examples/tests/errortest.py "
+            f"--job-results-dir {self.tmpdir.name} --disable-sysinfo"
+        )
+        process.run(cmd_line, ignore_status=True)
+        xunit_path = path.join(self.tmpdir.name, "latest", "results.xml")
+
+        with open(xunit_path, "rb") as fp:
+            xml = fp.read()
+        try:
+            dom = minidom.parseString(xml)
+        except Exception as details:
+            raise ValueError(f"Error parsing XML: '{details}'.\nXML Contents:\n{xml}")
+        self.assertTrue(dom)
+        els = dom.getElementsByTagName("error")
+        self.assertEqual(len(els), 1)
+        self.assertEqual(els[0].attributes["type"].value, "TestError")
+        self.assertEqual(
+            els[0].attributes["message"].value, "This should end with ERROR."
+        )
+        for child in els[0].childNodes:
+            if child.nodeType is child.CDATA_SECTION_NODE:
+                self.assertIn("Traceback (most recent call last):", child.nodeValue)

--- a/selftests/functional/plugin/test_xunit.py
+++ b/selftests/functional/plugin/test_xunit.py
@@ -1,0 +1,32 @@
+from os import path
+from xml.dom import minidom
+
+from avocado.utils import process
+from selftests.utils import AVOCADO, TestCaseTmpDir
+
+
+class JsonResultTest(TestCaseTmpDir):
+    def test_testcase(self):
+        cmd_line = (
+            f"{AVOCADO} run examples/tests/passtest.py "
+            f"--job-results-dir {self.tmpdir.name} --disable-sysinfo"
+        )
+        process.run(cmd_line, ignore_status=True)
+        xunit_path = path.join(self.tmpdir.name, "latest", "results.xml")
+
+        with open(xunit_path, "rb") as fp:
+            xml = fp.read()
+        try:
+            dom = minidom.parseString(xml)
+        except Exception as details:
+            raise ValueError(f"Error parsing XML: '{details}'.\nXML Contents:\n{xml}")
+        self.assertTrue(dom)
+        els = dom.getElementsByTagName("testcase")
+        self.assertEqual(len(els), 1)
+        self.assertEqual(els[0].attributes["classname"].value, "PassTest")
+        self.assertEqual(
+            els[0].attributes["name"].value, "examples/tests/passtest.py:PassTest.test"
+        )
+        self.assertEqual(els[0].attributes["file"].value, "examples/tests/passtest.py")
+        els = dom.getElementsByTagName("failure")
+        self.assertEqual(len(els), 0)

--- a/selftests/unit/test_nrunner.py
+++ b/selftests/unit/test_nrunner.py
@@ -342,7 +342,7 @@ class Runner(unittest.TestCase):
         result = results[-1]
         self.assertEqual(result["status"], "finished")
         self.assertEqual(result["result"], "error")
-        self.assertEqual(result["output"], output)
+        self.assertEqual(result["fail_reason"], output)
 
     def test_runner_python_unittest_empty_uri_error(self):
         runnable = Runnable("python-unittest", "")
@@ -353,7 +353,7 @@ class Runner(unittest.TestCase):
         result = results[-1]
         self.assertEqual(result["status"], "finished")
         self.assertEqual(result["result"], "error")
-        self.assertEqual(result["output"], output)
+        self.assertEqual(result["fail_reason"], output)
 
 
 class RunnerTmp(unittest.TestCase):


### PR DESCRIPTION
Gathering more metadata from resolvers and runners. It will provide better information about test and its failures, which can be used by result plugins.

Reference: https://github.com/avocado-framework/avocado/issues/5332
Signed-off-by: Jan Richter <jarichte@redhat.com>