### PR TITLE
Variant in xunit and json results

### DIFF
--- a/avocado/plugins/jsonresult.py
+++ b/avocado/plugins/jsonresult.py
@@ -45,7 +45,7 @@ class JSONResult(Result):
             # Actually we are saving the TestID() there.
             test_id = test.get("name", UNKNOWN)
             if isinstance(test_id, TestID):
-                name = test_id.name
+                name = f"{test_id.name}{test_id.str_variant}"
             tests.append(
                 {
                     "id": str(test_id),

--- a/avocado/plugins/xunit.py
+++ b/avocado/plugins/xunit.py
@@ -63,7 +63,10 @@ class XUnitResult(Result):
         testcase.setAttribute("classname", self._get_attr(state, "class_name"))
         name = state.get("name")
         if isinstance(name, TestID):
-            testcase.setAttribute("name", self._escape_attr(name.name))
+            testcase.setAttribute(
+                "name",
+                f"{self._escape_attr(name.name)}{self._escape_attr(name.str_variant)}",
+            )
             file_path, _ = reference_split(name.name)
         else:
             testcase.setAttribute("name", self._get_attr(state, "name"))

--- a/selftests/functional/plugin/test_jsonresult.py
+++ b/selftests/functional/plugin/test_jsonresult.py
@@ -43,3 +43,25 @@ class JsonResultTest(TestCaseTmpDir):
             data = json.load(json_file)
             test_data = data["tests"][0]
             self.assertEqual({"failure_expected": None}, test_data["tags"])
+
+    def test_variant(self):
+        cmd_line = (
+            f"{AVOCADO} run examples/tests/passtest.py "
+            "--mux-yaml examples/yaml_to_mux/simple_vars.yaml "
+            f"--job-results-dir {self.tmpdir.name} --disable-sysinfo "
+            "--max-parallel-tasks=1"
+        )
+        process.run(cmd_line, ignore_status=True)
+        json_path = path.join(self.tmpdir.name, "latest", "results.json")
+        with open(json_path, "r", encoding="utf-8") as json_file:
+            data = json.load(json_file)
+            test_data = data["tests"][0]
+            self.assertEqual(
+                "examples/tests/passtest.py:PassTest.test;run-first-febe",
+                test_data["name"],
+            )
+            test_data = data["tests"][1]
+            self.assertEqual(
+                "examples/tests/passtest.py:PassTest.test;run-second-bafe",
+                test_data["name"],
+            )

--- a/selftests/functional/plugin/test_xunit.py
+++ b/selftests/functional/plugin/test_xunit.py
@@ -80,3 +80,30 @@ class JsonResultTest(TestCaseTmpDir):
         for child in els[0].childNodes:
             if child.nodeType is child.CDATA_SECTION_NODE:
                 self.assertIn("Traceback (most recent call last):", child.nodeValue)
+
+    def test_variant(self):
+        cmd_line = (
+            f"{AVOCADO} run examples/tests/passtest.py "
+            "--mux-yaml examples/yaml_to_mux/simple_vars.yaml "
+            f"--job-results-dir {self.tmpdir.name} --disable-sysinfo "
+            "--max-parallel-tasks=1"
+        )
+        process.run(cmd_line, ignore_status=True)
+        xunit_path = path.join(self.tmpdir.name, "latest", "results.xml")
+
+        with open(xunit_path, "rb") as fp:
+            xml = fp.read()
+        try:
+            dom = minidom.parseString(xml)
+        except Exception as details:
+            raise ValueError(f"Error parsing XML: '{details}'.\nXML Contents:\n{xml}")
+        self.assertTrue(dom)
+        els = dom.getElementsByTagName("testcase")
+        self.assertEqual(
+            els[0].attributes["name"].value,
+            "examples/tests/passtest.py:PassTest.test;run-first-febe",
+        )
+        self.assertEqual(
+            els[1].attributes["name"].value,
+            "examples/tests/passtest.py:PassTest.test;run-second-bafe",
+        )


### PR DESCRIPTION
After the changes in 059e7646103ea673951e31f7e33895339b69ff14 and 0ccab1521d0286d6bf2c7555fc5be81cb029e96a the result plugins lost information about variants. This is a fix for that.

Reference: https://github.com/avocado-framework/avocado/issues/5589
Signed-off-by: Jan Richter <jarichte@redhat.com>