### PR TITLE
Runners: publish and use egg information by runner kind

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build eggs
-        run: python setup.py bdist_egg
+        run: make -f Makefile.gh build-egg
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.RELEASE_TOKEN }}
-          file: ${{ github.workspace }}/dist/avocado_framework*
+          file: ${{ github.workspace }}/EGG_UPLOAD/avocado_framework*egg
           tag: ${{ github.event.inputs.version }}
           overwrite: true
           file_glob: true

--- a/avocado/core/runners_assets.py
+++ b/avocado/core/runners_assets.py
@@ -1,0 +1,39 @@
+import json
+
+# pylint: disable=W4901
+from distutils.errors import DistutilsSetupError
+
+
+def check_runners_assets(dist, attr, value):  # pylint: disable=W0613
+    if not isinstance(value, dict):
+        raise DistutilsSetupError(
+            "runners_assets must be a dictionary keyed by test kind"
+        )
+
+    for kind, entries in value.items():
+        if not isinstance(entries, list):
+            raise DistutilsSetupError(f"value for runners_assets {kind} must be a list")
+        for entry in entries:
+            if not ("url_format" in entry or "url" in entry):
+                raise DistutilsSetupError(
+                    f'asset for runner {kind} lacks "url" or "url_format"'
+                )
+            if "url_format" in entry and "url" in entry:
+                raise DistutilsSetupError(
+                    f'asset for runner {kind} has conflicting options "url" and "url_format", only one is allowed'
+                )
+            if not "type" in entry:
+                raise DistutilsSetupError(f'asset for runner {kind} lacks "type"')
+
+
+def write_runners_assets_json(cmd, basename, filename):  # pylint: disable=W0613
+    if (
+        not hasattr(cmd.distribution, "runners_assets")
+        or not cmd.distribution.runners_assets
+    ):
+        return
+    cmd.write_file(
+        "runners_assets",
+        filename,
+        json.dumps(cmd.distribution.runners_assets, sort_keys=True),
+    )

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -42,5 +42,19 @@ setup(
         ],
         "avocado.plugins.runnable.runner": ["robot = avocado_robot.runner:RobotRunner"],
         "avocado.plugins.resolver": ["robot = avocado_robot.robot:RobotResolver"],
+        "distutils.setup_keywords": [
+            "runners_assets = avocado.core.runners_assets:check_runners_assets",
+        ],
+        "egg_info.writers": [
+            "runners_assets.json = avocado.core.runners_assets:write_runners_assets_json",
+        ],
+    },
+    runners_assets={
+        "robot": [
+            {
+                "url_format": f"https://github.com/avocado-framework/avocado/releases/download/{VERSION}/avocado_framework_plugin_robot-{VERSION}-py{{py_major}}.{{py_minor}}.egg",
+                "type": "egg",
+            }
+        ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -310,6 +310,9 @@ class Plugin(SimpleCommand):
             return
 
 
+EGG_URL_FMT = f"https://github.com/avocado-framework/avocado/releases/download/{VERSION}/avocado_framework-{VERSION}-py{{py_major}}.{{py_minor}}.egg"
+
+
 if __name__ == "__main__":
     # Force "make develop" inside the "readthedocs.org" environment
     if os.environ.get("READTHEDOCS") and "install" in sys.argv:
@@ -455,6 +458,24 @@ if __name__ == "__main__":
             "avocado.plugins.cache": [
                 "requirement = avocado.plugins.requirement_cache:RequirementCache",
             ],
+            "distutils.setup_keywords": [
+                "runners_assets = avocado.core.runners_assets:check_runners_assets",
+            ],
+            "egg_info.writers": [
+                "runners_assets.json = avocado.core.runners_assets:write_runners_assets_json",
+            ],
+        },
+        runners_assets={
+            "noop": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "dry-run": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "exec-test": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "python-unittest": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "avocado-instrumented": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "tap": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "asset": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "package": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "podman-image": [{"url_format": EGG_URL_FMT, "type": "egg"}],
+            "sysinfo": [{"url_format": EGG_URL_FMT, "type": "egg"}],
         },
         zip_safe=False,
         test_suite="selftests",


### PR DESCRIPTION
Until now, Avocado was limited to run tests on environments such as containers that are packaged in the main egg file "avocado_framework-{version}-py{major}.{minor}.egg".
    
Now, plugins can describe the assets that contain runners for external and specific test kinds.
    
At this time, Avocado won't resolve or fulfill dependencies of the assets themselves.  For instance, the "robot" plugin requires the "robotframework" Python package.  At this time, users have to prepare the environment with the missing asset dependencies.

In the future, other types of runner assets (other than "eggs") might be introduced.