### PR TITLE
Logging: remove avocado.app.debug / AVOCADO_LOG_DEBUG

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -43,7 +43,6 @@ jobs:
         run: python -m avocado run  examples/tests/passtest.py
       - name: Tree static check, unittests and fast functional tests
         run: |
-          export AVOCADO_LOG_DEBUG="yes"
           export AVOCADO_CHECK_LEVEL="1"
           python3 selftests/check.py
       - name: Archive test logs
@@ -86,7 +85,6 @@ jobs:
         run: avocado --version
       - name: Tree static check, unittests and fast functional tests without plugins
         run: |
-          export AVOCADO_LOG_DEBUG="yes"
           export AVOCADO_CHECK_LEVEL="1"
           python3 selftests/check.py --disable-plugin-checks golang,html,resultsdb,result_upload,robot,varianter_cit,varianter_pict,varianter_yaml_to_mux
       - name: Archive test logs

--- a/avocado/core/extension_manager.py
+++ b/avocado/core/extension_manager.py
@@ -189,13 +189,13 @@ class ExtensionManager:
             except KeyboardInterrupt:
                 raise
             except:  # catch any exception pylint: disable=W0702
-                stacktrace.log_exc_info(sys.exc_info(), logger="avocado.app.debug")
                 LOG_UI.error(
                     'Error running method "%s" of plugin "%s": %s',
                     method_name,
                     ext.name,
                     sys.exc_info()[1],
                 )
+                stacktrace.log_exc_info(sys.exc_info(), logger=LOG_UI)
         return ret
 
     def map_method(self, method_name, *args):
@@ -215,13 +215,13 @@ class ExtensionManager:
             except KeyboardInterrupt:
                 raise
             except:  # catch any exception pylint: disable=W0702
-                stacktrace.log_exc_info(sys.exc_info(), logger="avocado.app.debug")
                 LOG_UI.error(
                     'Error running method "%s" of plugin "%s": %s',
                     method_name,
                     ext.name,
                     sys.exc_info()[1],
                 )
+                stacktrace.log_exc_info(sys.exc_info(), logger=LOG_UI)
 
     def __getitem__(self, name):
         for ext in self.extensions:

--- a/avocado/core/main.py
+++ b/avocado/core/main.py
@@ -42,28 +42,25 @@ def get_crash_dir():
 
 
 def handle_exception(*exc_info):
-    # Print traceback if AVOCADO_LOG_DEBUG environment variable is set
-    msg = "Avocado crashed:\n" + "".join(traceback.format_exception(*exc_info))
-    msg += "\n"
-    if os.environ.get("AVOCADO_LOG_DEBUG"):
-        os.write(2, msg.encode("utf-8"))
+    tb = "".join(traceback.format_exception(*exc_info))
     # Store traceback in data_dir or TMPDIR
     prefix = "avocado-traceback-"
     prefix += time.strftime("%F_%T") + "-"
     tmp, name = tempfile.mkstemp(".log", prefix, get_crash_dir())
-    os.write(tmp, msg.encode("utf-8"))
+    os.write(tmp, tb.encode("utf-8"))
     os.close(tmp)
     if exc_info[0] is KeyboardInterrupt:
-        msg = f"{exc_info[0].__doc__}\nYou can find details in {name}\n"
+        os.write(
+            2,
+            f"{exc_info[0].__doc__}\nYou can find details in {name}\n".encode("utf-8"),
+        )
         exit_code = exit_codes.AVOCADO_JOB_INTERRUPTED
     else:
-        # Print friendly message in console-like output
-        msg = (
-            f"Avocado crashed unexpectedly: {exc_info[1]}\n"
-            f"You can find details in {name}\n"
-        )
+        # Print friendly message and traceback in console-like output
+        os.write(2, f"Avocado crashed unexpectedly: {exc_info[1]}\n".encode("utf-8"))
+        os.write(2, tb.encode("utf-8"))
+        os.write(2, f"\nYou can also find details in {name}\n".encode("utf-8"))
         exit_code = exit_codes.AVOCADO_GENERIC_CRASH
-    os.write(2, msg.encode("utf-8"))
     sys.exit(exit_code)
 
 

--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -366,9 +366,7 @@ class StdOutput:
             paginator = Paginator()
         except RuntimeError as details:
             # Paginator not available
-            logging.getLogger("avocado.app.debug").error(
-                "Failed to enable paginator: %s", details
-            )
+            LOG_UI.error("Failed to enable paginator: %s", details)
             return
         self.stdout = self.stderr = paginator
         self.__configured = True
@@ -401,10 +399,6 @@ def early_start():
     """
     Replace all outputs with in-memory handlers
     """
-    if os.environ.get("AVOCADO_LOG_DEBUG"):
-        add_log_handler(
-            LOG_UI.getChild("debug"), logging.StreamHandler, sys.stdout, logging.DEBUG
-        )
     if os.environ.get("AVOCADO_LOG_EARLY"):
         add_log_handler("avocado", logging.StreamHandler, sys.stdout, logging.DEBUG)
         add_log_handler(LOG_JOB, logging.StreamHandler, sys.stdout, logging.DEBUG)
@@ -460,8 +454,6 @@ def reconfigure(args):
         enabled.update(BUILTIN_STREAMS)
     if os.environ.get("AVOCADO_LOG_EARLY"):
         enabled.add("early")
-    if os.environ.get("AVOCADO_LOG_DEBUG"):
-        enabled.add("debug")
     # TODO: Avocado relies on stdout/stderr on some places, re-log them here
     # for now. This should be removed once we replace them with logging.
     if enabled:
@@ -503,15 +495,6 @@ def reconfigure(args):
             save_handler(LOG_JOB.name, handler, configuration)
         else:
             disable_log_handler("avocado")
-    # Not enabled by env
-    if not os.environ.get("AVOCADO_LOG_DEBUG"):
-        if "debug" in enabled:
-            handler = add_log_handler(
-                LOG_UI.getChild("debug"), stream=STD_OUTPUT.stdout
-            )
-            save_handler(LOG_UI.getChild("debug").name, handler, configuration)
-        else:
-            disable_log_handler(LOG_UI.getChild("debug"))
 
     # Add custom loggers
     for name in [_ for _ in enabled if _ not in BUILTIN_STREAMS]:

--- a/docs/source/guides/contributor/chapters/tips.rst
+++ b/docs/source/guides/contributor/chapters/tips.rst
@@ -28,10 +28,10 @@ During the execution look for::
 
 .. note::
    If you are running a test with Avocado, and want to measure the duration
-   of a method/function, make sure to enable the `debug` logging stream.
-   Example::
+   of a method/function, make sure to enable the `avocado.utils.debug`
+   logging stream. Example::
 
-    avocado --show avocado.app.debug run examples/tests/assets.py
+    avocado --show avocado.utils.debug run examples/tests/assets.py
 
 Line-profiler
 -------------

--- a/docs/source/guides/user/chapters/logging.rst
+++ b/docs/source/guides/user/chapters/logging.rst
@@ -19,7 +19,6 @@ streams) are listed below:
 
 :app: The text based UI (avocado.app)
 :test: Output of the executed tests (avocado.test, "")
-:debug: Messages useful to debug the Avocado Framework (avocado.app.debug)
 :early: Early logging before the logging system is set. It includes the test
         output and lots of output produced by used libraries. ("",
         avocado.test)


### PR DESCRIPTION
The "avocado.app.debug" is an opt-in that, by default, keeps the Avocado UI cleaner.  While there's a point to it, I believe it's not a strong reason for having this extra logger, because:
    
1) Avocado is executed in remote environments very often, and when a crash occurs, it's very useful to have all possible debugging information shown by default.
    
2) The logger is used on a very limited number of places and does not warrant the extra logic.
    
With this change, the extra debugging information (such as tracebacks) are given by default on the user UI.  If, for some reason, users begin to complain too much about this new behavior, one possibility may be to omit this information if the standard output is a TTY.