### PR TITLE
Static checks: isort improvements

### DIFF
--- a/avocado/__init__.py
+++ b/avocado/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
 ]
 
 
-from avocado.core import register_core_options, initialize_plugins
+from avocado.core import initialize_plugins, register_core_options
 from avocado.core.settings import settings
 
 register_core_options()

--- a/selftests/.data/safeloader/data/double_import.py
+++ b/selftests/.data/safeloader/data/double_import.py
@@ -1,3 +1,7 @@
+"""
+isort:skip_file
+"""
+
 import avocado as foo
 import avocado as bar  # pylint: disable=W0404
 

--- a/selftests/.data/safeloader/data/imports.py
+++ b/selftests/.data/safeloader/data/imports.py
@@ -1,3 +1,7 @@
+"""
+isort:skip_file
+"""
+
 # docstrings, methods, imports... pylint: disable=C0111,R0903,C0411,E0611,C0412
 
 # module imports

--- a/selftests/isort.sh
+++ b/selftests/isort.sh
@@ -1,7 +1,3 @@
 #!/bin/sh -e
 
-isort --check-only --profile black \
-      --skip selftests/.data/safeloader/data/double_import.py \
-      --skip selftests/.data/safeloader/data/dont_detect_non_avocado.py \
-      --skip selftests/.data/safeloader/data/imports.py \
-      .
+isort --check-only --profile black .

--- a/selftests/isort.sh
+++ b/selftests/isort.sh
@@ -4,4 +4,4 @@ isort --check-only --profile black \
       --skip selftests/.data/safeloader/data/double_import.py \
       --skip selftests/.data/safeloader/data/dont_detect_non_avocado.py \
       --skip selftests/.data/safeloader/data/imports.py \
-      --skip avocado/__init__.py .
+      .


### PR DESCRIPTION
This makes the `isort.sh` script repository agnostic.  This is a first step towards making the whole static check scripts and configuration common across all "avocado-framework" repositories.