### PR TITLE
Returning String instead of list based on test requirement in nvme.py

### DIFF
--- a/avocado/utils/nvme.py
+++ b/avocado/utils/nvme.py
@@ -47,7 +47,7 @@ def get_controller_name(pci_addr):
     """
     if pci_addr in pci.get_pci_addresses():
         path = f"/sys/bus/pci/devices/{pci_addr}/nvme/"
-        return os.listdir(path)
+        return "".join(os.listdir(path))
     raise NvmeException("Unable to list as wrong pci_addr")
 
 


### PR DESCRIPTION
current method is returning list but it is easy to handle if the controller name is in string format. Hence modified accordingly