### PR TITLE
Improve message when resolvers don't resolve the reference

### DIFF
--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -276,7 +276,10 @@ def resolve(references, hint=None, ignore_missing=True, config=None):
         # resolution process
         missing = [_ for _ in missing if not os.path.isdir(_)]
         if missing:
-            msg = f"Could not resolve references: {','.join(missing)}"
+            msg = (
+                f"No tests found for given test references: {', '.join(missing)}\n"
+                f"Try 'avocado -V list {' '.join(missing)}' for details"
+            )
             raise JobTestSuiteReferenceResolutionError(msg)
 
     return resolutions

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -563,7 +563,11 @@ class RunnerOperationTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
         self.assertEqual(result.stdout, b"")
-        self.assertEqual(result.stderr, b"Could not resolve references: sbrubles\n")
+        self.assertEqual(
+            result.stderr,
+            b"No tests found for given test references: sbrubles\n"
+            b"Try 'avocado -V list sbrubles' for details\n",
+        )
 
     def test_invalid_unique_id(self):
         cmd_line = (


### PR DESCRIPTION
This will improve avocado error message when some reference wasn't resolved. It adds a pointer to `avocado -V list` which provides more information about references.

Reference: #5644