### PR TITLE
Introduce support for test data files in resolvers and spawners [v2]

### DIFF
--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -87,6 +87,9 @@ class Runnable:
         self.dependencies = kwargs.pop("dependencies", None)
         self.variant = kwargs.pop("variant", None)
         self.output_dir = kwargs.pop("output_dir", None)
+        #: list of (:class:`ReferenceResolutionAssetType`, str) tuples
+        #: expressing assets that the test will require in order to run.
+        self.assets = kwargs.pop("assets", None)
         self.kwargs = kwargs
         self._identifier_format = config.get("runner.identifier_format", "{uri}")
 

--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -16,11 +16,23 @@
 Test resolver module.
 """
 
+import glob
 import os
 from enum import Enum
 
 from avocado.core.enabled_extension_manager import EnabledExtensionManager
 from avocado.core.exceptions import JobTestSuiteReferenceResolutionError
+
+
+class ReferenceResolutionAssetType(Enum):
+    #: The actual test file.  Spawners may use this as the entry point
+    #: to run the tests.  Usually only one of this is given, and the
+    #: behavior with either a single or multiple items given is spawner
+    #: dependent.
+    TEST_FILE = "test_file"
+    #: Auxiliary data file placed alongside the test in a ".data"
+    #: directory
+    DATA_FILE = "data_file"
 
 
 class ReferenceResolutionResult(Enum):
@@ -187,6 +199,19 @@ def check_file(
         )
 
     return True
+
+
+def get_file_assets(test_file_path):
+    """Gets asset files from the test file and its the ".data" directory
+
+    :param test_file_path: the filesystem location of the test file
+    :type test_file_path: str
+    :returns: list of tuples with (asset type, path)
+    """
+    file_assets = [(ReferenceResolutionAssetType.TEST_FILE, test_file_path)]
+    for data_file in glob.glob(os.path.join(f"{test_file_path}.data", "*")):
+        file_assets.append((ReferenceResolutionAssetType.DATA_FILE, data_file))
+    return file_assets
 
 
 def _extend_directory(path):

--- a/avocado/plugins/resolvers.py
+++ b/avocado/plugins/resolvers.py
@@ -27,6 +27,7 @@ from avocado.core.resolver import (
     ReferenceResolution,
     ReferenceResolutionResult,
     check_file,
+    get_file_assets,
 )
 from avocado.core.safeloader import find_avocado_tests, find_python_unittests
 
@@ -50,7 +51,7 @@ class ExecTestResolver(Resolver):
         if criteria_check is not True:
             return criteria_check
 
-        runnable = Runnable("exec-test", reference)
+        runnable = Runnable("exec-test", reference, assets=get_file_assets(reference))
         return ReferenceResolution(
             reference, ReferenceResolutionResult.SUCCESS, [runnable]
         )
@@ -74,7 +75,15 @@ def python_resolver(name, reference, find_tests):
             if tests_filter is not None and not tests_filter.search(klass_method):
                 continue
             uri = f"{module_path}:{klass_method}"
-            runnables.append(Runnable(name, uri=uri, tags=tags, dependencies=depens))
+            runnables.append(
+                Runnable(
+                    name,
+                    uri=uri,
+                    tags=tags,
+                    dependencies=depens,
+                    assets=get_file_assets(module_path),
+                )
+            )
     if runnables:
         return ReferenceResolution(
             reference, ReferenceResolutionResult.SUCCESS, runnables
@@ -130,7 +139,7 @@ class TapResolver(Resolver):
         if criteria_check is not True:
             return criteria_check
 
-        runnable = Runnable("tap", reference)
+        runnable = Runnable("tap", reference, assets=get_file_assets(reference))
         return ReferenceResolution(
             reference, ReferenceResolutionResult.SUCCESS, [runnable]
         )

--- a/avocado/utils/ar.py
+++ b/avocado/utils/ar.py
@@ -50,7 +50,7 @@ class Ar:
         self._valid = False
 
     def __enter__(self):
-        self._file = open(self._path, "r+b")
+        self._file = open(self._path, "rb")
         return self._file
 
     def __exit__(self, _exc_type, _exc_value, _traceback):

--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -256,6 +256,43 @@ and transform the reference given into its **url**:
 
 .. literalinclude:: ../../../../../examples/plugins/tests/magic/avocado_magic/resolver.py
 
+Tests contained in files and associated data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``magic`` test does *not* depend on a file, only on the "magic" word
+(either "pass" or "fail").  Because of that, there's no need to
+provide information at resolution time about the file(s) comprising
+the magic tests.
+
+For most other test types, though, the test will be contained within a
+file, and/or may be comprised by many supplemental files containing
+test specific data.  While local execution of a test will easily find
+those files, in order to be prepared for the execution of a test in
+different environments (by different spawners), it's recommended that
+the resolver (and discoverer) provide that kind of information.
+
+A feature that is strongly recommended to be implemented by resolvers
+and discoverers of tests that are file-based is the ``.data``
+directory support.  Whenever a test contained in a file has a matching
+directory with the ``.data`` :data:`suffix
+<avocado.core.test.TestData.SUFFIX>`, the test can get quick access to
+these files with the :meth:`get_data
+<avocado.core.test.TestData.get_data>` method.
+
+To do so, use the ``assets`` keyword argument when creating
+:class:`Runnable <avocado.core.nrunner.runnable.Runnable>` instances.
+The ``assets`` keyword argument takes a list of tuples with ``(type,
+path)`` tuples, which will then be available at the :data:`Runnable
+<avocado.core.nrunner.runnable.Runnable.assets>` attribute.
+Actual examples are available in the implementation of the
+``exec-test`` and similar builtin resolvers.
+
+For the file that contains the test, it's recommended that resolvers
+and discoverers use the type
+:data:`avocado.core.resolver.ReferenceResolutionAssetType.TEST_FILE`.
+For other data files, use the
+:data:`avocado.core.resolver.ReferenceResolutionAssetType.DATA_FILE`.
+
 Runner example
 --------------
 

--- a/examples/tests/use_data.sh
+++ b/examples/tests/use_data.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+# A minimal test that depends on the presence of data files
+test -f "$(dirname $0)/$(basename $0).data/data"

--- a/optional_plugins/varianter_cit/tests/basic.py
+++ b/optional_plugins/varianter_cit/tests/basic.py
@@ -45,7 +45,7 @@ class Run(TestCaseTmpDir):
         )
         all_tests_content = b""
         for test_result_file in test_result_files:
-            with open(test_result_file, "r+b") as one_test_result:
+            with open(test_result_file, "rb") as one_test_result:
                 all_tests_content += one_test_result.read()
 
         # all values should be looked for at least once

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -679,7 +679,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         with open(json_path, encoding="utf-8") as json_file:
             result_json = json.load(json_file)
         with open(
-            result_json["tests"][0]["logfile"], "r+b"
+            result_json["tests"][0]["logfile"], "rb"
         ) as test_log_file:  # pylint: disable=W1514
             test_log = test_log_file.read()
 

--- a/selftests/functional/plugin/spawners/podman.py
+++ b/selftests/functional/plugin/spawners/podman.py
@@ -102,3 +102,17 @@ class PodmanSpawnerTest(Test):
         data_files = glob.glob(os.path.join(job.test_results_path, "1-*", "data", "*"))
         self.assertEqual(len(data_files), 1)
         self.assertTrue(data_files[0].endswith("test.json"))
+
+    def test_asset_files(self):
+        test = os.path.join(BASEDIR, "examples", "tests", "use_data.sh")
+        result = process.run(
+            f"{AVOCADO} run "
+            f"--job-results-dir {self.workdir} "
+            f"--disable-sysinfo --spawner=podman "
+            f"--spawner-podman-image=fedora:36 -- "
+            f"{test}",
+            ignore_status=True,
+        )
+        self.assertEqual(result.exit_status, 0)
+        self.assertIn("use_data.sh: STARTED", result.stdout_text)
+        self.assertIn("use_data.sh:  PASS", result.stdout_text)


### PR DESCRIPTION
So far, spawners that run tests in different environments have been mostly guessing about what the test constitutes.

This adds more responsibilities on the resolvers. If applicable, they can describe which files constitute the test, so that they will be deployed on the actual environment the test will be executed on.

---

Changes from v1 (#5633):
* Added documentation on how resolvers/discoverers should provide test data files information to spawners' use
* Improved portability by using `os.path.join` on the data files `glob.glob()` call