### PR TITLE
avocado.utils.archive: add support for Zstandard uncompression

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -28,7 +28,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-avocado
 Version: 100.1
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2+ and GPLv2 and MIT
 URL: https://avocado-framework.github.io/
 %if 0%{?rel_build}
@@ -69,6 +69,7 @@ BuildRequires: perl-Test-Harness
 BuildRequires: python3-elementpath
 BuildRequires: python3-xmlschema
 %endif
+BuildRequires: zstd
 %endif
 
 %description
@@ -408,6 +409,9 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Tue Feb 14 2023 Cleber Rosa <crosa@redhat.com> - 100.1-2
+- Added zstd to build requirements
+
 * Thu Jan 19 2023 Cleber Rosa <crosa@redhat.com> - 100.1-1
 - New release
 

--- a/selftests/unit/utils/test_archive.py
+++ b/selftests/unit/utils/test_archive.py
@@ -7,6 +7,8 @@ import unittest
 from avocado.utils import archive, crypto, data_factory
 from selftests.utils import BASEDIR, temp_dir_prefix
 
+ZSTD_AVAILABLE = archive._probe_zstd_cmd() is not None
+
 
 class ArchiveTest(unittest.TestCase):
     def setUp(self):
@@ -216,6 +218,27 @@ class ArchiveTest(unittest.TestCase):
     def test_zstd_is_archive(self):
         zstd_path = os.path.join(BASEDIR, "selftests", ".data", "avocado.zst")
         self.assertTrue(archive.is_archive(zstd_path))
+
+    @unittest.skipUnless(ZSTD_AVAILABLE, "zstd tool is not available")
+    def test_zstd_uncompress_to_dir(self):
+        zstd_path = os.path.join(BASEDIR, "selftests", ".data", "avocado.zst")
+        ret = archive.zstd_uncompress(zstd_path, self.decompressdir)
+        self.assertEqual(ret, os.path.join(self.decompressdir, "avocado"))
+
+    @unittest.skipUnless(ZSTD_AVAILABLE, "zstd tool is not available")
+    def test_zstd_uncompress_to_file(self):
+        zstd_path = os.path.join(BASEDIR, "selftests", ".data", "avocado.zst")
+        filename = os.path.join(self.decompressdir, "other")
+        ret = archive.zstd_uncompress(zstd_path, filename)
+        self.assertEqual(ret, filename)
+
+    @unittest.skipUnless(ZSTD_AVAILABLE, "zstd tool is not available")
+    def test_uncompress_zstd(self):
+        zstd_path = os.path.join(BASEDIR, "selftests", ".data", "avocado.zst")
+        ret = archive.uncompress(zstd_path, self.decompressdir)
+        self.assertEqual(ret, os.path.join(self.decompressdir, "avocado"))
+        with open(ret, "rb") as decompressed:
+            self.assertEqual(decompressed.read(), b"avocado\n")
 
     def test_null_is_not_archive(self):
         self.assertFalse(archive.is_archive(os.devnull))

--- a/selftests/unit/utils/test_archive.py
+++ b/selftests/unit/utils/test_archive.py
@@ -199,9 +199,6 @@ class ArchiveTest(unittest.TestCase):
         xz_path = os.path.join(BASEDIR, "selftests", ".data", "avocado.xz")
         self.assertTrue(archive.is_archive(xz_path))
 
-    def test_null_lzma_is_not_archive(self):
-        self.assertFalse(archive.is_archive(os.devnull))
-
     def test_uncompress_lzma(self):
         xz_path = os.path.join(BASEDIR, "selftests", ".data", "avocado.xz")
         ret = archive.uncompress(xz_path, self.decompressdir)
@@ -220,7 +217,7 @@ class ArchiveTest(unittest.TestCase):
         zstd_path = os.path.join(BASEDIR, "selftests", ".data", "avocado.zst")
         self.assertTrue(archive.is_archive(zstd_path))
 
-    def test_null_zstd_is_not_archive(self):
+    def test_null_is_not_archive(self):
         self.assertFalse(archive.is_archive(os.devnull))
 
     def tearDown(self):


### PR DESCRIPTION
This adds support for extracting zstd archives using the `avocado.utils.archive.uncompress()` API, and is similar to the feature level introduced earlier for lzma archives.
    
In the future it should be possible to expand this with:
    
* support for compression
* support for more backends (such as python-zstd or python-zstandard)
    
All in all, this should be enough to fulfill the use case described in the matching issue.
    
Fixes: https://github.com/avocado-framework/avocado/issues/5609