### PR TITLE
Post test plugins [v2]

### DIFF
--- a/avocado/core/dispatcher.py
+++ b/avocado/core/dispatcher.py
@@ -75,6 +75,19 @@ class TestPreDispatcher(EnabledExtensionManager):
         super().__init__("avocado.plugins.test.pre")
 
 
+class TestPostDispatcher(EnabledExtensionManager):
+
+    """
+    Calls extensions after Test execution
+
+    Automatically adds all the extension with entry points registered under
+    'avocado.plugins.test.post'
+    """
+
+    def __init__(self):
+        super().__init__("avocado.plugins.test.post")
+
+
 class ResultDispatcher(EnabledExtensionManager):
     def __init__(self):
         super().__init__("avocado.plugins.result")

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -169,10 +169,11 @@ class PreTest(Plugin):
     """
 
     @abc.abstractmethod
-    def pre_test_runnables(self, test_runnable):
+    def pre_test_runnables(self, test_runnable, suite_config=None):
         """Entry point for creating runnables, which will be run before test.
 
         :param test_runnable: Runnable of the Test itself.
+        :param suite_config: Configuration dict relevant for the whole suite.
         :return: PreTest task runnables created by plugin.
         :rtype: list of :class:`avocado.core.nrunner.Runnable`
         """
@@ -186,10 +187,11 @@ class PostTest(Plugin):
     """
 
     @abc.abstractmethod
-    def post_test_runnables(self, test_runnable):
+    def post_test_runnables(self, test_runnable, suite_config=None):
         """Entry point for creating runnables, which will be run after test.
 
         :param test_runnable: Runnable of the Test itself.
+        :param suite_config: Configuration dict relevant for the whole suite.
         :return: PostTest task runnables created by plugin.
         :rtype: list of tuple(:class:`avocado.core.nrunner.Runnable`,
         `avocado.core.task.runtime.RuntimeTask.possible_dependency_results`)

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -178,6 +178,24 @@ class PreTest(Plugin):
         """
 
 
+class PostTest(Plugin):
+    """Base plugin interface for adding tasks after a test run.
+
+    This interface helps to create `avocado.core.nrunner.Task` for running
+    additional actions inside spawner environment after Test.
+    """
+
+    @abc.abstractmethod
+    def post_test_runnables(self, test_runnable):
+        """Entry point for creating runnables, which will be run after test.
+
+        :param test_runnable: Runnable of the Test itself.
+        :return: PostTest task runnables created by plugin.
+        :rtype: list of tuple(:class:`avocado.core.nrunner.Runnable`,
+        `avocado.core.task.runtime.RuntimeTask.possible_dependency_results`)
+        """
+
+
 class ResultEvents(JobPreTests, JobPostTests):
     """Base plugin interface for event based (stream-able) results.
 

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -174,24 +174,21 @@ class PrePostRuntimeTaskMixin(RuntimeTask):
     """Common utilities for PrePostRuntimeTask implementations."""
 
     @classmethod
-    def get_tasks_from_runnable(
+    def get_tasks_from_test_task(
         cls,
-        runnable,
+        test_task,
         no_digits,
-        index,
         test_suite_name=None,
         status_server_uri=None,
         job_id=None,
         suite_config=None,
     ):
-        """Creates runtime tasks for preTest task from runnable
+        """Creates runtime tasks for preTest task from test task.
 
-        :param runnable: the "description" of what the task should run.
-        :type runnable: :class:`avocado.core.nrunner.Runnable`
+        :param test_task: Runtime test task.
+        :type test_task: :class:`avocado.core.task.runtime.RuntimeTask`
         :param no_digits: number of digits of the test uid
         :type no_digits: int
-        :param index: index of tests inside test suite
-        :type index: int
         :param test_suite_name: test suite name which this test is related to
         :type test_suite_name: str
         :param status_server_uri: the URIs for the status servers that this
@@ -208,6 +205,8 @@ class PrePostRuntimeTaskMixin(RuntimeTask):
         """
         tasks = []
         plugins = cls.dispatcher().get_extentions_by_priority()
+        runnable = test_task.task.runnable
+        prefix = f"{test_task.task.identifier.str_filesystem}"
         for plugin in plugins:
             plugin = plugin.obj
             is_cacheable = getattr(plugin, "is_cacheable", False)
@@ -220,7 +219,7 @@ class PrePostRuntimeTaskMixin(RuntimeTask):
                 task = cls.from_runnable(
                     runnable,
                     no_digits,
-                    index,
+                    prefix,
                     test_suite_name,
                     status_server_uri,
                     job_id,
@@ -286,20 +285,18 @@ class RuntimeTaskGraph:
 
             # with --dry-run we don't want to run dependencies
             if runnable.kind != "dry-run":
-                tasks = PreRuntimeTask.get_tasks_from_runnable(
-                    runnable,
+                tasks = PreRuntimeTask.get_tasks_from_test_task(
+                    runtime_test,
                     no_digits,
-                    index,
                     test_suite_name,
                     status_server_uri,
                     job_id,
                     suite_config,
                 )
                 tasks.append(runtime_test)
-                tasks = tasks + PostRuntimeTask.get_tasks_from_runnable(
-                    runnable,
+                tasks = tasks + PostRuntimeTask.get_tasks_from_test_task(
+                    runtime_test,
                     no_digits,
-                    index,
                     test_suite_name,
                     status_server_uri,
                     job_id,

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -36,11 +36,14 @@ class RuntimeTask:
     information about its execution by a spawner within a state machine.
     """
 
-    def __init__(self, task):
+    def __init__(self, task, satisfiable_deps_execution_statuses=None):
         """Instantiates a new RuntimeTask.
 
         :param task: The task to keep additional information about
         :type task: :class:`avocado.core.nrunner.Task`
+        :param satisfiable_deps_execution_statuses: The dependency result types that
+        satisfy the execution of this RuntimeTask.
+        :type satisfiable_deps_execution_statuses: list of test results.
         """
         #: The :class:`avocado.core.nrunner.Task`
         self.task = task
@@ -59,6 +62,9 @@ class RuntimeTask:
         #: The result of the spawning of a Task
         self.spawning_result = None
         self.dependencies = []
+        self.satisfiable_deps_execution_statuses = (
+            satisfiable_deps_execution_statuses or ["pass"]
+        )
 
     def __repr__(self):
         if self.status is None:
@@ -96,7 +102,7 @@ class RuntimeTask:
             return False
 
         for dependency in self.dependencies:
-            if dependency.result != "pass":
+            if dependency.result not in self.satisfiable_deps_execution_statuses:
                 return False
         return True
 
@@ -109,6 +115,7 @@ class RuntimeTask:
         test_suite_name=None,
         status_server_uri=None,
         job_id=None,
+        satisfiable_deps_execution_statuses=None,
     ):
         """Creates runtime task for test from runnable
 
@@ -127,6 +134,9 @@ class RuntimeTask:
                        sent to the destination job's status server and will
                        make into the job's results.
         :type job_id: str
+        :param satisfiable_deps_execution_statuses: The dependency result types that
+        satisfy the execution of this RuntimeTask.
+        :type satisfiable_deps_execution_statuses: list of test results.
         :returns: RuntimeTask of the test from runnable
         """
 
@@ -141,7 +151,7 @@ class RuntimeTask:
         task = Task(
             runnable, identifier=test_id, status_uris=status_server_uri, job_id=job_id
         )
-        return cls(task)
+        return cls(task, satisfiable_deps_execution_statuses)
 
 
 class PreRuntimeTask(RuntimeTask):
@@ -154,6 +164,7 @@ class PreRuntimeTask(RuntimeTask):
         test_suite_name=None,
         status_server_uri=None,
         job_id=None,
+        satisfiable_deps_execution_statuses=None,
     ):
         """Creates runtime task for pre_test plugin from runnable
 
@@ -172,6 +183,9 @@ class PreRuntimeTask(RuntimeTask):
                        sent to the destination job's status server and will
                        make into the job's results.
         :type job_id: str
+        :param satisfiable_deps_execution_statuses: The dependency result types that
+        satisfy the execution of this RuntimeTask.
+        :type satisfiable_deps_execution_statuses: list of test results.
         :returns: RuntimeTask of the test from runnable
         """
         # create test ID
@@ -202,6 +216,7 @@ class PreRuntimeTask(RuntimeTask):
         test_suite_name=None,
         status_server_uri=None,
         job_id=None,
+        satisfiable_deps_execution_statuses=None,
     ):
         """Creates runtime tasks for preTest task from runnable
 
@@ -220,6 +235,9 @@ class PreRuntimeTask(RuntimeTask):
                        sent to the destination job's status server and will
                        make into the job's results.
         :type job_id: str
+        :param satisfiable_deps_execution_statuses: The dependency result types that
+        satisfy the execution of this RuntimeTask.
+        :type satisfiable_deps_execution_statuses: list of test results.
         :returns: Pre RuntimeTasks of the dependencies from runnable
         :rtype: list
         """
@@ -240,6 +258,7 @@ class PreRuntimeTask(RuntimeTask):
                 test_suite_name,
                 status_server_uri,
                 job_id,
+                satisfiable_deps_execution_statuses,
             )
             pre_test_tasks.append(pre_task)
         return pre_test_tasks

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -279,25 +279,27 @@ class Worker:
                 )
                 return
         if runtime_task.task.category != "test":
-            async with self._state_machine.cache_lock:
-                is_task_in_cache = await self._spawner.is_requirement_in_cache(
-                    runtime_task
-                )
-                if is_task_in_cache is None:
-                    async with self._state_machine.lock:
-                        self._state_machine.triaging.append(runtime_task)
-                        runtime_task.status = RuntimeTaskStatus.WAIT
-                        await asyncio.sleep(0.1)
-                    return
-
-                if is_task_in_cache:
-                    await self._state_machine.finish_task(
-                        runtime_task, RuntimeTaskStatus.IN_CACHE
+            # save or retrieve task from cache
+            if runtime_task.is_cacheable:
+                async with self._state_machine.cache_lock:
+                    is_task_in_cache = await self._spawner.is_requirement_in_cache(
+                        runtime_task
                     )
-                    runtime_task.result = "pass"
-                    return
+                    if is_task_in_cache is None:
+                        async with self._state_machine.lock:
+                            self._state_machine.triaging.append(runtime_task)
+                            runtime_task.status = RuntimeTaskStatus.WAIT
+                            await asyncio.sleep(0.1)
+                        return
 
-                await self._spawner.save_requirement_in_cache(runtime_task)
+                    if is_task_in_cache:
+                        await self._state_machine.finish_task(
+                            runtime_task, RuntimeTaskStatus.IN_CACHE
+                        )
+                        runtime_task.result = "pass"
+                        return
+
+                    await self._spawner.save_requirement_in_cache(runtime_task)
 
         # the task is ready to run
         async with self._state_machine.lock:

--- a/avocado/plugins/dependency.py
+++ b/avocado/plugins/dependency.py
@@ -26,6 +26,7 @@ class DependencyResolver(PreTest):
 
     name = "dependency"
     description = "Dependency resolver for tests with dependencies"
+    is_cacheable = True
 
     @staticmethod
     def pre_test_runnables(test_runnable, suite_config=None):  # pylint: disable=W0221

--- a/avocado/plugins/dependency.py
+++ b/avocado/plugins/dependency.py
@@ -28,7 +28,7 @@ class DependencyResolver(PreTest):
     description = "Dependency resolver for tests with dependencies"
 
     @staticmethod
-    def pre_test_runnables(test_runnable):  # pylint: disable=W0221
+    def pre_test_runnables(test_runnable, suite_config=None):  # pylint: disable=W0221
         if not test_runnable.dependencies:
             return []
         dependency_runnables = []

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -66,6 +66,10 @@ class Plugins(CLICmd):
                 "Plugins that run before the execution of each test (test.pre):",
             ),
             (
+                dispatcher.TestPostDispatcher(),
+                "Plugins that run after the execution of each test (test.post):",
+            ),
+            (
                 dispatcher.ResultDispatcher(),
                 "Plugins that generate job result in different formats (result):",
             ),

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -286,6 +286,7 @@ class Runner(SuiteRunner):
             test_suite.name,
             self._determine_status_server(test_suite, "run.status_server_uri"),
             job.unique_id,
+            test_suite.config,
         )
         # pylint: disable=W0201
         self.runtime_tasks = graph.get_tasks_in_topological_order()

--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -215,6 +215,19 @@ the ``plugins.$type.order`` is [plugin2, plugin4] then the real order will be
 
 .. _new-test-type-plugin-example:
 
+Cacheable plugins
+=================
+The results of Pre-test and Post-test plugins defined in :class:`avocado.core.plugin_interfaces.PreTest`
+and :class:`avocado.core.plugin_interfaces.PostTest` can be saved in cache. This is 
+very useful If the results can be used by other tests or even other avocado executions. 
+As an example of such plugin is `Dependency resolver` in :ref:`managing-requirements` 
+which installs dependencies for test into the test environment.
+
+As a default, all pre- / post-plugins are noncacheable. To make plugin cacheable you 
+have to set plugin variable `is_cacheable` to `True`, like this:
+
+.. literalinclude:: ../../../../../examples/plugins/test-pre-post/hello/hello.py
+
 New test type plugin example
 ============================
 

--- a/examples/plugins/test-pre-post/hello/hello.py
+++ b/examples/plugins/test-pre-post/hello/hello.py
@@ -1,0 +1,15 @@
+from avocado.core.output import LOG_UI
+from avocado.core.plugin_interfaces import PostTest, PreTest
+
+
+class HelloWorld(PreTest, PostTest):
+
+    name = "hello"
+    description = "The classical Hello World! plugin example."
+    is_cacheable = True
+
+    def pre_test_runnables(self, test_runnable, suite_config=None):
+        LOG_UI.info(self.description)
+
+    def post_test_runnables(self, test_runnable, suite_config=None):
+        LOG_UI.info(self.description)

--- a/examples/plugins/test-pre-post/hello/setup.py
+++ b/examples/plugins/test-pre-post/hello/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup(
+        name="avocado-hello-world-pre-post-test",
+        version="1.0",
+        description="Avocado Hello World pre and post test plugin",
+        py_modules=["hello"],
+        entry_points={
+            "avocado.plugins.test.pre": ["hello_pre = hello:HelloWorld"],
+            "avocado.plugins.test.post": ["hello_post = hello:HelloWorld"],
+        },
+    )


### PR DESCRIPTION
Infrastructure for creating post-test plugins. Such plugin will
be able to add tasks after the test task.

Introduces first post test plugin which is using this infrastructure the sysinfo plugin.
It adds sysinfo gathering into the suite run. It creates pre and
post sysinfo tasks in a suite which will be run before and after the
testing. Those tasks will gather sysinfo by sysinfo-runner and save it
into the test-results folder.

Reference: https://github.com/avocado-framework/avocado/issues/5204, https://github.com/avocado-framework/avocado/issues/3877
Signed-off-by: Jan Richter [jarichte@redhat.com](mailto:jarichte@redhat.com)

---
Changes from v1 (#5452):

* remove PostRuntimeTaskPrototype. I used a different approach. Now the post plugins have to create post tasks for each test result and based on the test result the tasks will be run or skipped.
* The W0221 error of Pre- and Post-tasks resolved.