### PR TITLE
Changing the script to get the exact active controller_id in nvme.py

### DIFF
--- a/avocado/utils/nvme.py
+++ b/avocado/utils/nvme.py
@@ -84,9 +84,9 @@ def get_controller_id(controll_name):
     :param controller_name: Name of the controller eg: nvme0
     :rtype: string
     """
-    cmd = f"nvme list-ctrl /dev/{controll_name}"
-    output = process.system_output(cmd, shell=True, ignore_status=True).decode("utf-8")
+    cmd = f"nvme id-ctrl /dev/{controll_name}"
+    output = process.run(cmd, shell=True, sudo=True, ignore_status=True).stdout_text
     for line in output.splitlines():
-        if "0]" in line:
-            return line.split(":")[-1]
+        if "cntlid" in line:
+            return line.split(":")[-1].strip()
     return ""


### PR DESCRIPTION
currently we are using the 0] string to get the controller id in list_ctrl option. This may not give always the active controller ID of nvme adapter among the two IDs it holds. So changing the nvme option to id-ctrl and finding with exact controller_id string.

also made the script to pep8 compliance.