### PR TITLE
Tags inheritance

### DIFF
--- a/selftests/unit/safeloader_core.py
+++ b/selftests/unit/safeloader_core.py
@@ -262,11 +262,34 @@ class FindClassAndMethods(UnlimitedDiff):
             "Child": [
                 (
                     "test_maybe_replaced_by_child",
-                    {"child-tag": None, "child.tag": None},
+                    {
+                        "child-tag": None,
+                        "child.tag": None,
+                        "base-tag": None,
+                        "base.tag": None,
+                    },
                     [],
                 ),
-                ("test_child", {"child-tag": None, "child.tag": None}, []),
-                ("test_basic", {"base-tag": None, "base.tag": None}, []),
+                (
+                    "test_child",
+                    {
+                        "child-tag": None,
+                        "child.tag": None,
+                        "base-tag": None,
+                        "base.tag": None,
+                    },
+                    [],
+                ),
+                (
+                    "test_basic",
+                    {
+                        "base-tag": None,
+                        "base.tag": None,
+                        "child-tag": None,
+                        "child.tag": None,
+                    },
+                    [],
+                ),
             ],
         }
         self.assertEqual(expected, tests)


### PR DESCRIPTION
This commit introduces tags inheritance. Now, the avocado tags will respect tags from parent classes and parent methods. Let's imagine such a test file:

```

class Base(avocado.Test):
	'''
    :avocado: tags=foo
	'''
    def test_one(self):
        pass

class Derived(Base):
	'''
    :avocado: tags=boo
	'''
    def test_two(self):
        pass

```

The methods Derived.test_one and Derived.test_two will have tags from Base and Derived classes `foo` and `boo`.

Reference: #5680