### PR TITLE
disk.py: added disk utils to get all paths and absolute path

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -172,25 +172,6 @@ def get_absolute_disk_path(device):
     return device
 
 
-def get_disks_by_id():
-    """
-    Returns the physical "hard drives" available with wwid
-
-    This will get all the sysfs scsi disks by its device id,
-    irrespective of any platform and device type, a unique key
-    ie wwid will help work with devices in unpredictable device
-    name environment.
-
-    :returns: a list of scsi ids of real scsi devcies
-    :rtype: list of str
-    """
-    disk_list = []
-    for device in os.listdir("/dev/disk/by-id/"):
-        if os.path.realpath(os.path.join("/dev/disk/by-id/", device)):
-            disk_list.append(f"/dev/disk/by-id/{device}")
-    return disk_list
-
-
 def get_available_filesystems():
     """
     Return a list of all available filesystem types

--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -123,6 +123,55 @@ def get_disks():
     return [str(disk["name"]) for disk in json_data["blockdevices"]]
 
 
+def get_all_disk_paths():
+    """
+    Returns all available disk names and alias on this  system
+
+    This will get all the sysfs disks name entries by its device
+    node name, by-uuid, by-id and by-path, irrespective of any
+    platform and device type
+
+    :returns: a list of all disk path names
+    :rtype: list of str
+    """
+    disk_list = abs_path = []
+    for path in [
+        "/dev",
+        "/dev/mapper",
+        "/dev/disk/by-id",
+        "/dev/disk/by-path",
+        "/dev/disk/by-uuid",
+        "/dev/disk/by-partuuid",
+        "/dev/disk/by-partlabel",
+    ]:
+        if os.path.exists(path):
+            for device in os.listdir(path):
+                abs_path.append(os.path.join(path, device))
+            disk_list.extend(abs_path)
+    return disk_list
+
+
+def get_absolute_disk_path(device):
+    """
+    Returns absolute device path of given disk
+
+    This will get actual disks path of given device, it can take
+    node name, by-uuid, by-id and by-path, irrespective of any
+    platform and device type
+
+    :param device: disk name or disk alias names sda or scsi-xxx
+    :type device: str
+
+    :returns: the device absolute path name
+    :rtype: bool
+    """
+    if not os.path.exists(device):
+        for dev_path in get_all_disk_paths():
+            if device == os.path.basename(dev_path):
+                return dev_path
+    return device
+
+
 def get_disks_by_id():
     """
     Returns the physical "hard drives" available with wwid

--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -97,6 +97,24 @@ def get_mpath_name(wwid):
         return process.run(cmd, sudo=True).stdout_text.split()[0]
 
 
+def get_mpath_from_dm(dm_id):
+    """
+    Get the mpath name for given device mapper id
+
+    :param dev_mapper: Input device mapper dm-x
+    :return: mpath name like mpathx
+    :rtype: str
+    """
+    cmd = "multipathd show maps format '%d %n'"
+    try:
+        mpaths = process.run(cmd, ignore_status=True, sudo=True, shell=True).stdout_text
+    except process.CmdError as ex:
+        raise MPException(f"Multipathd Command Failed : {ex} ")
+    for mpath in mpaths.splitlines():
+        if dm_id in mpath:
+            return mpath.split()[1]
+
+
 def get_multipath_wwids():
     """
     Get list of multipath wwids.


### PR DESCRIPTION
These utils will help to get all the available disks names or alias names disk by-id, by-path, by-uuid, or mapper names and also get absolute device path of a given disk irrespecitve of device type and platform