### PR TITLE
Spawner: require runtime operation suitability

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -426,6 +426,16 @@ class Spawner(Plugin):
         :type result: `avocado.core.teststatus.STATUSES`
         """
 
+    @abc.abstractmethod
+    def is_operational(self):
+        """Checks whether this spawner is operationally capable to perform.
+
+        :result: whether or not this spawner is operational on this system,
+                 that is, whether it has all its requirements set up and
+                 should be ready to operate successfully.
+        :rtype: bool
+        """
+
 
 class DeploymentSpawner(Spawner):
     """Spawners that needs basic deployment are based on this class.

--- a/avocado/core/spawners/mock.py
+++ b/avocado/core/spawners/mock.py
@@ -17,6 +17,9 @@ class MockSpawner(Spawner):
     def __init__(self):  # pylint: disable=W0231
         self._known_tasks = {}
 
+    def is_operational(self):
+        return True
+
     def is_task_alive(self, runtime_task):  # pylint: disable=W0221
         alive = self._known_tasks.get(runtime_task, None)
         # task was never spawned

--- a/avocado/plugins/human.py
+++ b/avocado/plugins/human.py
@@ -140,7 +140,7 @@ class Human(ResultEvents):
             return
 
         if job.interrupted_reason is not None:
-            LOG_UI.info(job.interrupted_reason)
+            LOG_UI.warning(job.interrupted_reason)
 
         if job.status == "PASS":
             LOG_UI.info(

--- a/avocado/plugins/spawners/lxc.py
+++ b/avocado/plugins/spawners/lxc.py
@@ -105,6 +105,12 @@ class LXCSpawner(Spawner, SpawnerMixin):
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
     slots_cache = {}
 
+    def is_operational(self):
+        if not LXC_AVAILABLE:
+            LOG.error("LXC python bindings not available on the system")
+            return False
+        return True
+
     @staticmethod
     def run_container_cmd(container, command):
         with LXCStreamsFile() as tmp_out, LXCStreamsFile() as tmp_err:
@@ -208,11 +214,6 @@ class LXCSpawner(Spawner, SpawnerMixin):
         release = self.config.get("spawner.lxc.release")
         arch = self.config.get("spawner.lxc.arch")
         create_hook = self.config.get("spawner.lxc.create_hook")
-
-        if not LXC_AVAILABLE:
-            msg = "LXC python bindings not available on the system"
-            runtime_task.status = msg
-            return False
 
         container_id = runtime_task.spawner_handle
         container = lxc.Container(container_id)

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -138,6 +138,20 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             f'output received "{out}" does not match expected output'
         )
 
+    def is_operational(self):
+        try:
+            _ = self.podman_version
+        except PodmanException as ex:
+            LOG.error(ex)
+            return False
+
+        if self.podman_version[0] >= 3:
+            return True
+        LOG.error(
+            f"The podman binary f{self.podman_bin} did not report a suitable version (>= 3.0)"
+        )
+        return False
+
     @property
     def podman_version(self):
         if self._podman_version == (None, None, None):

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -33,6 +33,9 @@ class ProcessSpawner(Spawner, SpawnerMixin):
     description = "Process based spawner"
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
 
+    def is_operational(self):
+        return True
+
     @staticmethod
     def is_task_alive(runtime_task):
         if runtime_task.spawner_handle is None:

--- a/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
+++ b/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
@@ -68,6 +68,9 @@ class RemoteSpawner(Spawner, SpawnerMixin):
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
     slots_cache = {}
 
+    def is_operational(self):
+        return True
+
     @staticmethod
     async def run_remote_cmd_async(session, command, timeout):
         loop = asyncio.get_event_loop()

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -29,7 +29,7 @@ TEST_SIZE = {
     "nrunner-requirement": 16,
     "unit": 667,
     "jobs": 11,
-    "functional-parallel": 297,
+    "functional-parallel": 298,
     "functional-serial": 4,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -212,7 +212,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             f"--max-parallel-tasks=1"
         )
         result = process.run(cmd_line, ignore_status=True)
-        self.assertIn(b"Interrupting job (failfast).", result.stdout)
+        self.assertIn(b"Interrupting job (failfast).", result.stderr)
         self.assertIn(b"PASS 1 | ERROR 0 | FAIL 1 | SKIP 1", result.stdout)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.assertEqual(
@@ -230,7 +230,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             f"--max-parallel-tasks=1"
         )
         result = process.run(cmd_line, ignore_status=True)
-        self.assertIn(b"Interrupting job (failfast).", result.stdout)
+        self.assertIn(b"Interrupting job (failfast).", result.stderr)
         self.assertIn(b"PASS 1 | ERROR 1 | FAIL 0 | SKIP 1", result.stdout)
         expected_rc = exit_codes.AVOCADO_TESTS_FAIL | exit_codes.AVOCADO_JOB_INTERRUPTED
         self.assertEqual(

--- a/selftests/functional/plugin/spawners/podman.py
+++ b/selftests/functional/plugin/spawners/podman.py
@@ -2,6 +2,7 @@ import glob
 import os
 
 from avocado import Test
+from avocado.core import exit_codes
 from avocado.core.job import Job
 from avocado.utils import process, script
 from selftests.utils import AVOCADO, BASEDIR
@@ -116,3 +117,18 @@ class PodmanSpawnerTest(Test):
         self.assertEqual(result.exit_status, 0)
         self.assertIn("use_data.sh: STARTED", result.stdout_text)
         self.assertIn("use_data.sh:  PASS", result.stdout_text)
+
+
+class OperationalTest(Test):
+    def test_not_operational(self):
+        fake_podman_bin = os.path.join(BASEDIR, "examples", "tests", "false")
+        result = process.run(
+            f"{AVOCADO} run "
+            f"--job-results-dir {self.workdir} "
+            f"--disable-sysinfo --spawner=podman "
+            f"--spawner-podman-bin={fake_podman_bin} "
+            f"-- examples/tests/true",
+            ignore_status=True,
+        )
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_INTERRUPTED)
+        self.assertIn('Spawner "podman" is not operational', result.stderr_text)


### PR DESCRIPTION
This adds a new mandatory method to spawners: is_operational().  The goal of this method is to signal to the execution of the test suite whether the spawner is fully set up and capable to operate.  This will of course, depend on the spawner implementation and requirements.

In the case of the podman spawner, often times jobs configured to use that spawner will succeed, when they actually need to signal a failure.  This is what happens on a system without a working podman installation:

```
   # avocado run --spawner=podman -- /bin/true
   JOB ID     : daf6869a348f14c52460adc6f18f89f35f8d6ecd
   JOB LOG    : /root/avocado/job-results/job-2023-04-14T20.57-daf6869/job.log
   RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 1 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB TIME   : 0.32 s
   [root@22d3a3b15197 ~]# echo $?
   0
```

Clearly, test workflows depending on the tests errouneously succeed. With this change, an error is reported both on the logs/UI and on the exit code.