### PR TITLE
Improve portability on Darwin/macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       - name: List test
         run: python -m avocado --verbose list selftests/unit/* selftests/functional/* selftests/*sh
       - name: Run a subset of avocado's selftests
-        run: PATH=~/Library/Python/3.11/bin:$PATH ./selftests/check.py --select=nrunner-interface,job-api,jobs,optional-plugins
+        run: PATH=~/Library/Python/3.11/bin:$PATH ./selftests/check.py --skip=static-checks
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
 

--- a/avocado/core/main.py
+++ b/avocado/core/main.py
@@ -12,6 +12,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
+import multiprocessing
 import os
 import sys
 import tempfile
@@ -65,6 +66,9 @@ def handle_exception(*exc_info):
 
 
 def main():
+    if sys.platform == "darwin":
+        multiprocessing.set_start_method("fork")
+
     sys.excepthook = handle_exception
     from avocado.core.app import AvocadoApp  # pylint: disable=E0611
 

--- a/avocado/plugins/runners/asset.py
+++ b/avocado/plugins/runners/asset.py
@@ -1,5 +1,6 @@
+import sys
 import time
-from multiprocessing import Process, SimpleQueue
+from multiprocessing import Process, SimpleQueue, set_start_method
 
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.nrunner.runner import RUNNER_RUN_STATUS_INTERVAL, BaseRunner
@@ -116,6 +117,8 @@ class RunnerApp(BaseRunnerApp):
 
 
 def main():
+    if sys.platform == "darwin":
+        set_start_method("fork")
     app = RunnerApp(print)
     app.run()
 

--- a/avocado/plugins/runners/avocado_instrumented.py
+++ b/avocado/plugins/runners/avocado_instrumented.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import sys
 import tempfile
 import time
 import traceback
@@ -190,6 +191,8 @@ class RunnerApp(BaseRunnerApp):
 
 
 def main():
+    if sys.platform == "darwin":
+        multiprocessing.set_start_method("fork")
     app = RunnerApp(print)
     app.run()
 

--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -1,6 +1,8 @@
+import multiprocessing
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 
 import pkg_resources
@@ -205,6 +207,8 @@ class RunnerApp(BaseRunnerApp):
 
 
 def main():
+    if sys.platform == "darwin":
+        multiprocessing.set_start_method("fork")
     app = RunnerApp(print)
     app.run()
 

--- a/avocado/plugins/runners/package.py
+++ b/avocado/plugins/runners/package.py
@@ -93,6 +93,7 @@ class PackageRunner(BaseRunner):
                 "stderr": ("Package manager not supported or not available."),
             }
             queue.put(output)
+            return
 
         if cmd == "install":
             result, stdout, stderr = self._install(software_manager, cmd, package)

--- a/avocado/plugins/runners/package.py
+++ b/avocado/plugins/runners/package.py
@@ -90,7 +90,7 @@ class PackageRunner(BaseRunner):
             output = {
                 "result": "error",
                 "stdout": "",
-                "stderr": ("Package manager not supported or not" " available."),
+                "stderr": ("Package manager not supported or not available."),
             }
             queue.put(output)
 

--- a/avocado/plugins/runners/package.py
+++ b/avocado/plugins/runners/package.py
@@ -1,5 +1,6 @@
+import sys
 import time
-from multiprocessing import Process, SimpleQueue
+from multiprocessing import Process, SimpleQueue, set_start_method
 
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.nrunner.runner import RUNNER_RUN_STATUS_INTERVAL, BaseRunner
@@ -162,6 +163,8 @@ class RunnerApp(BaseRunnerApp):
 
 
 def main():
+    if sys.platform == "darwin":
+        set_start_method("fork")
     app = RunnerApp(print)
     app.run()
 

--- a/avocado/plugins/runners/podman_image.py
+++ b/avocado/plugins/runners/podman_image.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
+import sys
 import time
-from multiprocessing import Process, SimpleQueue
+from multiprocessing import Process, SimpleQueue, set_start_method
 
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.nrunner.runner import RUNNER_RUN_STATUS_INTERVAL, BaseRunner
@@ -68,6 +69,8 @@ class RunnerApp(BaseRunnerApp):
 
 
 def main():
+    if sys.platform == "darwin":
+        set_start_method("fork")
     app = RunnerApp(print)
     app.run()
 

--- a/avocado/plugins/runners/python_unittest.py
+++ b/avocado/plugins/runners/python_unittest.py
@@ -192,6 +192,8 @@ class RunnerApp(BaseRunnerApp):
 
 
 def main():
+    if sys.platform == "darwin":
+        multiprocessing.set_start_method("fork")
     app = RunnerApp(print)
     app.run()
 

--- a/avocado/plugins/runners/sysinfo.py
+++ b/avocado/plugins/runners/sysinfo.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import sys
 import time
 import traceback
 
@@ -204,6 +205,8 @@ class RunnerApp(BaseRunnerApp):
 
 
 def main():
+    if sys.platform == "darwin":
+        multiprocessing.set_start_method("fork")
     app = RunnerApp(print)
     app.run()
 

--- a/avocado/plugins/runners/tap.py
+++ b/avocado/plugins/runners/tap.py
@@ -1,4 +1,6 @@
 import io
+import multiprocessing
+import sys
 
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.tapparser import TapParser, TestResult
@@ -74,6 +76,8 @@ class RunnerApp(BaseRunnerApp):
 
 
 def main():
+    if sys.platform == "darwin":
+        multiprocessing.set_start_method("fork")
     app = RunnerApp(print)
     app.run()
 

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -62,6 +62,23 @@ def url_open(url, data=None, timeout=5):
     return result
 
 
+def _url_download(url, filename, data):
+    src_file = url_open(url, data=data)
+    if not src_file:
+        msg = (
+            "Failed to get file. Probably timeout was reached when "
+            "connecting to the server.\n"
+        )
+        sys.stderr.write(msg)
+        sys.exit(1)
+
+    try:
+        with open(filename, "wb") as dest_file:
+            shutil.copyfileobj(src_file, dest_file)
+    finally:
+        src_file.close()
+
+
 def url_download(url, filename, data=None, timeout=300):
     """
     Retrieve a file from given url.
@@ -72,24 +89,7 @@ def url_download(url, filename, data=None, timeout=300):
     :param timeout: (optional) default timeout in seconds.
     :return: `None`.
     """
-
-    def download():
-        src_file = url_open(url, data=data)
-        if not src_file:
-            msg = (
-                "Failed to get file. Probably timeout was reached when "
-                "connecting to the server.\n"
-            )
-            sys.stderr.write(msg)
-            sys.exit(1)
-
-        try:
-            with open(filename, "wb") as dest_file:
-                shutil.copyfileobj(src_file, dest_file)
-        finally:
-            src_file.close()
-
-    process = Process(target=download)
+    process = Process(target=_url_download, args=(url, filename, data))
     log.info("Fetching %s -> %s", url, filename)
     process.start()
     process.join(timeout)

--- a/avocado/utils/memory.py
+++ b/avocado/utils/memory.py
@@ -495,14 +495,20 @@ class _MemInfoItem:
 class MemInfo:
     """
     Representation of /proc/meminfo
+
+    There will not be memory information on systems that do not have a
+    /proc/meminfo file accessible.
     """
 
     def __init__(self):
-        with open("/proc/meminfo", "r") as meminfo_file:  # pylint: disable=W1514
-            for line in meminfo_file.readlines():
-                name = line.strip().split()[0].strip(":")
-                safe_name = name.replace("(", "_").replace(")", "_")
-                setattr(self, safe_name, _MemInfoItem(name))
+        try:
+            with open("/proc/meminfo", "r") as meminfo_file:  # pylint: disable=W1514
+                for line in meminfo_file.readlines():
+                    name = line.strip().split()[0].strip(":")
+                    safe_name = name.replace("(", "_").replace(")", "_")
+                    setattr(self, safe_name, _MemInfoItem(name))
+        except FileNotFoundError:
+            pass
 
     def __iter__(self):
         for item in self.__dict__.items():

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -102,7 +102,10 @@ def get_capabilities(pid=None):
     """
     if pid is None:
         pid = os.getpid()
-    result = run(f"getpcaps {int(pid)}", ignore_status=True)
+    try:
+        result = run(f"getpcaps {int(pid)}", ignore_status=True)
+    except FileNotFoundError:
+        return []
     if result.exit_status != 0:
         return []
     if result.stderr_text.startswith("Capabilities "):

--- a/avocado/utils/software_manager/main.py
+++ b/avocado/utils/software_manager/main.py
@@ -88,6 +88,13 @@ def main():
         logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     software_manager = SoftwareManager()
+    if not software_manager.is_capable():
+        log.error(
+            "ERROR: There is no backend implementation for this sytem. No "
+            "action will be performed."
+        )
+        return exit_codes.UTILITY_FAIL
+
     if args:
         action = args[0]
         args = " ".join(args[1:])

--- a/selftests/.data/exec_test_std/exec_test_1mib.py
+++ b/selftests/.data/exec_test_std/exec_test_1mib.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/selftests/.data/exec_test_std/exec_test_64kib.py
+++ b/selftests/.data/exec_test_std/exec_test_64kib.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/selftests/functional/plugin/bystatus.py
+++ b/selftests/functional/plugin/bystatus.py
@@ -11,7 +11,7 @@ class ByStatusTest(TestCaseTmpDir):
             f"{AVOCADO} run "
             f"--job-results-dir {self.tmpdir.name} "
             f"--disable-sysinfo --json - "
-            f"/bin/true /bin/false",
+            f"examples/tests/true examples/tests/false",
             ignore_status=True,
         )
         res = json.loads(result.stdout_text)

--- a/selftests/functional/runner_package.py
+++ b/selftests/functional/runner_package.py
@@ -3,7 +3,10 @@ import sys
 import unittest
 
 from avocado.utils import process
+from avocado.utils.software_manager.manager import SoftwareManager
 from selftests.utils import BASEDIR
+
+SOFTWARE_MANAGER_CAPABLE = SoftwareManager().is_capable()
 
 RUNNER = f"{sys.executable} -m avocado.plugins.runners.package"
 
@@ -27,6 +30,9 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'log': b'Package name should be passed as kwargs", res.stdout)
         self.assertEqual(res.exit_status, 0)
 
+    @unittest.skipUnless(
+        SOFTWARE_MANAGER_CAPABLE, "Not capable of a SoftwareManager backend"
+    )
     @unittest.skipUnless(
         os.getenv("CI"),
         "This test runs on CI environments"

--- a/selftests/unit/datadir.py
+++ b/selftests/unit/datadir.py
@@ -102,7 +102,9 @@ class DataDirTest(Base):
         self.assertNotEqual(None, logs_dir)
         unique_id = job_id.create_unique_job_id()
         # Expected job results dir
-        expected_jrd = data_dir.create_job_logs_dir(logs_dir, unique_id)
+        expected_jrd = os.path.realpath(
+            data_dir.create_job_logs_dir(logs_dir, unique_id)
+        )
 
         # Now let's test some cases
         #
@@ -122,7 +124,7 @@ class DataDirTest(Base):
 
         self.assertEqual(
             expected_jrd,
-            data_dir.get_job_results_dir(expected_jrd, logs_dir),
+            os.path.realpath(data_dir.get_job_results_dir(expected_jrd, logs_dir)),
             "It should get from the path to the directory",
         )
 
@@ -137,20 +139,20 @@ class DataDirTest(Base):
         os.chdir(logs_dir)
         self.assertEqual(
             expected_jrd,
-            data_dir.get_job_results_dir(results_dirname, logs_dir),
+            os.path.realpath(data_dir.get_job_results_dir(results_dirname, logs_dir)),
             "It should get from relative path to the directory",
         )
         os.chdir(pwd)
 
         self.assertEqual(
             expected_jrd,
-            data_dir.get_job_results_dir(id_file_path, logs_dir),
+            os.path.realpath(data_dir.get_job_results_dir(id_file_path, logs_dir)),
             "It should get from the path to the id file",
         )
 
         self.assertEqual(
             expected_jrd,
-            data_dir.get_job_results_dir(unique_id, logs_dir),
+            os.path.realpath(data_dir.get_job_results_dir(unique_id, logs_dir)),
             "It should get from the id",
         )
 
@@ -164,13 +166,13 @@ class DataDirTest(Base):
 
         self.assertEqual(
             expected_jrd,
-            data_dir.get_job_results_dir(unique_id[:7], logs_dir),
+            os.path.realpath(data_dir.get_job_results_dir(unique_id[:7], logs_dir)),
             "It should get from partial id equals to 7 digits",
         )
 
         self.assertEqual(
             expected_jrd,
-            data_dir.get_job_results_dir(unique_id[:4], logs_dir),
+            os.path.realpath(data_dir.get_job_results_dir(unique_id[:4], logs_dir)),
             "It should get from partial id less than 7 digits",
         )
 
@@ -185,7 +187,7 @@ class DataDirTest(Base):
         os.symlink(expected_jrd, os.path.join(logs_dir, "latest"))
         self.assertEqual(
             expected_jrd,
-            data_dir.get_job_results_dir("latest", logs_dir),
+            os.path.realpath(data_dir.get_job_results_dir("latest", logs_dir)),
             "It should get from the 'latest' id",
         )
 
@@ -199,7 +201,7 @@ class DataDirTest(Base):
         with unittest.mock.patch("avocado.core.data_dir.settings", stg):
             self.assertEqual(
                 expected_jrd,
-                data_dir.get_job_results_dir(unique_id),
+                os.path.realpath(data_dir.get_job_results_dir(unique_id)),
                 "It should use the default base logs directory",
             )
 

--- a/selftests/unit/job.py
+++ b/selftests/unit/job.py
@@ -8,7 +8,7 @@ from avocado.core.exceptions import JobBaseException, JobTestSuiteDuplicateNameE
 from avocado.core.nrunner.runnable import Runnable
 from avocado.core.suite import TestSuite, TestSuiteStatus
 from avocado.utils import path as utils_path
-from selftests.utils import setup_avocado_loggers, temp_dir_prefix
+from selftests.utils import BASEDIR, setup_avocado_loggers, temp_dir_prefix
 
 setup_avocado_loggers()
 
@@ -96,7 +96,13 @@ class JobTest(unittest.TestCase):
         self.assertEqual(suite.status, TestSuiteStatus.RESOLUTION_NOT_STARTED)
 
     def test_suite_tests_found(self):
-        suite = TestSuite.from_config({"resolver.references": ["/bin/true"]})
+        suite = TestSuite.from_config(
+            {
+                "resolver.references": [
+                    os.path.join(BASEDIR, "examples", "tests", "true")
+                ]
+            }
+        )
         self.assertEqual(suite.status, TestSuiteStatus.TESTS_FOUND)
 
     def test_suite_tests_not_found(self):
@@ -271,13 +277,18 @@ class JobTest(unittest.TestCase):
         config = {
             "run.results_dir": self.tmpdir.name,
             "core.show": ["none"],
-            "resolver.references": ["/bin/true"],
+            "resolver.references": [os.path.join(BASEDIR, "examples", "tests", "true")],
         }
 
-        suite_config = {"resolver.references": ["/bin/false"]}
+        suite_config = {
+            "resolver.references": [os.path.join(BASEDIR, "examples", "tests", "false")]
+        }
         self.job = job.Job.from_config(config, [suite_config])
         self.job.setup()
-        self.assertEqual(self.job.config.get("resolver.references"), ["/bin/true"])
+        self.assertEqual(
+            self.job.config.get("resolver.references"),
+            [os.path.join(BASEDIR, "examples", "tests", "true")],
+        )
 
     def test_job_dryrun_no_unique_job_id(self):
         config = {
@@ -304,7 +315,9 @@ class JobTest(unittest.TestCase):
         """This will test if test suites are inheriting configs from job."""
         config = {"core.show": ["none"], "run.results_dir": self.tmpdir.name}
 
-        suite_config = {"resolver.references": ["/bin/true"]}
+        suite_config = {
+            "resolver.references": [os.path.join(BASEDIR, "examples", "tests", "true")]
+        }
 
         # Manual/Custom method
         suite = TestSuite("foo-test", config=suite_config, job_config=config)
@@ -320,7 +333,13 @@ class JobTest(unittest.TestCase):
         )
 
         # Automatic method passing only one config
-        config.update({"resolver.references": ["/bin/true"]})
+        config.update(
+            {
+                "resolver.references": [
+                    os.path.join(BASEDIR, "examples", "tests", "true")
+                ]
+            }
+        )
         self.job = job.Job.from_config(job_config=config)
         self.assertEqual(
             self.job.test_suites[0].config.get("run.results_dir"), self.tmpdir.name
@@ -349,7 +368,10 @@ class JobTest(unittest.TestCase):
 
     def test_job_get_failed_tests(self):
         config = {
-            "resolver.references": ["/bin/true", "/bin/false"],
+            "resolver.references": [
+                os.path.join(BASEDIR, "examples", "tests", "true"),
+                os.path.join(BASEDIR, "examples", "tests", "false"),
+            ],
             "run.results_dir": self.tmpdir.name,
             "core.show": ["none"],
         }
@@ -361,7 +383,10 @@ class JobTest(unittest.TestCase):
 
     def test_job_dryrun(self):
         config = {
-            "resolver.references": ["/bin/true", "/bin/false"],
+            "resolver.references": [
+                os.path.join(BASEDIR, "examples", "tests", "true"),
+                os.path.join(BASEDIR, "examples", "tests", "false"),
+            ],
             "run.results_dir": self.tmpdir.name,
             "run.dry_run.enabled": True,
             "core.show": ["none"],
@@ -374,7 +399,9 @@ class JobTest(unittest.TestCase):
 
     def test_job_duplicate_suite_names(self):
         config = {"core.show": ["none"], "run.results_dir": self.tmpdir.name}
-        suite_config = {"resolver.references": ["/bin/true"]}
+        suite_config = {
+            "resolver.references": [os.path.join(BASEDIR, "examples", "tests", "true")]
+        }
         suite_1 = TestSuite("suite", config=suite_config)
         suite_2 = TestSuite("suite", config=suite_config)
         with self.assertRaises(JobTestSuiteDuplicateNameError):

--- a/selftests/unit/nrunner.py
+++ b/selftests/unit/nrunner.py
@@ -470,6 +470,10 @@ class RunnerCommandSelection(unittest.TestCase):
     def setUp(self):
         self.kind = "mykind"
 
+    @unittest.skipIf(
+        sys.platform.startswith("darwin"),
+        "echo implementation under darwin lacks the -n feature",
+    )
     def test_is_task_kind_supported(self):
         cmd = [
             "sh",

--- a/selftests/unit/runner_package.py
+++ b/selftests/unit/runner_package.py
@@ -3,6 +3,9 @@ from unittest.mock import patch
 
 from avocado.core.nrunner.runnable import Runnable
 from avocado.plugins.runners.package import PackageRunner
+from avocado.utils.software_manager.manager import SoftwareManager
+
+SOFTWARE_MANAGER_CAPABLE = SoftwareManager().is_capable()
 
 
 class BasicTests(unittest.TestCase):
@@ -39,6 +42,9 @@ class BasicTests(unittest.TestCase):
         self.assertIn(stderr, messages[-2]["log"])
 
 
+@unittest.skipUnless(
+    SOFTWARE_MANAGER_CAPABLE, "Not capable of a SoftwareManager backend"
+)
 class ActionTests(unittest.TestCase):
     """Unit tests for the actions on PackageRunner class"""
 

--- a/selftests/unit/runner_sysinfo.py
+++ b/selftests/unit/runner_sysinfo.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 
 from avocado.core.nrunner.runnable import Runnable
@@ -6,6 +7,10 @@ from avocado.core.settings import settings
 from avocado.plugins.runners.sysinfo import SysinfoRunner
 
 
+@unittest.skipIf(
+    sys.platform.startswith("darwin"),
+    "Tests attempt to collect files not available under darwin",
+)
 class BasicTests(unittest.TestCase):
     """Basic unit tests for the RequirementPackageRunner class"""
 

--- a/selftests/unit/utils/linux_modules.py
+++ b/selftests/unit/utils/linux_modules.py
@@ -1,7 +1,8 @@
 import io
+import sys
 import unittest.mock
 
-from avocado import Test
+from avocado import Test, skipIf
 from avocado.utils import linux_modules
 
 
@@ -54,6 +55,7 @@ class Modules(Test):
         file_mock.__exit__ = unittest.mock.Mock()
         return file_mock
 
+    @skipIf(sys.platform.startswith("darwin"), "macOS does not support Linux Modules")
     def test_is_module_loaded(self):
         with unittest.mock.patch(
             "builtins.open", return_value=self._get_data_mock("proc_modules")

--- a/selftests/unit/utils/process.py
+++ b/selftests/unit/utils/process.py
@@ -707,6 +707,10 @@ class GetCommandOutputPattern(unittest.TestCase):
         self.assertEqual(res, ["foo"])
 
     @unittest.skipUnless(ECHO_CMD, "Echo command not available in system")
+    @unittest.skipIf(
+        sys.platform.startswith("darwin"),
+        "Darwin implementation of echo lacks -e behavior",
+    )
     def test_matches_multiple(self):
         res = process.get_command_output_matching("echo -e 'foo\nfoo\n'", "foo")
         self.assertEqual(res, ["foo", "foo"])


### PR DESCRIPTION
This puts darwin/macos at about the same level of coverage (apart from the specific skips) as the other platforms.
    
Disclaimer: the core Avocado team has no regular access to those platforms.  If issues on these platforms arise, either the community needs to address them, or coverage will be reduced.

Reference: https://github.com/avocado-framework/avocado/issues/4888

---

@lmr @philmd @XVilka this might be of interest to you.