### PR TITLE
setup.py: Add dependency for ansible plugin 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,3 +30,6 @@ jsonschema==3.2.0
 
 # For ansible plugin nested dep, compatible with Python 3.6
 setuptools_rust==1.1.2
+
+# For ansible plugin nested dep
+cryptography==41.0.2


### PR DESCRIPTION
Add cryptography distribution. Without it, ansible plugin setup
will fail.


Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>