### PR TITLE
Restore LXC spawner task output path handling

### DIFF
--- a/avocado/plugins/spawners/lxc.py
+++ b/avocado/plugins/spawners/lxc.py
@@ -265,7 +265,10 @@ class LXCSpawner(Spawner, SpawnerMixin):
 
     def create_task_output_dir(self, runtime_task):
         output_dir_path = self.task_output_dir(runtime_task)
-        runtime_task.task.setup_output_dir(output_dir_path)
+        output_lxc_path = "/tmp/.avocado_task_output_dir"
+
+        os.makedirs(output_dir_path, exist_ok=True)
+        runtime_task.task.setup_output_dir(output_lxc_path)
 
     async def wait_task(self, runtime_task):
         while True:


### PR DESCRIPTION
Before this adaptation we get simple avocado runs to result in
```
[root@c5 site-packages]# avocado run --status-server-disable-auto --spawner=lxc -- /bin/true
JOB ID     : 937ec5bb7275feabd48fcf5b5b315ad2cd2b63fc
JOB LOG    : /mnt/local/results/job-2023-05-02T22.51-937ec5b/job.log
 (1/1) /bin/true: STARTED
 (1/1) /bin/true: ERROR: [Errno 2] No such file or directory: '/mnt/local/results/job-2023-05-02T22.51-937ec5b/test-results/1-_bin_true/stdout' (0.00 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /mnt/local/results/job-2023-05-02T22.51-937ec5b/results.html
JOB TIME   : 2.69 s
```
while after this fix we finally get
```
[root@c5 site-packages]# avocado run --status-server-disable-auto --spawner=lxc -- /bin/true
JOB ID     : 1b736d172710a2d0d85d63b181cd65d0bc8ff518
JOB LOG    : /mnt/local/results/job-2023-05-02T22.54-1b736d1/job.log
 (1/1) /bin/true: STARTED
 (1/1) /bin/true: PASS (0.01 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /mnt/local/results/job-2023-05-02T22.54-1b736d1/results.html
JOB TIME   : 2.66 s
```

Note that all of this requires mounting the results directory into the LXC container, similarly to the way it is done for podman containers.