### PR TITLE
Environment variables for exec tests

### DIFF
--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -98,9 +98,14 @@ class ExecTestRunner(BaseRunner):
         avocado_test_env_variables = {
             "AVOCADO_VERSION": self._get_avocado_version(),
             "AVOCADO_TEST_WORKDIR": workdir,
+            "AVOCADO_TEST_BASEDIR": os.path.dirname(os.path.abspath(runnable.uri)),
         }
         if runnable.output_dir:
+            avocado_test_env_variables["AVOCADO_TEST_LOGDIR"] = runnable.output_dir
             avocado_test_env_variables["AVOCADO_TEST_OUTPUTDIR"] = runnable.output_dir
+            avocado_test_env_variables["AVOCADO_TEST_LOGFILE"] = os.path.join(
+                runnable.output_dir, "debug.log"
+            )
         return avocado_test_env_variables
 
     @staticmethod

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -50,6 +50,8 @@ class ProcessSpawner(Spawner, SpawnerMixin):
     def create_task_output_dir(self, runtime_task):
         output_dir_path = self.task_output_dir(runtime_task)
         os.makedirs(output_dir_path, exist_ok=True)
+        with open(os.path.join(output_dir_path, "debug.log"), mode="ba"):
+            pass
         runtime_task.task.setup_output_dir(output_dir_path)
 
     @staticmethod

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1313,8 +1313,6 @@ tests:
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_OUTPUTDIR      | Output directory for the test         | /var/tmp/.avocado-taskcx8of8di/test-results/1-Env.test/data                                         |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_SYSINFODIR     | The system information directory      | $HOME/avocado/job-results/job-2021-10-26T17.23-98f17a2/sysinfo/pre                                  |
-+-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | `***`                       | All variables from --mux-yaml         | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 
@@ -1326,16 +1324,20 @@ tests:
 +=============================+=======================================+=====================================================================================================+
 | AVOCADO_VERSION             | Version of Avocado test runner        | 92.0                                                                                                |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/.avocado-task-_4qquwyq/workdir                                                             |
+| AVOCADO_TEST_BASEDIR        | Base directory of Avocado tests       | $HOME/src/avocado/avocado.dev/examples/tests                                                        |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/.avocado-taskcx8of8di/test-results/tmp_dirfgqrnbu_/1-Env.test                              |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TESTS_COMMON_TMPDIR | Temporary directory created by the    | /var/tmp/avocado_XhEdo/                                                                             |
 |                             | :ref:`plugin_teststmpdir` plugin.  The|                                                                                                     |
 |                             | directory is persistent throughout the|                                                                                                     |
 |                             | tests in the same Job                 |                                                                                                     |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_OUTPUTDIR      | Output directory for the test         | /var/tmp/.avocado-task-_4qquwyq                                                                     |
+| AVOCADO_TEST_LOGDIR         | Log directory for the test            | /var/tmp/.avocado-task_5t_srpn/test-results/1-Env.test                                              |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
-| AVOCADO_TEST_SYSINFODIR     | The system information directory      | $HOME/avocado/job-results/job-2021-10-26T17.03-d09ca41/sysinfo/pre                                  |
+| AVOCADO_TEST_LOGFILE        | Log file for the test                 | /var/tmp/.avocado-taskcx8of8di/test-results/1-Env.test/debug.log                                    |
++-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
+| AVOCADO_TEST_OUTPUTDIR      | Output directory for the test         | /var/tmp/.avocado-taskcx8of8di/test-results/1-Env.test/data                                         |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | `***`                       | All variables from --mux-yaml         | TIMEOUT=60; IO_WORKERS=10; VM_BYTES=512M; ...                                                       |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+

--- a/examples/tests/env_variables.sh
+++ b/examples/tests/env_variables.sh
@@ -3,14 +3,13 @@
 # information, exported through environment variables.
 echo "Avocado Version: $AVOCADO_VERSION"
 echo "Avocado Test basedir: $AVOCADO_TEST_BASEDIR"
+test -d "$AVOCADO_TEST_BASEDIR" || exit 1
 echo "Avocado Test workdir: $AVOCADO_TEST_WORKDIR"
+test -d "$AVOCADO_TEST_WORKDIR" || exit 1
 echo "Avocado Test logdir: $AVOCADO_TEST_LOGDIR"
+test -d "$AVOCADO_TEST_LOGDIR" || exit 1
 echo "Avocado Test logfile: $AVOCADO_TEST_LOGFILE"
+test -f "$AVOCADO_TEST_LOGFILE" || exit 1
 echo "Avocado Test outputdir: $AVOCADO_TEST_OUTPUTDIR"
+test -d "$AVOCADO_TEST_OUTPUTDIR" || exit 1
 echo "Custom variable: $CUSTOM_VARIABLE"
-
-test -d "$AVOCADO_TEST_BASEDIR" -a \
-     -d "$AVOCADO_TEST_WORKDIR" -a \
-     -d "$AVOCADO_TEST_LOGDIR" -a \
-     -f "$AVOCADO_TEST_LOGFILE" -a \
-     -d "$AVOCADO_TEST_OUTPUTDIR"

--- a/selftests/functional/plugin/runners/exec_test.py
+++ b/selftests/functional/plugin/runners/exec_test.py
@@ -1,0 +1,37 @@
+import os
+
+from avocado import Test
+from avocado.core import exit_codes
+from avocado.core.job import Job
+from avocado.utils import script
+from selftests.utils import TestCaseTmpDir
+
+
+class ExecTestRunnerTest(Test, TestCaseTmpDir):
+    def test_env_variables(self):
+        commands_path = os.path.join(self.tmpdir.name, "commands")
+        script.make_script(commands_path, "uname -a")
+        base_config = {
+            "run.results_dir": self.tmpdir.name,
+            "sysinfo.collect.per_test": True,
+            "sysinfo.collectibles.commands": commands_path,
+            "resolver.references": ["examples/tests/env_variables.sh"],
+        }
+        with Job.from_config(base_config) as j:
+            result = j.run()
+        logfile_path = os.path.join(
+            self.tmpdir.name,
+            "latest",
+            "test-results",
+            "1-1-examples_tests_env_variables.sh",
+            "debug.log",
+        )
+        with open(logfile_path, "rb") as f:
+            for line in f.readlines():
+                self.log.debug(line)
+        expected_rc = exit_codes.AVOCADO_ALL_OK
+        self.assertEqual(
+            result,
+            expected_rc,
+            (f"Avocado did not return rc " f"{int(expected_rc)}:\n{result}"),
+        )


### PR DESCRIPTION
This PR enables all avocado variables from
`examples/tests/env_variables.sh` example for exec tests. It will
decrease the difference of environment variables between exec-test tests
and avocado-instrumented tests.

Reference: https://github.com/avocado-framework/avocado/issues/5637
Signed-off-by: Jan Richter <jarichte@redhat.com>