### PR TITLE
avocado/utils/ssh.py Repair File transfer failed when the remote path…

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -256,6 +256,7 @@ class Session:
         :returns: True if success and an exception if not.
         :rtype: bool
         """
+        path = destination.split(":")[-1]
         try:
             cmd = path_utils.find_command("scp")
         except path_utils.CmdNotFoundError as exc:
@@ -268,6 +269,8 @@ class Session:
             options += " -r"
         options += f" {source} {destination}"
         try:
+            if self.cmd(f"test -d {path}").exit_status != 0:
+                self.cmd(f"mkdir -p {path}")
             result = process.run(f"{cmd} {options}", ignore_status=True)
             return result.exit_status == 0
         except process.CmdError as exc:


### PR DESCRIPTION
 avocado/utils/ssh.py If the destination path does not exist on the peer machine, a file with the same name is created on the peer machine. As a result, file transfer fails     
 Signed-off-by: zuohanxu <zuohanxu@uniontech.com>
