### PR TITLE
Packit: update list of chroots as supported by COPR

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -11,7 +11,7 @@ jobs:
       - centos-stream-9
       - epel-8
       - epel-9
-      - fedora-36-aarch64
-      - fedora-36-ppc64le
-      - fedora-36-s390x
+      - fedora-38-aarch64
+      - fedora-38-ppc64le
+      - fedora-38-s390x
       enable_net: False


### PR DESCRIPTION
COPR no longer supports fedora-36, as can be seen by:

 $ copr-cli list-chroots

Let's bump the Fedora versions used for alternative architectures.