### PR TITLE
Runnable log_dir and sysinfo support

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -119,7 +119,7 @@ class StartMessageHandler(BaseMessageHandler):
         """
         task_id = TestID.from_identifier(task.identifier)
         base_path = job.test_results_path
-        task_path = os.path.join(base_path, task_id.str_filesystem)
+        task_path = task.runnable.output_dir
         logfile = os.path.join(task_path, DEFAULT_LOG_FILE)
         os.makedirs(task_path, exist_ok=True)
         params = []
@@ -131,7 +131,6 @@ class StartMessageHandler(BaseMessageHandler):
                 for param in params[1]
             ]
 
-        open(logfile, "w", encoding="utf-8").close()
         metadata = {
             "job_logdir": job.logdir,
             "job_unique_id": job.unique_id,

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -1,8 +1,6 @@
 import enum
-import os
 
 from avocado.core.settings import settings
-from avocado.core.spawners.exceptions import SpawnerException
 
 
 class SpawnMethod(enum.Enum):
@@ -32,8 +30,4 @@ class SpawnerMixin:
         self._job = job
 
     def task_output_dir(self, runtime_task):
-        if self._job is None:
-            raise SpawnerException("Job wasn't set properly")
-        return os.path.join(
-            self._job.test_results_path, runtime_task.task.identifier.str_filesystem
-        )
+        return runtime_task.task.runnable.output_dir

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -1,3 +1,4 @@
+import os
 from enum import Enum
 
 from avocado.core.dispatcher import TestPostDispatcher, TestPreDispatcher
@@ -35,6 +36,7 @@ class RuntimeTaskMixin:
         runnable,
         no_digits,
         index,
+        base_dir,
         test_suite_name=None,
         status_server_uri=None,
         job_id=None,
@@ -48,6 +50,8 @@ class RuntimeTaskMixin:
         :type no_digits: int
         :param index: index of tests inside test suite
         :type index: int
+        :param base_dir: Path to the job base directory.
+        :type base_dir: str
         :param test_suite_name: test suite name which this test is related to
         :type test_suite_name: str
         :param status_server_uri: the URIs for the status servers that this
@@ -75,6 +79,8 @@ class RuntimeTaskMixin:
 
         test_id = TestID(prefix, name, runnable.variant, no_digits)
 
+        if not runnable.output_dir:
+            runnable.output_dir = os.path.join(base_dir, test_id.str_filesystem)
         # handles the test task
         task = Task(
             runnable,
@@ -179,6 +185,7 @@ class PrePostRuntimeTaskMixin(RuntimeTask):
         cls,
         test_task,
         no_digits,
+        base_dir,
         test_suite_name=None,
         status_server_uri=None,
         job_id=None,
@@ -190,6 +197,8 @@ class PrePostRuntimeTaskMixin(RuntimeTask):
         :type test_task: :class:`avocado.core.task.runtime.RuntimeTask`
         :param no_digits: number of digits of the test uid
         :type no_digits: int
+        :param base_dir: Path to the job base directory.
+        :type base_dir: str
         :param test_suite_name: test suite name which this test is related to
         :type test_suite_name: str
         :param status_server_uri: the URIs for the status servers that this
@@ -221,6 +230,7 @@ class PrePostRuntimeTaskMixin(RuntimeTask):
                     runnable,
                     no_digits,
                     prefix,
+                    base_dir,
                     test_suite_name,
                     status_server_uri,
                     job_id,
@@ -249,7 +259,13 @@ class RuntimeTaskGraph:
     """Graph representing dependencies between runtime tasks."""
 
     def __init__(
-        self, tests, test_suite_name, status_server_uri, job_id, suite_config=None
+        self,
+        tests,
+        test_suite_name,
+        status_server_uri,
+        job_id,
+        base_dir,
+        suite_config=None,
     ):
         """Instantiates a new RuntimeTaskGraph.
 
@@ -267,6 +283,8 @@ class RuntimeTaskGraph:
                        sent to the destination job's status server and will
                        make into the job's results.
         :type job_id: str
+        :param base_dir: Path to the job base directory.
+        :type base_dir: str
         :param suite_config: Configuration dict relevant for the whole suite.
         :type suite_config: dict
         """
@@ -278,6 +296,7 @@ class RuntimeTaskGraph:
                 runnable,
                 no_digits,
                 index,
+                base_dir,
                 test_suite_name,
                 status_server_uri,
                 job_id,
@@ -289,6 +308,7 @@ class RuntimeTaskGraph:
                 tasks = PreRuntimeTask.get_tasks_from_test_task(
                     runtime_test,
                     no_digits,
+                    base_dir,
                     test_suite_name,
                     status_server_uri,
                     job_id,
@@ -298,6 +318,7 @@ class RuntimeTaskGraph:
                 tasks = tasks + PostRuntimeTask.get_tasks_from_test_task(
                     runtime_test,
                     no_digits,
+                    base_dir,
                     test_suite_name,
                     status_server_uri,
                     job_id,

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -286,6 +286,7 @@ class Runner(SuiteRunner):
             test_suite.name,
             self._determine_status_server(test_suite, "run.status_server_uri"),
             job.unique_id,
+            job.test_results_path,
             test_suite.config,
         )
         # pylint: disable=W0201

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -14,10 +14,18 @@
 """
 System information plugin
 """
-
 from avocado.core import sysinfo
-from avocado.core.plugin_interfaces import CLICmd, Init, JobPostTests, JobPreTests
+from avocado.core.nrunner.runnable import Runnable
+from avocado.core.plugin_interfaces import (
+    CLICmd,
+    Init,
+    JobPostTests,
+    JobPreTests,
+    PostTest,
+    PreTest,
+)
 from avocado.core.settings import settings
+from avocado.core.teststatus import STATUSES_NOT_OK
 from avocado.core.utils.path import prepend_base_path, system_wide_or_base_path
 from avocado.utils import path
 
@@ -36,6 +44,18 @@ class SysinfoInit(Init):
             section="sysinfo.collect",
             key="enabled",
             default=True,
+            key_type=bool,
+            help_msg=help_msg,
+        )
+
+        help_msg = (
+            "Enable or disable sysinfo collection (like hardware "
+            "details, profiles, etc.) for each test"
+        )
+        settings.register_option(
+            section="sysinfo.collect",
+            key="per_test",
+            default=False,
             key_type=bool,
             help_msg=help_msg,
         )
@@ -175,6 +195,72 @@ class SysInfoJob(JobPreTests, JobPostTests):
             return
         self._init_sysinfo(job.logdir)
         self.sysinfo.end()
+
+
+class SysInfoTest(PreTest, PostTest):
+    """Implements the sysinfo pre/post test plugin.
+
+    It will create pre/post-test tasks for collecting system information.
+    """
+
+    name = "sysinfo"
+    description = "Collects system information before/after the test is run."
+
+    def _is_sysinfo_enabled(self, config):
+        if not (
+            config.get("sysinfo.collect.enabled")
+            and config.get("sysinfo.collect.per_test")
+        ):
+            return False
+        return True
+
+    def pre_test_runnables(self, test_runnable, suite_config=None):
+        suite_config = suite_config or {}
+        if not self._is_sysinfo_enabled(suite_config):
+            return []
+        sysinfo_config = sysinfo.gather_collectibles_config(suite_config)
+        return [
+            Runnable.from_avocado_config(
+                "sysinfo",
+                "pre",
+                config=suite_config,
+                name="pre",
+                sysinfo=sysinfo_config,
+                output_dir=test_runnable.output_dir,
+            )
+        ]
+
+    def post_test_runnables(self, test_runnable, suite_config=None):
+        suite_config = suite_config or {}
+        if not self._is_sysinfo_enabled(suite_config):
+            return []
+        sysinfo_config = sysinfo.gather_collectibles_config(suite_config)
+        return [
+            (
+                Runnable.from_avocado_config(
+                    "sysinfo",
+                    "post",
+                    config=suite_config,
+                    name="post",
+                    sysinfo=sysinfo_config,
+                    test_fail=False,
+                    output_dir=test_runnable.output_dir,
+                ),
+                ["pass"],
+            ),
+            (
+                Runnable.from_avocado_config(
+                    "sysinfo",
+                    "post",
+                    config=suite_config,
+                    name="post",
+                    sysinfo=sysinfo_config,
+                    test_fail=True,
+                    output_dir=test_runnable.output_dir,
+                ),
+                [status.lower() for status in STATUSES_NOT_OK],
+            ),
+        ]
 
 
 class SysInfo(CLICmd):

--- a/selftests/unit/task_runtime.py
+++ b/selftests/unit/task_runtime.py
@@ -66,7 +66,7 @@ class DependencyGraph(TestCaseTmpDir):
             config = {"resolver.references": [test.path]}
             suite = TestSuite.from_config(config=config)
             tests = suite.tests
-            graph = RuntimeTaskGraph(tests, suite.name, 1, "")
+            graph = RuntimeTaskGraph(tests, suite.name, 1, "", "")
             runtime_tests = graph.get_tasks_in_topological_order()
             self.assertTrue(runtime_tests[0].task.identifier.name.endswith("test_a"))
             self.assertTrue(runtime_tests[1].task.identifier.name.endswith("hello"))
@@ -82,7 +82,7 @@ class DependencyGraph(TestCaseTmpDir):
             config = {"resolver.references": [test.path]}
             suite = TestSuite.from_config(config=config)
             tests = suite.tests
-            graph = RuntimeTaskGraph(tests, suite.name, 1, "")
+            graph = RuntimeTaskGraph(tests, suite.name, 1, "", "")
             runtime_tests = graph.get_tasks_in_topological_order()
             self.assertTrue(runtime_tests[0].task.identifier.name.endswith("hello"))
             self.assertTrue(runtime_tests[1].task.identifier.name.endswith("test_a"))

--- a/setup.py
+++ b/setup.py
@@ -404,6 +404,10 @@ if __name__ == "__main__":
             ],
             "avocado.plugins.test.pre": [
                 "dependency = avocado.plugins.dependency:DependencyResolver",
+                "sysinfo = avocado.plugins.sysinfo:SysInfoTest",
+            ],
+            "avocado.plugins.test.post": [
+                "sysinfo = avocado.plugins.sysinfo:SysInfoTest",
             ],
             "avocado.plugins.result": [
                 "xunit = avocado.plugins.xunit:XUnitResult",


### PR DESCRIPTION
This PR introduces the ability for Runnable to specify the output_dir. Because of this, the Tasks will be able to share the output directory. Since this was the last piece which has been missing for sysinfo support, this PR also enables sysinfo per test.

Reference: #5647, #3877
Signed-off-by: Jan Richter <jarichte@redhat.com>