### PR TITLE
Add utility to check cpu is hotpluggable

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -271,6 +271,10 @@ def online_count():
     return os.sysconf("SC_NPROCESSORS_ONLN")
 
 
+def is_hotpluggable(cpu):
+    return os.path.exists(f"/sys/devices/system/cpu/cpu{cpu}/online")
+
+
 def online(cpu):
     """Online given CPU."""
     if _get_status(cpu) is False:


### PR DESCRIPTION
Add a utilty to check if a CPU is hotpluggable
by checking if /sys/devices/system/cpu/cpu(cpu)/online present or not in sysfs.

Signed-off-by: Ayush Jain <ayush.jain3@amd.com>