### PR TITLE
Adds a determination of whether the path exists when the call is null

### DIFF
--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -138,8 +138,9 @@ class PathInspector:
         return mode & stat.S_IXUSR
 
     def is_empty(self):
-        size = os.stat(self.path)[stat.ST_SIZE]
-        return size == 0
+        if os.path.exists(self.path):
+            size = os.stat(self.path)[stat.ST_SIZE]
+            return size == 0
 
     def is_script(self, language=None):
         first_line = self.get_first_line()


### PR DESCRIPTION
If the path is incorrect, an error is reported directly, adding a judgment to determine whether the path is correct. If the path does not exist, None is returned