### PR TITLE
host.py: fix typo in function name

### DIFF
--- a/avocado/utils/network/hosts.py
+++ b/avocado/utils/network/hosts.py
@@ -73,7 +73,7 @@ class Host:
     def get_interface_by_hwaddr(self, mac):
         """Return an interface that has a specific mac."""
         for interface in self.interfaces:
-            if mac in interface.get_hwaddrs():
+            if mac in interface.get_hwaddr():
                 return interface
 
     def get_default_route_interface(self):


### PR DESCRIPTION
While sending previous commit, function name get_hwaddr had minor typo is now fixed

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>