### PR TITLE
DependencyResolver output fix [v2]

### DIFF
--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -123,6 +123,12 @@ class StartMessageHandler(BaseMessageHandler):
         logfile = os.path.join(task_path, DEFAULT_LOG_FILE)
         os.makedirs(task_path, exist_ok=True)
         params = []
+        symlink_dir = task.metadata.get("symlink")
+        if symlink_dir:
+            os.makedirs(
+                os.path.abspath(os.path.join(symlink_dir, os.pardir)), exist_ok=True
+            )
+            os.symlink(task_path, symlink_dir, target_is_directory=True)
         if task.runnable.variant is not None:
             # convert variant into the list of parameters
             params = [

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -241,6 +241,7 @@ class PrePostRuntimeTaskMixin(RuntimeTask):
                 satisfiable_deps_execution_statuses = None
                 if isinstance(runnable, tuple):
                     runnable, satisfiable_deps_execution_statuses = runnable
+                output_dir_not_exists = runnable.output_dir is None
                 task = cls.from_runnable(
                     runnable,
                     no_digits,
@@ -251,6 +252,17 @@ class PrePostRuntimeTaskMixin(RuntimeTask):
                     job_id,
                     satisfiable_deps_execution_statuses,
                 )
+                if output_dir_not_exists:
+                    runnable.output_dir = os.path.join(
+                        os.path.abspath(os.path.join(base_dir, os.pardir)),
+                        "dependencies",
+                        str(task.task.identifier),
+                    )
+                    task.task.metadata["symlink"] = os.path.join(
+                        test_task.task.runnable.output_dir,
+                        "dependencies",
+                        f'{runnable.kind}-{runnable.kwargs.get("name")}',
+                    )
                 task.is_cacheable = is_cacheable
                 tasks.append(task)
         return tasks

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -291,6 +291,36 @@ class Worker:
                         return
 
                     if is_task_in_cache:
+                        task_id = str(runtime_task.task.identifier)
+                        job_id = runtime_task.task.job_id
+                        encoding = "utf-8"
+                        start_message = {
+                            "status": "started",
+                            "time": time.monotonic(),
+                            "output_dir": runtime_task.task.runnable.output_dir,
+                            "id": task_id,
+                            "job_id": job_id,
+                        }
+                        log_message = {
+                            "status": "running",
+                            "type": "log",
+                            "log": f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | "
+                            f"Dependency fulfilled from cache.".encode(encoding),
+                            "encoding": encoding,
+                            "time": time.monotonic(),
+                            "id": task_id,
+                            "job_id": job_id,
+                        }
+                        finish_message = {
+                            "status": "finished",
+                            "result": "pass",
+                            "time": time.monotonic(),
+                            "id": task_id,
+                            "job_id": job_id,
+                        }
+                        self._state_machine._status_repo.process_message(start_message)
+                        self._state_machine._status_repo.process_message(log_message)
+                        self._state_machine._status_repo.process_message(finish_message)
                         await self._state_machine.finish_task(
                             runtime_task, RuntimeTaskStatus.IN_CACHE
                         )

--- a/docs/source/guides/user/chapters/dependencies.rst
+++ b/docs/source/guides/user/chapters/dependencies.rst
@@ -42,6 +42,15 @@ with `avocado cache list`.
         If such a change is made to the environment, it's recommended to clear 
         the dependencies cache with `$avocado cache clear`.
 
+Dependency logs
+---------------
+
+Each dependency will create its own log directory where you can find logs related to
+this dependence. Dependencies logs related to one job are stored in
+`{avocado_dir}/job-results/{job}/dependencies` and for each dependence logs the symlink
+to correct test logs directory is created. Therefore, if your test has dependencies,
+you can find dependency logs in `{avocado_dir}/job-results/{job}/test-results/{test_id}/dependencies`
+
 Defining a test dependency
 ---------------------------
 

--- a/selftests/functional/serial/requirements.py
+++ b/selftests/functional/serial/requirements.py
@@ -1,10 +1,11 @@
+import glob
 import os
 import unittest
 
 from avocado import Test, skipUnless
 from avocado.core import exit_codes
 from avocado.utils import process, script
-from selftests.utils import AVOCADO
+from selftests.utils import AVOCADO, TestCaseTmpDir
 
 SINGLE_SUCCESS_CHECK = '''#!/usr/bin/env python3
 
@@ -93,7 +94,7 @@ class FailTest(Test):
 '''
 
 
-class BasicTest(Test):
+class BasicTest(Test, TestCaseTmpDir):
 
     """
     :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
@@ -117,14 +118,13 @@ class BasicTest(Test):
         spawner_command = ""
         if spawner == "podman":
             spawner_command = "--spawner=podman --spawner-podman-image=fedora:36"
-        return (
-            f"{AVOCADO} run {spawner_command} --job-results-dir {self.workdir} {path}"
-        )
+        return f"{AVOCADO} run {spawner_command} --job-results-dir {self.tmpdir.name} {path}"
 
     @skipUnless(os.getenv("CI"), skip_package_manager_message)
     def test_single_success(self):
         with script.Script(
-            os.path.join(self.workdir, "test_single_success.py"), SINGLE_SUCCESS_CHECK
+            os.path.join(self.tmpdir.name, "test_single_success.py"),
+            SINGLE_SUCCESS_CHECK,
         ) as test:
             command = self.get_command(test.path)
             result = process.run(command, ignore_status=True)
@@ -137,11 +137,33 @@ class BasicTest(Test):
                 "bash",
                 result.stdout_text,
             )
+            test_results_path = os.path.join(self.tmpdir.name, "latest", "test-results")
+            self.assertEqual(
+                len(os.listdir(test_results_path)),
+                2,
+                "DependencyResolver created unwanted result directories.",
+            )
+            test_dependency_dir = glob.glob(
+                os.path.join(test_results_path, "1-*", "dependencies")
+            )[0]
+            self.assertEqual(
+                len(os.listdir(test_dependency_dir)),
+                1,
+                "Dependency directories is missing.",
+            )
+            job_dependency_dir = os.path.join(
+                self.tmpdir.name, "latest", "dependencies"
+            )
+            self.assertEqual(
+                len(os.listdir(job_dependency_dir)),
+                1,
+                "Dependency symlink wasn't created.",
+            )
 
     @skipUnless(os.getenv("CI"), skip_package_manager_message)
     def test_single_fail(self):
         with script.Script(
-            os.path.join(self.workdir, "test_single_fail.py"), SINGLE_FAIL_CHECK
+            os.path.join(self.tmpdir.name, "test_single_fail.py"), SINGLE_FAIL_CHECK
         ) as test:
             command = self.get_command(test.path)
             result = process.run(command, ignore_status=True)
@@ -162,7 +184,7 @@ class BasicTest(Test):
     @skipUnless(os.getenv("CI"), skip_install_message)
     def test_multiple_success(self):
         with script.Script(
-            os.path.join(self.workdir, "test_multiple_success.py"), MULTIPLE_SUCCESS
+            os.path.join(self.tmpdir.name, "test_multiple_success.py"), MULTIPLE_SUCCESS
         ) as test:
             command = self.get_command(test.path)
             result = process.run(command, ignore_status=True)
@@ -179,7 +201,7 @@ class BasicTest(Test):
     @skipUnless(os.getenv("CI"), skip_install_message)
     def test_multiple_fails(self):
         with script.Script(
-            os.path.join(self.workdir, "test_multiple_fail.py"), MULTIPLE_FAIL
+            os.path.join(self.tmpdir.name, "test_multiple_fail.py"), MULTIPLE_FAIL
         ) as test:
             command = self.get_command(test.path)
             result = process.run(command, ignore_status=True)


### PR DESCRIPTION
This commit will create a new directory in
`{avocado_dir}/job-results/{job}/dependencies` for storing test
dependencies logs. Also for these logs symlinks to test directories will
be created. Therefore, if you want to get dependencies logs related to
one test, you will find them in
`{avocado_dir}/job-results/{job}/test-results/{test_id}/dependencies`

Reference: https://github.com/avocado-framework/avocado/issues/5671
Signed-off-by: Jan Richter <jarichte@redhat.com>

---
changes from v1 (#5673)
* Special directory for job related dependencies
* Symlink of dependency logs to the test-results directory.
* New log message when the dependency has been fulfilled by cache.