### PR TITLE
Podman spawner: find correct runner module [v2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,27 @@ jobs:
          python3 setup.py clean --all
          python3 -c 'import sys; sys.path.insert(0, "/tmp/avocado_framework.egg"); from avocado.core.main import main; sys.exit(main())' run --spawner=podman --spawner-podman-image=fedora:36 --spawner-podman-avocado-egg=file:///tmp/avocado_framework.egg -- /bin/true
 
+  podman_external_runner_task:
+
+    name: Podman spawner with 3rd party runner plugin
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Test running avocado from released eggs under Podman spawner with 3rd party plugins
+        run: |
+         apt update && apt -y install python3 python3-setuptools
+         python3 setup.py develop --user
+         cd examples/plugins/tests/magic
+         python3 setup.py develop --user
+         cd ../../../../
+         python3 -m avocado -V list -- pass fail | grep "magic: 2"
+         podman pull quay.io/avocado-framework/avocado-ci-magic
+         python3 -m avocado run --spawner=podman --spawner-podman-image=quay.io/avocado-framework/avocado-ci-magic -- pass
+         tail -n1 ~/avocado/job-results/latest/results.tap | grep "ok 1 pass"
+         python3 -m avocado run --spawner=podman --spawner-podman-image=quay.io/avocado-framework/avocado-ci-magic -- fail || true
+         tail -n1 ~/avocado/job-results/latest/results.tap | grep "not ok 1 fail"
+
   fedora_develop_install_uninstall_task:
     name: Fedora develop install/uninstall task
     runs-on: ubuntu-latest

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -46,7 +46,8 @@ class RuntimeTask:
         """
         #: The :class:`avocado.core.nrunner.Task`
         self.task = task
-        #: Additional descriptive information about the task status
+        #: The task status, a value from the enum
+        #: :class:`avocado.core.task.runtime.RuntimeTaskStatus`
         self.status = None
         #: Information about task result when it is finished
         self.result = None

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -248,8 +248,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
                 image,
             )
         except PodmanException as ex:
-            msg = f"Could not create podman container: {ex}"
-            runtime_task.status = msg
+            LOG.error("Could not create podman container: %s", ex)
             return False
 
         return stdout.decode().strip()
@@ -261,7 +260,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             # pylint: disable=W0201
             self.podman = Podman(podman_bin)
         except PodmanException as ex:
-            runtime_task.status = str(ex)
+            LOG.error(ex)
             return False
 
         major, minor, _ = await self.python_version
@@ -282,9 +281,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             # pylint: disable=W0201
             returncode, _, _ = await self.podman.start(container_id)
         except PodmanException as ex:
-            msg = f"Could not start container: {ex}"
-            runtime_task.status = msg
-            LOG.error(msg)
+            LOG.error("Could not start container: %s", ex)
             return False
 
         return returncode == 0
@@ -306,9 +303,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
         try:
             await self.podman.stop(runtime_task.spawner_handle)
         except PodmanException as ex:
-            msg = f"Could not stop container: {ex}"
-            runtime_task.status = msg
-            LOG.error(msg)
+            LOG.error("Could not stop container: %s", ex)
             return False
 
     @staticmethod

--- a/contrib/containers/ci/selftests/magic.docker
+++ b/contrib/containers/ci/selftests/magic.docker
@@ -1,0 +1,12 @@
+# This dockerfile copies and installs the magic example plugin, and
+# thus needs access to the "magic" directory.  Make sure the context
+# (directory) is correct before building this image.  One example
+# is by running:
+# $ cd examples/plugins/tests
+# $ buildah bud -f ../../../contrib/containers/ci/selftests/magic.docker
+FROM fedora:36
+LABEL description "Image that contains the example magic plugin"
+RUN dnf -y install python3-setuptools
+COPY magic /tmp/magic
+WORKDIR /tmp/magic
+RUN python3 setup.py install

--- a/examples/plugins/tests/README.rst
+++ b/examples/plugins/tests/README.rst
@@ -20,4 +20,4 @@ list tests with::
 
 And run tests with::
 
-  avocado run --test-runner=nrunner $REFERENCE
+  avocado run $REFERENCE

--- a/examples/plugins/tests/magic/setup.py
+++ b/examples/plugins/tests/magic/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 name = "magic"
 module = "avocado_magic"
@@ -20,4 +20,5 @@ if __name__ == "__main__":
             "avocado.plugins.runnable.runner": [runner_ep],
             "console_scripts": [runner_script],
         },
+        packages=find_packages(),
     )


### PR DESCRIPTION
This brings an unified approach for finding the name of Python modules that can be used with "python -m".
    
This allows for runners that exist in module namespaces other than "avocado.plugins.runners".

Reference: https://github.com/avocado-framework/avocado/issues/5588
Reference: https://github.com/avocado-framework/avocado/pull/5577#discussion_r1086266317

---

Changes from v1 (#5597):
* Wrap entire creation of container in try/except block to signal container creation errors
* Log RuntimeTask errors instead of keeping them in a new attribute
* Replaced `pkg_resource` API usage with `pkg.iter_entry_points()` as it covers entry points coming from any `pkg_resource.Distribution`, which is absolutely necessary to the goal of this change 
* Added container with `magic` plugin and CI check with podman spawner + magic plugin runner
* Fixed distribution of magic example files in packages (new commit)