### PR TITLE
VMimage pre-release tests fix

### DIFF
--- a/selftests/pre_release/jobs/pre_release.py
+++ b/selftests/pre_release/jobs/pre_release.py
@@ -28,9 +28,25 @@ vmimage = {
     "run.max_parallel_tasks": 1,
 }
 
+vmimage_get = {
+    "resolver.references": [os.path.join(TESTS_DIR, "vmimage_functional.py")],
+    "yaml_to_mux.files": [os.path.join(TESTS_DIR, "vmimage.py.data", "variants.yml")],
+    "run.max_parallel_tasks": 1,
+    "yaml_to_mux.filter_only": ["/run/architectures/x86_64"],
+    "yaml_to_mux.filter_out": [
+        "/run/distro/centos/version",
+        "/run/distro/cirros/version",
+        "/run/distro/debian/version",
+        "/run/distro/fedora/version",
+        "/run/distro/ubuntu/version",
+        "/run/distro/opensuse/version",
+        "/run/distro/freebsd/version",
+    ],
+}
+
 if __name__ == "__main__":
     os.chdir(ROOT_DIR)
     config = {"job.output.testlogs.statuses": ["FAIL", "ERROR", "INTERRUPT"]}
-    with Job.from_config(config, [cirrus_ci, parallel_1, vmimage]) as j:
+    with Job.from_config(config, [cirrus_ci, parallel_1, vmimage, vmimage_get]) as j:
         os.environ["AVOCADO_CHECK_LEVEL"] = "3"
         sys.exit(j.run())

--- a/selftests/pre_release/tests/vmimage.py
+++ b/selftests/pre_release/tests/vmimage.py
@@ -1,11 +1,8 @@
-import os
-import shutil
 from urllib.error import HTTPError
 from urllib.request import urlopen
 
 from avocado import Test, fail_on
-from avocado.plugins import vmimage as vmimage_plug
-from avocado.utils import process, vmimage
+from avocado.utils import vmimage
 
 
 class Base(Test):
@@ -72,24 +69,3 @@ class Image(Base):
             self.vmimage_build,
             self.vmimage_arch,
         )
-
-
-class ImageFunctional(Base):
-    @staticmethod
-    def __get_cache_files():
-        return set(i["file"] for i in vmimage_plug.list_downloaded_images())
-
-    def setUp(self):
-        super().setUp()
-        self.cache_files = self.__get_cache_files()
-
-    @fail_on(process.CmdError)
-    def test_get(self):
-        cmd = "avocado vmimage get --distro=%s --distro-version=%s --arch=%s"
-        cmd %= (self.vmimage_name, self.vmimage_version, self.vmimage_arch)
-        process.run(cmd)
-
-    def tearDown(self):
-        dirty_files = self.__get_cache_files() - self.cache_files
-        for file_path in dirty_files:
-            shutil.rmtree(os.path.dirname(file_path))

--- a/selftests/pre_release/tests/vmimage_functional.py
+++ b/selftests/pre_release/tests/vmimage_functional.py
@@ -1,0 +1,25 @@
+import os
+import shutil
+
+from avocado import Test, fail_on
+from avocado.plugins import vmimage as vmimage_plug
+from avocado.utils import process
+
+
+class ImageFunctional(Test):
+    @staticmethod
+    def __get_cache_files():
+        return set(i["file"] for i in vmimage_plug.list_downloaded_images())
+
+    def setUp(self):
+        self.vmimage_name = self.params.get("name", default="fedora")
+        self.cache_files = self.__get_cache_files()
+
+    @fail_on(process.CmdError)
+    def test_get(self):
+        process.run(f"avocado vmimage get --distro={self.vmimage_name}")
+
+    def tearDown(self):
+        dirty_files = self.__get_cache_files() - self.cache_files
+        for file_path in dirty_files:
+            shutil.rmtree(os.path.dirname(file_path))


### PR DESCRIPTION
It removes downloading of all vmimage versions. It will try to download
only the default version to check that downloading is working.

Reference: https://github.com/avocado-framework/avocado/issues/5619
Signed-off-by: Jan Richter <jarichte@redhat.com>