### PR TITLE
Build plugins' eggs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
 # Checks that Python packages builds succeeds
 
   package-build:
-    name: Build Package for Python ${{ matrix.python-version }}
+    name: Build Package (wheel/tarball) for Python ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
 
     strategy:
@@ -196,16 +196,33 @@ jobs:
     - name: Save tarballs and wheels as artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: tarballs_and_wheels
+        name: tarballs_and_wheels-${{ matrix.python-version }}
         path: ${{github.workspace}}/PYPI_UPLOAD/
         retention-days: 1
+    - run: echo "🥑 This job's status is ${{ job.status }}."
+
+  egg-build:
+    name: Build Egg for Python ${{ matrix.python-version }}
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Build eggs
-      run: python setup.py bdist_egg
+      run: make -f Makefile.gh build-egg
     - name: Save eggs as artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: egg-${{ matrix.python-version }}
-        path: /home/runner/work/avocado/avocado/dist/
+        name: eggs-${{ matrix.python-version }}
+        path: ${{github.workspace}}/EGG_UPLOAD/
         retention-days: 1
     - run: echo "🥑 This job's status is ${{ job.status }}."
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Build tarballs and wheels
       run: make -f Makefile.gh build-wheel
+    - name: Save tarballs and wheels as artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: tarballs_and_wheels
+        path: ${{github.workspace}}/PYPI_UPLOAD/
+        retention-days: 1
     - name: Build eggs
       run: python setup.py bdist_egg
     - name: Save eggs as artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,12 +191,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
+    - name: Build tarballs and wheels
+      run: make -f Makefile.gh build-wheel
     - name: Build eggs
       run: python setup.py bdist_egg
     - name: Save eggs as artifacts

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all:
 	@echo
 
 pip:
-	$(PYTHON) -m pip --version || $(PYTHON) -m ensurepip $(PYTHON_DEVELOP_ARGS) || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"
+	$(PYTHON) -m pip --version || $(PYTHON) -m ensurepip $(PYTHON_DEVELOP_ARGS)
 
 clean:
 	$(PYTHON) setup.py clean --all

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 include Makefile.include
 
-PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 DESTDIR=/
 AVOCADO_DIRNAME=$(shell basename ${PWD})
 AVOCADO_OPTIONAL_PLUGINS=$(shell find ./optional_plugins -maxdepth 1 -mindepth 1 -type d)
@@ -27,9 +26,6 @@ all:
 	@echo "man:          Generate the avocado man page"
 	@echo "pip:          Auxiliary target to install pip. (It's not recommended to run this directly)"
 	@echo
-
-pip:
-	$(PYTHON) -m pip --version || $(PYTHON) -m ensurepip $(PYTHON_DEVELOP_ARGS)
 
 clean:
 	$(PYTHON) setup.py clean --all

--- a/Makefile.gh
+++ b/Makefile.gh
@@ -70,6 +70,17 @@ build-wheel: pip
 		fi;\
 	done
 
+build-egg:
+	if test ! -d EGG_UPLOAD; then mkdir EGG_UPLOAD; fi
+	$(PYTHON) setup.py bdist_egg -d EGG_UPLOAD
+	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\
+		if test -f $$PLUGIN/setup.py; then\
+			cd $$PLUGIN;\
+			$(PYTHON) setup.py bdist_egg -d ../../EGG_UPLOAD;\
+			cd -;\
+		fi;\
+	done
+
 update-pypi:
 ifndef TWINE_USERNAME
 	$(error TWINE_USERNAME is undefined)

--- a/Makefile.gh
+++ b/Makefile.gh
@@ -58,8 +58,8 @@ endif
 	curl -X POST \
 		-H "Authorization: Token $(TOKEN_RTD)" "$(URL)/versions/$(VERSION)/builds/"
 
-build-wheel:
-	pip3 install --user build
+build-wheel: pip
+	$(PYTHON) -m pip install $(PYTHON_DEVELOP_ARGS) build
 	if test ! -d PYPI_UPLOAD; then mkdir PYPI_UPLOAD; fi
 	$(PYTHON) -m build -o PYPI_UPLOAD
 	for PLUGIN in $(AVOCADO_OPTIONAL_PLUGINS); do\

--- a/Makefile.include
+++ b/Makefile.include
@@ -7,3 +7,10 @@ endif
 ifndef VERSION
 VERSION=$(shell $(PYTHON) setup.py --version 2>/dev/null)
 endif
+
+ifndef PYTHON_DEVELOP_ARGS
+PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
+endif
+
+pip:
+	$(PYTHON) -m pip --version || $(PYTHON) -m ensurepip $(PYTHON_DEVELOP_ARGS)

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ class Clean(clean):
         super().run()
         cleaning_list = [
             "PYPI_UPLOAD",
+            "EGG_UPLOAD",
             "./build",
             "./dist",
             "./man/avocado.1",


### PR DESCRIPTION
Avocado's CI jobs currently only build eggs for the main "avocado-framework" package, but not for the plugins.  Given that the Podman spawner deserves to be able to also prepare and use runners from plugins, it also needs to have the plugins' eggs built and available for download.

This is a first step that adds the building of the eggs to every job run at PR time.  Later, the same shall be added to the Release jobs, and a permanent location for plugins' eggs will be determined.

Reference: https://github.com/avocado-framework/avocado/issues/5588