### PR TITLE
examples/tests/test_env.py: protect against lack of isatty()

### DIFF
--- a/examples/tests/test_env.py
+++ b/examples/tests/test_env.py
@@ -29,7 +29,11 @@ class Env(Test):
         def log_std_io(name, std_io):
             self.log.debug("%s:", name.upper())
             self.log.debug(" sys.%s: %s", name, std_io)
-            self.log.debug(" sys.%s is a tty: %s", name, std_io.isatty())
+            self.log.debug(
+                " sys.%s is a tty: %s",
+                name,
+                hasattr(std_io, "isatty") and std_io.isatty(),
+            )
             if hasattr(std_io, "fileno"):
                 self.log.debug(" fd: %s", std_io.fileno())
                 self.log.debug(" fd is tty: %s", os.isatty(std_io.fileno()))


### PR DESCRIPTION
Instances of avocado.core.utils.messages.StreamToQueue do not have a isatty() method.  Even if we end up implementing it, it's a good idea to protect the test against the lack of such an interface.

Fixes: https://github.com/avocado-framework/avocado/issues/5659