### PR TITLE
Disable garbage collection during logging

### DIFF
--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -1,3 +1,4 @@
+import gc
 import logging
 import sys
 import time
@@ -207,7 +208,9 @@ class RunnerLogHandler(logging.Handler):
             kwargs.update(**self.kwargs)
         else:
             kwargs = self.kwargs
+        gc.disable()
         self.queue.put(self.message.get(msg, **kwargs))
+        gc.enable()
 
 
 class StreamToQueue:
@@ -224,7 +227,9 @@ class StreamToQueue:
         self.message = _supported_types[message_type]
 
     def write(self, buf):
+        gc.disable()
         self.queue.put(self.message.get(buf))
+        gc.enable()
 
     def flush(self):
         pass


### PR DESCRIPTION
In some circumstances, avocado instrumented runner can hang indefinitely and block other test to execute. This is caused by a very specific bug in `multiprocessing.Queue` which can cause deadlock when you're manipulating with queue during garbage collection. This issue was investigated and well described by @pevogam in
https://github.com/avocado-framework/avocado/issues/4935#issuecomment-938069202 for long story short, this is the process which causes deadlock:

   1. The program was calling q.put(2).
   2. This involves acquiring a lock.
   3. Half-way through the function call, garbage collection happens.
   4. Garbage collection calls Object.__del__.
   5. Object.__del__ calls q.put(1).
   6. q.put(1) tries to acquire the lock… but the lock is already held, so it waits.

Because instrumented runner is using multiprocessing.Queue for storing logs, this is quite common scenario if any object does logging in `__del__` method.

This commit disables garbage collection for the process when the logs are stored to `multiprocessing.Queue`. Such change prevents this kind of deadlock.

Reference: #4935