### PR TITLE
Asset plugin parse dict assignment

### DIFF
--- a/avocado/plugins/assets.py
+++ b/avocado/plugins/assets.py
@@ -185,6 +185,8 @@ class FetchAssetHandler(ast.NodeVisitor):  # pylint: disable=R0902
                 # otherwise, save the local variable name
                 if isinstance(node.targets[0], ast.Attribute):
                     name = node.targets[0].attr
+                elif isinstance(node.targets[0], ast.Subscript):
+                    name = node.targets[0].slice.value
                 else:
                     name = node.targets[0].id
 


### PR DESCRIPTION
The asset plugin failed, during the parse phase of the test file, when the test contains dict assignment
 as this `boo["foo"] = "zxy" `. This is a fix for this bug.

Reference: #5684