### PR TITLE
DependencyResolver output fix

### DIFF
--- a/avocado/plugins/dependency.py
+++ b/avocado/plugins/dependency.py
@@ -41,7 +41,12 @@ class DependencyResolver(PreTest):
             uri = dependency_copy.pop("uri", None)
             args = dependency_copy.pop("args", ())
             dependency_runnable = Runnable(
-                kind, uri, *args, config=test_runnable.config, **dependency_copy
+                kind,
+                uri,
+                *args,
+                config=test_runnable.config,
+                output_dir=test_runnable.output_dir,
+                **dependency_copy
             )
             dependency_runnables.append(dependency_runnable)
         return dependency_runnables

--- a/selftests/functional/serial/requirements.py
+++ b/selftests/functional/serial/requirements.py
@@ -137,6 +137,12 @@ class BasicTest(Test):
                 "bash",
                 result.stdout_text,
             )
+            test_results_path = os.path.join(self.workdir, "latest", "test-results")
+            self.assertEqual(
+                len(os.listdir(test_results_path)),
+                2,
+                "DependencyResolver created unwanted result directories.",
+            )
 
     @skipUnless(os.getenv("CI"), skip_package_manager_message)
     def test_single_fail(self):


### PR DESCRIPTION
The `DependencyResolver` task created its own output directory in `test-results` dir. This will connect outputs of the Test task and its `DependencyResolver` task, so both of those tasks will have output in the one directory together.

Reference: #5671