### PR TITLE
Present proper interrupt reason on KeyboardInterrupt/SIGINT

### DIFF
--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -6,6 +6,7 @@ from avocado.core.test_id import TestID
 
 
 class RuntimeTaskStatus(Enum):
+    INTERRUPTED = "FINISHED INTERRUPTED"
     WAIT_DEPENDENCIES = "WAITING DEPENDENCIES"
     WAIT = "WAITING"
     FINISHED = "FINISHED"

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -2,7 +2,6 @@ import asyncio
 import collections
 import logging
 import multiprocessing
-import sys
 import time
 
 from avocado.core.exceptions import TestFailFast
@@ -188,14 +187,13 @@ class Worker:
         for terminated_task in terminate_tasks:
             task_id = str(terminated_task.task.identifier)
             job_id = terminated_task.task.job_id
+            encoding = "utf-8"
             log_message = {
                 "status": "running",
                 "type": "log",
                 "log": f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | "
-                "Runner error occurred: Timeout reached".encode(
-                    sys.getdefaultencoding()
-                ),
-                "encoding": "utf-8",
+                "Runner error occurred: Timeout reached".encode(encoding),
+                "encoding": encoding,
                 "time": time.monotonic(),
                 "id": task_id,
                 "job_id": job_id,

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -175,7 +175,7 @@ class Worker:
             self._spawner, self._max_triaging, self._max_running, self._task_timeout
         )
 
-    async def _send_timeout_message(self, terminate_tasks):
+    async def _send_finished_tasks_message(self, terminate_tasks, reason):
         """Sends messages related to timeout to status repository.
         When the task is terminated, it is necessary to send a finish message to status
         repository to close logging. This method will send log message with timeout
@@ -192,7 +192,7 @@ class Worker:
                 "status": "running",
                 "type": "log",
                 "log": f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | "
-                "Runner error occurred: Timeout reached".encode(encoding),
+                f"Runner error occurred: {reason}".encode(encoding),
                 "encoding": encoding,
                 "time": time.monotonic(),
                 "id": task_id,
@@ -201,7 +201,7 @@ class Worker:
             finish_message = {
                 "status": "finished",
                 "result": "interrupted",
-                "fail_reason": "Test interrupted: Timeout reached",
+                "fail_reason": f"Test interrupted: {reason}",
                 "time": time.monotonic(),
                 "id": task_id,
                 "job_id": job_id,
@@ -361,9 +361,10 @@ class Worker:
                     remaining = runtime_task.execution_timeout - time.monotonic()
                 await asyncio.wait_for(self._spawner.wait_task(runtime_task), remaining)
             except asyncio.TimeoutError:
-                runtime_task.status = RuntimeTaskStatus.TIMEOUT
-                await self._spawner.terminate_task(runtime_task)
-                await self._send_timeout_message([runtime_task])
+                await self._terminate_task(runtime_task, RuntimeTaskStatus.TIMEOUT)
+                await self._send_finished_tasks_message(
+                    [runtime_task], "Timeout reached"
+                )
             async with self._state_machine.lock:
                 try:
                     self._state_machine.monitored.remove(runtime_task)
@@ -402,9 +403,12 @@ class Worker:
 
         await self._state_machine.finish_task(runtime_task, RuntimeTaskStatus.FINISHED)
 
-    async def terminate_tasks_timeout(self):
-        """Terminate all running tasks with timeout message."""
-        await self._state_machine.abort(RuntimeTaskStatus.TIMEOUT)
+    async def _terminate_task(self, runtime_task, task_status):
+        runtime_task.status = task_status
+        await self._spawner.terminate_task(runtime_task)
+
+    async def _terminate_tasks(self, task_status):
+        await self._state_machine.abort(task_status)
         terminated = []
         while True:
             is_complete = await self._state_machine.complete
@@ -414,10 +418,21 @@ class Worker:
                 except IndexError:
                     if is_complete:
                         break
-                runtime_task.status = RuntimeTaskStatus.TIMEOUT
-                await self._spawner.terminate_task(runtime_task)
+                await self._terminate_task(runtime_task, task_status)
                 terminated.append(runtime_task)
-        await self._send_timeout_message(terminated)
+        return terminated
+
+    async def terminate_tasks_timeout(self):
+        """Terminate all running tasks with a timeout message."""
+        task_status = RuntimeTaskStatus.TIMEOUT
+        terminated = await self._terminate_tasks(task_status)
+        await self._send_finished_tasks_message(terminated, "Timeout reached")
+
+    async def terminate_tasks_interrupted(self):
+        """Terminate all running tasks with an interrupted message."""
+        task_status = RuntimeTaskStatus.INTERRUPTED
+        terminated = await self._terminate_tasks(task_status)
+        await self._send_finished_tasks_message(terminated, "Interrupted by user")
 
     async def run(self):
         """Pushes Tasks forward and makes them do something with their lives."""

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -328,7 +328,7 @@ class Runner(SuiteRunner):
                         asyncio.shield(asyncio.gather(*workers)), job.timeout or None
                     )
                 )
-            except (KeyboardInterrupt, asyncio.TimeoutError):
+            except asyncio.TimeoutError:
                 terminate_worker = Worker(
                     state_machine=self.tsm,
                     spawner=spawner,
@@ -338,6 +338,20 @@ class Runner(SuiteRunner):
                 )
                 loop.run_until_complete(
                     asyncio.wait_for(terminate_worker.terminate_tasks_timeout(), None)
+                )
+                raise
+            except KeyboardInterrupt:
+                terminate_worker = Worker(
+                    state_machine=self.tsm,
+                    spawner=spawner,
+                    max_running=max_running,
+                    task_timeout=timeout,
+                    failfast=failfast,
+                )
+                loop.run_until_complete(
+                    asyncio.wait_for(
+                        terminate_worker.terminate_tasks_interrupted(), None
+                    )
                 )
                 raise
         except (KeyboardInterrupt, asyncio.TimeoutError, TestFailFast) as ex:

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -86,13 +86,6 @@ this does not help user can press ``ctrl+c`` again (after 2s grace period)
 which destroys the test's process ungracefully and safely finishes the job
 execution always providing the test results.
 
-To pause the test execution a user can use ``ctrl+z`` which sends ``SIGSTOP``
-to all processes inherited from the test's PID. We do our best to stop all
-processes, but the operation is not atomic and some new processes might not be
-stopped. Another ``ctrl+z`` sends ``SIGCONT`` to all processes inherited by the
-test's PID resuming the execution. Note the test execution time (concerning the
-test timeout) are still running while the test's process is stopped.
-
 Interrupting the job on first fail (failfast)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1415,12 +1415,6 @@ subprocesses we create before ending our execution.
 
 Signals sent to the Avocado main process will be handled as follows:
 
-- SIGSTP/Ctrl+Z: On SIGSTP, Avocado will pause the execution of the
-  subprocesses, while the main process will still be running,
-  respecting the timeout timer and waiting for the subprocesses to
-  finish. A new SIGSTP will make the subprocesses to resume the
-  execution.
-
 - SIGINT/Ctrl+C: This signal will be forwarded to the test process and
   Avocado will wait until it's finished. If the test process does not
   finish after receiving a SIGINT, user can send a second SIGINT (after

--- a/selftests/functional/interrupt.py
+++ b/selftests/functional/interrupt.py
@@ -207,11 +207,6 @@ class InterruptTest(TestCaseTmpDir):
         # Make sure the Interrupted test sentence is there
         self.assertIn(b"Terminated\n", proc.stdout.read())
 
-    @unittest.skip(
-        "Skip until "
-        "https://github.com/avocado-framework/avocado/issues/4994 "
-        "is implemented"
-    )
     @skipOnLevelsInferiorThan(2)
     def test_well_behaved_sigint(self):
         """
@@ -250,16 +245,6 @@ class InterruptTest(TestCaseTmpDir):
             wait.wait_for(self._no_test_in_process_table, timeout=10),
             "Avocado left processes behind.",
         )
-
-        output = proc.stdout.read()
-        # Make sure the Interrupted requested sentence is there
-        self.assertIn(
-            b"Interrupt requested. Waiting 2 seconds for test to "
-            b"finish (ignoring new Ctrl+C until then)",
-            output,
-        )
-        # Make sure the Killing test subprocess message is not there
-        self.assertNotIn(b"Killing test subprocess", output)
 
     @skipOnLevelsInferiorThan(2)
     def test_well_behaved_sigterm(self):


### PR DESCRIPTION
This adds a finer grained handling of the reason why a job is being interrupted, adding proper support for when the user interrupts it by pressing CTRL+C (KeyboardInterrupt) or sending a SIGINT signal.


Fixes: https://github.com/avocado-framework/avocado/issues/5560