### PR TITLE
signedoff-check.sh false positive fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Installing Avocado in develop mode
         run: python3 setup.py develop --user
       - name: Run static checks
+        env:
+          COMMIT_COUNT: ${{ github.event.pull_request.commits  }}
         run: python3 setup.py test --select=static-checks
       - name: Archive failed tests logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Allow git to operate on directory checked out by GH Actions
         run: git config --global --add safe.directory `pwd`
       - name: Installing Avocado development dependencies

--- a/selftests/signedoff-check.sh
+++ b/selftests/signedoff-check.sh
@@ -1,12 +1,16 @@
 #!/bin/sh -e
 
 echo "** Running signedoff-check..."
-
-AUTHOR="$(git log --no-merges -1 --pretty='format:%aN <%aE>')"
-HEADER=$(git log --no-merges -1 --format='%s')
-echo "The commit header is: '${HEADER}"
-git log --no-merges -1 --pretty=format:%B | grep -i "Signed-off-by: $AUTHOR"
-if [ $? != 0 ]; then
+if [ -z "$COMMIT_COUNT" ]; then
+  COMMIT_COUNT=1
+fi
+readarray -t commits <<< $(git log --no-merges -n "$COMMIT_COUNT" --format='%H')
+for commit in "${commits[@]}"; do
+  AUTHOR=$(git log -1 --format='%aN <%aE>' "$commit")
+  HEADER=$(git log -1 --format='%s' "$commit")
+  echo " Checking commit with header: '$HEADER"
+  if ! git log -1 --pretty=format:%B "$commit" | grep -i "Signed-off-by: $AUTHOR"; then
     echo "The commit message does not contain author's signature (Signed-off-by: $AUTHOR)"
     exit 1
-fi
+  fi
+done

--- a/selftests/signedoff-check.sh
+++ b/selftests/signedoff-check.sh
@@ -3,6 +3,8 @@
 echo "** Running signedoff-check..."
 
 AUTHOR="$(git log --no-merges -1 --pretty='format:%aN <%aE>')"
+HEADER=$(git log --no-merges -1 --format='%s')
+echo "The commit header is: '${HEADER}"
 git log --no-merges -1 --pretty=format:%B | grep -i "Signed-off-by: $AUTHOR"
 if [ $? != 0 ]; then
     echo "The commit message does not contain author's signature (Signed-off-by: $AUTHOR)"


### PR DESCRIPTION
On GH Actions, selftests/signedoff-check.sh has been false positive when
the PR commits were older than master branch commits. It was caused by
rebase mechanism of used github action. This will change the action from
"git rebase" to "git merge". Also, we are always checking only the last commit,
this change will add a check for all commits in one PR.

Reference: https://github.com/avocado-framework/avocado/issues/5670