### PR TITLE
get_disk_by_id: function to return all disks by device ids

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -123,6 +123,25 @@ def get_disks():
     return [str(disk["name"]) for disk in json_data["blockdevices"]]
 
 
+def get_disks_by_id():
+    """
+    Returns the physical "hard drives" available with wwid
+
+    This will get all the sysfs scsi disks by its device id,
+    irrespective of any platform and device type, a unique key
+    ie wwid will help work with devices in unpredictable device
+    name environment.
+
+    :returns: a list of scsi ids of real scsi devcies
+    :rtype: list of str
+    """
+    disk_list = []
+    for device in os.listdir("/dev/disk/by-id/"):
+        if os.path.realpath(os.path.join("/dev/disk/by-id/", device)):
+            disk_list.append(f"/dev/disk/by-id/{device}")
+    return disk_list
+
+
 def get_available_filesystems():
     """
     Return a list of all available filesystem types


### PR DESCRIPTION
In an unpredicatable device name environment, it is better to always work via unique device ids which does not change post install/reboot/dlpar. so added a function to get all devices by its /dev/disk/by-ids

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>