### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11]
       fail-fast: false
 
     steps:
@@ -182,7 +182,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11]
       fail-fast: false
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        python-version: [3.6.15, 3.7.15, 3.8.16, 3.9.16, 3.10.9, 3.11.1]
+        python-version: [3.7.15, 3.8.16, 3.9.16, 3.10.9, 3.11.1]
       fail-fast: false
 
     steps:

--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import sys
 
 from avocado.core.settings import settings
 
@@ -42,9 +41,7 @@ class StatusServer:
         if self._server_task is None:
             await self.create_server()
 
-        # TODO: Delete this after deprecation of python 3.6
-        if sys.version_info >= (3, 7):
-            await self._server_task.serve_forever()
+        await self._server_task.serve_forever()
 
     def close(self):
         self._server_task.close()

--- a/setup.py
+++ b/setup.py
@@ -331,7 +331,6 @@ if __name__ == "__main__":
             "Topic :: Software Development :: Quality Assurance",
             "Topic :: Software Development :: Testing",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
@@ -458,7 +457,7 @@ if __name__ == "__main__":
         },
         zip_safe=False,
         test_suite="selftests",
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         cmdclass={
             "clean": Clean,
             "develop": Develop,


### PR DESCRIPTION
Python 3.6 has been EOL'd for over a year.  But some projects such as QEMU still have it as the mininum required Python versions, and this has kept us from deprecating it.

There's a [new effort](https://lists.gnu.org/archive/html/qemu-devel/2023-01/msg04398.html) going on to bump the minimum required version in QEMU, so I feel more confident in dropping it in Avocado too.
