### PR TITLE
Podman spawner: find correct runner module

### DIFF
--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -2,7 +2,6 @@ import base64
 import collections
 import json
 import logging
-import os
 import subprocess
 import sys
 
@@ -409,13 +408,6 @@ class Runnable:
         return kind in capabilities.get("runnables", [])
 
     @staticmethod
-    def _module_exists(module_name):
-        """Returns whether a nrunner "runner" module exists."""
-        module_filename = f"{module_name}.py"
-        mod_path = os.path.join("plugins", "runners", module_filename)
-        return pkg_resources.resource_exists("avocado", mod_path)
-
-    @staticmethod
     def pick_runner_command(kind, runners_registry=None):
         """Selects a runner command based on the runner kind.
 
@@ -455,10 +447,9 @@ class Runnable:
         # runner convention within the avocado.plugins.runners namespace dir.
         # Looking for the file only avoids an attempt to load the module
         # and should be a lot faster
-        module_name = kind.replace("-", "_")
-        if Runnable._module_exists(module_name):
-            full_module_name = f"avocado.plugins.runners.{module_name}"
-            candidate_cmd = [sys.executable, "-m", full_module_name]
+        module_name = Runnable.pick_runner_module_from_entry_point_kind(kind)
+        if module_name is not None:
+            candidate_cmd = [sys.executable, "-m", module_name]
             if Runnable.is_kind_supported_by_runner_command(
                 kind, candidate_cmd, env=get_python_path_env_if_egg()
             ):
@@ -488,6 +479,24 @@ class Runnable:
         :rtype: list of str or None
         """
         return Runnable.pick_runner_command(self.kind, runners_registry)
+
+    @staticmethod
+    def pick_runner_module_from_entry_point_kind(kind):
+        """Selects a runner module from entry points based on kind.
+
+        This is related to the :data:`SpawnMethod.STANDALONE_EXECUTABLE`.
+        The module found (if any) will be one that can be used with the
+        Python interpreter using the "python -m $module" command.
+
+        :param kind: Kind of runner
+        :type kind: str
+        :returns: a module that can be run with "python -m" or None"""
+        dist = pkg_resources.get_distribution("avocado-framework")
+        info = pkg_resources.get_entry_info(
+            dist, "console_scripts", f"avocado-runner-{kind}"
+        )
+        if info is not None:
+            return info.module_name
 
     @staticmethod
     def pick_runner_class_from_entry_point_kind(kind):

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -46,8 +46,10 @@ class RuntimeTask:
         """
         #: The :class:`avocado.core.nrunner.Task`
         self.task = task
-        #: Additional descriptive information about the task status
+        #: A :class:`avocado.core.task.runtime.RuntimeTaskStatus` value
         self.status = None
+        #: Additional descriptive information about the task status
+        self.status_description = None
         #: Information about task result when it is finished
         self.result = None
         #: Timeout limit for the completion of the task execution

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -124,9 +124,10 @@ class TaskStateMachine:
                 if status_reason:
                     runtime_task.status = status_reason
                     LOG.debug(
-                        'Task "%s" finished with status: %s',
+                        'Task "%s" finished with status: %s (%s)',
                         runtime_task.task.identifier,
                         status_reason,
+                        runtime_task.status_description,
                     )
                 else:
                     LOG.debug('Task "%s" finished', runtime_task.task.identifier)

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -249,7 +249,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             )
         except PodmanException as ex:
             msg = f"Could not create podman container: {ex}"
-            runtime_task.status = msg
+            runtime_task.status_description = msg
             return False
 
         return stdout.decode().strip()
@@ -261,7 +261,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             # pylint: disable=W0201
             self.podman = Podman(podman_bin)
         except PodmanException as ex:
-            runtime_task.status = str(ex)
+            runtime_task.status_description = str(ex)
             return False
 
         major, minor, _ = await self.python_version
@@ -283,7 +283,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             returncode, _, _ = await self.podman.start(container_id)
         except PodmanException as ex:
             msg = f"Could not start container: {ex}"
-            runtime_task.status = msg
+            runtime_task.status_description = msg
             LOG.error(msg)
             return False
 
@@ -307,7 +307,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             await self.podman.stop(runtime_task.spawner_handle)
         except PodmanException as ex:
             msg = f"Could not stop container: {ex}"
-            runtime_task.status = msg
+            runtime_task.status_description = msg
             LOG.error(msg)
             return False
 

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -193,9 +193,15 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             runtime_task.task.status_services[0].uri = mounted_status_server_socket
 
         _, _, python_binary = await self.python_version
+        full_module_name = (
+            runtime_task.task.runnable.pick_runner_module_from_entry_point_kind(
+                runtime_task.task.runnable.kind
+            )
+        )
+        if full_module_name is None:
+            runtime_task.status_description = f"Could not determine Python module name for runnable with kind {runtime_task.task.runnable.kind}"
+            return False
 
-        module_name = runtime_task.task.runnable.kind.replace("-", "_")
-        full_module_name = f"avocado.plugins.runners.{module_name}"
         entry_point_args = [python_binary, "-m", full_module_name, "task-run"]
 
         test_opts = ()

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -273,6 +273,8 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
         container_id = await self._create_container_for_task(
             runtime_task, env_args, output_dir_path
         )
+        if container_id is False:
+            return False
 
         runtime_task.spawner_handle = container_id
 

--- a/examples/plugins/tests/README.rst
+++ b/examples/plugins/tests/README.rst
@@ -20,4 +20,4 @@ list tests with::
 
 And run tests with::
 
-  avocado run --test-runner=nrunner $REFERENCE
+  avocado run $REFERENCE


### PR DESCRIPTION
This brings an unified approach for finding the name of Python modules that can be used with "python -m".
    
This allows for runners that exist in module namespaces other than "avocado.plugins.runners".

Reference: https://github.com/avocado-framework/avocado/issues/5588
Reference: https://github.com/avocado-framework/avocado/pull/5577#discussion_r1086266317