### PR TITLE
Assets plugin: do not assume assigments have ids

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -189,8 +189,11 @@ class FetchAssetHandler(ast.NodeVisitor):  # pylint: disable=R0902
                 # otherwise, save the local variable name
                 if isinstance(node.targets[0], ast.Attribute):
                     name = node.targets[0].attr
-                else:
+                elif hasattr(node.targets[0], "id"):
                     name = node.targets[0].id
+                else:
+                    self.generic_visit(node)
+                    return
 
                 if isinstance(node.value, ast.Str):
                     self.asgmts[cur_klass][cur_method][name] = node.value.s

--- a/selftests/unit/plugin/assets.py
+++ b/selftests/unit/plugin/assets.py
@@ -40,7 +40,7 @@ class AssetsPlugin(unittest.TestCase):
                 True,
                 OSError("Failed to fetch fail.tar.gz."),
             ]
-            success, fail = assets.fetch_assets("test.py")
+            success, fail = assets.fetch_assets("test.py", {})
         expected_success = ["success.tar.gz"]
         expected_fail_exception = OSError
         self.assertEqual(expected_success, success)
@@ -62,7 +62,7 @@ class AssetsPlugin(unittest.TestCase):
         ]
         with patch("avocado.plugins.assets.Asset") as mocked_asset:
             mocked_asset.return_value.fetch.side_effect = [True]
-            success, fail = assets.fetch_assets("test.py")
+            success, fail = assets.fetch_assets("test.py", {})
         expected_success = ["success.tar.gz"]
         expected_fail = []
         self.assertEqual(expected_success, success)
@@ -86,7 +86,7 @@ class AssetsPlugin(unittest.TestCase):
             mocked_asset.return_value.fetch.side_effect = [
                 OSError("Failed to fetch fail.tar.gz.")
             ]
-            success, fail = assets.fetch_assets("test.py")
+            success, fail = assets.fetch_assets("test.py", {})
         expected_success = []
         expected_fail_exception = OSError
         self.assertEqual(expected_success, success)
@@ -98,7 +98,7 @@ class AssetsPlugin(unittest.TestCase):
         Exercise a normal fetch_assets for an empty `calls` variable.
         """
         mocked_fetch_asset_handler.return_value.calls = []
-        success, fail = assets.fetch_assets("test.py")
+        success, fail = assets.fetch_assets("test.py", {})
         expected_success = []
         expected_fail = []
         self.assertEqual(expected_success, success)
@@ -139,7 +139,7 @@ class AssetsClass(unittest.TestCase):
             with patch.object(assets.ast, "parse"):
                 with patch.object(assets.FetchAssetHandler, "visit"):
                     with patch.object(assets.FetchAssetHandler, "generic_visit"):
-                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler = assets.FetchAssetHandler("fake_file.py", {})
                         handler.visit_ClassDef(node)
                         self.assertEqual(handler.current_klass, "FetchAssets")
 
@@ -155,7 +155,7 @@ class AssetsClass(unittest.TestCase):
             with patch.object(assets.ast, "parse"):
                 with patch.object(assets.FetchAssetHandler, "visit"):
                     with patch.object(assets.FetchAssetHandler, "generic_visit"):
-                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler = assets.FetchAssetHandler("fake_file.py", {})
                         handler.visit_ClassDef(node)
                         self.assertTrue((handler.current_klass is None))
 
@@ -173,7 +173,7 @@ class AssetsClass(unittest.TestCase):
             with patch.object(assets.ast, "parse"):
                 with patch.object(assets.FetchAssetHandler, "visit"):
                     with patch.object(assets.FetchAssetHandler, "generic_visit"):
-                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler = assets.FetchAssetHandler("fake_file.py", {})
                         handler.visit_ClassDef(node_class)
                         handler.visit_FunctionDef(node_function)
                         self.assertEqual(handler.current_method, expected_method)
@@ -190,7 +190,7 @@ class AssetsClass(unittest.TestCase):
             with patch.object(assets.ast, "parse"):
                 with patch.object(assets.FetchAssetHandler, "visit"):
                     with patch.object(assets.FetchAssetHandler, "generic_visit"):
-                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler = assets.FetchAssetHandler("fake_file.py", {})
                         handler.visit_FunctionDef(node)
                         self.assertTrue((handler.current_method is None))
 
@@ -209,7 +209,7 @@ class AssetsClass(unittest.TestCase):
             with patch.object(assets.ast, "parse"):
                 with patch.object(assets.FetchAssetHandler, "visit"):
                     with patch.object(assets.FetchAssetHandler, "generic_visit"):
-                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler = assets.FetchAssetHandler("fake_file.py", {})
                         handler.visit_ClassDef(node_class)
                         handler.visit_FunctionDef(node_function)
                         handler.visit_Assign(node_assign)
@@ -234,7 +234,7 @@ class AssetsClass(unittest.TestCase):
             with patch.object(assets.ast, "parse"):
                 with patch.object(assets.FetchAssetHandler, "visit"):
                     with patch.object(assets.FetchAssetHandler, "generic_visit"):
-                        handler = assets.FetchAssetHandler("fake_file.py")
+                        handler = assets.FetchAssetHandler("fake_file.py", {})
                         handler.visit_Assign(node)
                         self.assertTrue((handler.current_method is None))
 


### PR DESCRIPTION
Some "left hand side" part of assigments won't always have an id. This is the case of a Subscript, that exist in assignments such as:

  foo["bar"] = "baz"

Instead of attempting to deal with each type of "left hand side" here, let's check for the existence of an "id" attribute, and back off if it doesn't exist.

Reference: https://docs.python.org/3/library/ast.html#ast.Subscript
Fixes: https://github.com/avocado-framework/avocado/issues/5415