### PR TITLE
Document standard plugin teststmpdir

### DIFF
--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1303,9 +1303,9 @@ tests:
 | AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/.avocado-taskcx8of8di/test-results/tmp_dirfgqrnbu_/1-Env.test                              |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TESTS_COMMON_TMPDIR | Temporary directory created by the    | /var/tmp/avocado_cp07qzd9                                                                           |
-|                             | `teststmpdir` plugin. The directory   |                                                                                                     |
-|                             | is persistent throughout the tests    |                                                                                                     |
-|                             | in the same Job                       |                                                                                                     |
+|                             | :ref:`plugin_teststmpdir` plugin.  The|                                                                                                     |
+|                             | directory is persistent throughout the|                                                                                                     |
+|                             | tests in the same Job                 |                                                                                                     |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_LOGDIR         | Log directory for the test            | /var/tmp/.avocado-task_5t_srpn/test-results/1-Env.test                                              |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
@@ -1329,9 +1329,9 @@ tests:
 | AVOCADO_TEST_WORKDIR        | Work directory for the test           | /var/tmp/.avocado-task-_4qquwyq/workdir                                                             |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TESTS_COMMON_TMPDIR | Temporary directory created by the    | /var/tmp/avocado_XhEdo/                                                                             |
-|                             | `teststmpdir` plugin. The directory   |                                                                                                     |
-|                             | is persistent throughout the tests    |                                                                                                     |
-|                             | in the same Job                       |                                                                                                     |
+|                             | :ref:`plugin_teststmpdir` plugin.  The|                                                                                                     |
+|                             | directory is persistent throughout the|                                                                                                     |
+|                             | tests in the same Job                 |                                                                                                     |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+
 | AVOCADO_TEST_OUTPUTDIR      | Output directory for the test         | /var/tmp/.avocado-task-_4qquwyq                                                                     |
 +-----------------------------+---------------------------------------+-----------------------------------------------------------------------------------------------------+

--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -1,6 +1,25 @@
 ================
+Standard plugins
+================
+
+Avocado is highly modular, and a lot of its functionality is
+implemented as "plugins".  On this section, you'll find documentation
+for plugins that come standard with Avocado.
+
+Please note that this is not a fully comprehensive list.
+
+.. tip:: Running ``avocado plugins`` will show the full list of
+         plugins installed and available on your system.
+
+================
 Optional plugins
 ================
+
+The plugins listed here are not automatically available on every
+Avocado installation.  Depending on the installation method, it may
+require additional steps or packages to be installed.
+
+Some of these plugins may have extra dependencies of their own.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -11,6 +11,12 @@ Please note that this is not a fully comprehensive list.
 .. tip:: Running ``avocado plugins`` will show the full list of
          plugins installed and available on your system.
 
+
+.. toctree::
+   :maxdepth: 3
+
+   standard/teststmpdir
+
 ================
 Optional plugins
 ================

--- a/docs/source/plugins/standard/teststmpdir.rst
+++ b/docs/source/plugins/standard/teststmpdir.rst
@@ -1,0 +1,31 @@
+.. _plugin_teststmpdir:
+
+teststmpdir
+===========
+
+This plugin will create a temporary directory **on the system where
+the Avocado job is running**.  This directory will be available
+throughout the execution of the job.
+
+The indented use case is for legacy test suites that have dependencies
+between tests.  An early test may benefit from doing some sort of
+setup, such as downloading a file or compiling some code.  The
+location of this directory will be made available:
+
+* At the environment variable ``AVOCADO_TESTS_COMMON_TMPDIR``
+* At the :data:`avocado.Test.teststmpdir` property for
+  ``avocado-instrumented`` tests.
+
+By making use of the temporary directory that will precede and outlive
+the test itself, the setup performed by one test may be reused by a
+later test.
+
+This is opposed to a test's own and private work directory
+(environment variable ``AVOCADO_TEST_WORKDIR``, property
+:data:`avocado.Test.workdir`) which will only be available during each
+individual test execution.
+
+.. warning:: if an Avocado job spawns tests with a spawner other than
+             ``process`` (say ``podman``, ``lxc`` or another custom
+             spawner), those tests won't have access to the common
+             temporary directory created by this plugin.


### PR DESCRIPTION
This adds section for standard plugins (as opposed to the existing "optional" plugins).  It also documents the `teststmpdir` plugin.