### PR TITLE
Test variant creation refactoring

### DIFF
--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -1,11 +1,9 @@
-from copy import deepcopy
 from enum import Enum
 from itertools import chain
 
 from avocado.core.dispatcher import TestPreDispatcher
 from avocado.core.nrunner.task import Task
 from avocado.core.test_id import TestID
-from avocado.core.varianter import dump_variant
 
 
 class RuntimeTaskStatus(Enum):
@@ -107,7 +105,6 @@ class RuntimeTask:
         runnable,
         no_digits,
         index,
-        variant,
         test_suite_name=None,
         status_server_uri=None,
         job_id=None,
@@ -137,9 +134,7 @@ class RuntimeTask:
             prefix = f"{test_suite_name}-{index}"
         else:
             prefix = index
-        test_id = TestID(prefix, runnable.identifier, variant, no_digits)
-        # inject variant on runnable
-        runnable.variant = dump_variant(variant)
+        test_id = TestID(prefix, runnable.identifier, runnable.variant, no_digits)
 
         # handles the test task
         task = Task(
@@ -221,7 +216,7 @@ class RuntimeTaskGraph:
         From the list of tests, it will create runtime tasks and connects them
         inside the graph by its dependencies.
 
-        :param tests: variants of runnables from test suite
+        :param tests: runnables from test suite
         :type tests: list
         :param test_suite_name: test suite name which this test is related to
         :type test_suite_name: str
@@ -236,13 +231,11 @@ class RuntimeTaskGraph:
         self.graph = {}
         # create graph
         no_digits = len(str(len(tests)))
-        for index, (runnable, variant) in enumerate(tests, start=1):
-            runnable = deepcopy(runnable)
+        for index, runnable in enumerate(tests, start=1):
             runtime_test = RuntimeTask.from_runnable(
                 runnable,
                 no_digits,
                 index,
-                variant,
                 test_suite_name,
                 status_server_uri,
                 job_id,

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -281,14 +281,12 @@ class Runner(SuiteRunner):
 
         self._abort_if_missing_runners(missing_requirements)
 
-        job.result.tests_total = test_suite.variants.get_number_of_tests(
-            test_suite.tests
-        )
+        job.result.tests_total = len(test_suite.tests)
 
         self._create_status_server(test_suite, job)
 
         graph = RuntimeTaskGraph(
-            test_suite.get_test_variants(),
+            test_suite.tests,
             test_suite.name,
             self._determine_status_server(test_suite, "run.status_server_uri"),
             job.unique_id,

--- a/examples/jobs/sleepjob_parameters.py
+++ b/examples/jobs/sleepjob_parameters.py
@@ -1,0 +1,21 @@
+import sys
+
+from avocado.core.job import Job
+from avocado.core.nrunner.runnable import Runnable
+from avocado.core.suite import TestSuite
+
+config = {}
+
+test = Runnable(
+    "avocado-instrumented",
+    "examples/tests/sleeptest.py:SleepTest.test",
+    variant={
+        "paths": ["/"],
+        "variant_id": None,
+        "variant": [["/", [["/", "sleep_length", "0.01"]]]],
+    },
+)
+suite = TestSuite("suite_1", tests=[test])
+
+with Job(config, [suite]) as j:
+    sys.exit(j.run())

--- a/selftests/unit/test_task_runtime.py
+++ b/selftests/unit/test_task_runtime.py
@@ -65,7 +65,7 @@ class DependencyGraph(TestCaseTmpDir):
         ) as test:
             config = {"resolver.references": [test.path]}
             suite = TestSuite.from_config(config=config)
-            tests = suite.get_test_variants()
+            tests = suite.tests
             graph = RuntimeTaskGraph(tests, suite.name, 1, "")
             runtime_tests = graph.get_tasks_in_topological_order()
             self.assertTrue(runtime_tests[0].task.identifier.name.endswith("test_a"))
@@ -81,7 +81,7 @@ class DependencyGraph(TestCaseTmpDir):
         ) as test:
             config = {"resolver.references": [test.path]}
             suite = TestSuite.from_config(config=config)
-            tests = suite.get_test_variants()
+            tests = suite.tests
             graph = RuntimeTaskGraph(tests, suite.name, 1, "")
             runtime_tests = graph.get_tasks_in_topological_order()
             self.assertTrue(runtime_tests[0].task.identifier.name.endswith("hello"))


### PR DESCRIPTION
It moves test variant creation from runtime task to suite. When we are creating suite, we have all information about tests and variants, so there is no need to wait for generating test variants. This refactoring will make things easier because we will know the actual test size right after the suite has been created.

Also, it fixes problems with Job API when users want to define variants or parameters by themselves and not with varianters, like in `examples/jobs/sleepjob_parameters.py`

Reference: #5356, #5347
Signed-off-by: Jan Richter <jarichte@redhat.com>