### PR TITLE
selftests tmp dir cleanup fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ smokecheck: clean uninstall develop
 check: clean uninstall develop
 	# Unless manually set, this is equivalent to AVOCADO_CHECK_LEVEL=0
 	$(PYTHON) selftests/check.py
-	selftests/check_tmp_dirs
 
 develop:
 	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -13,6 +13,7 @@ from avocado import Test
 from avocado.core import exit_codes
 from avocado.core.job import Job
 from avocado.core.suite import TestSuite
+from avocado.utils import process
 from selftests.utils import python_module_available
 
 
@@ -808,6 +809,9 @@ def main(args):  # pylint: disable=W0621
             print("check.py didn't clean test results.")
             print("uncleaned directories:")
             print(post_job_test_result_dirs.difference(pre_job_test_result_dirs))
+
+    # tmp dirs clean up check
+    process.run(f"{sys.executable} selftests/check_tmp_dirs")
     return exit_code
 
 

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -8,6 +8,7 @@ import unittest
 import xml.dom.minidom
 import zipfile
 
+from avocado import Test
 from avocado.core import exit_codes
 from avocado.utils import path as utils_path
 from avocado.utils import process, script
@@ -883,15 +884,14 @@ class RunnerOperationTest(TestCaseTmpDir):
             )
 
 
-class DryRunTest(TestCaseTmpDir):
+class DryRunTest(Test):
     def test_dry_run(self):
         examples_path = os.path.join("examples", "tests")
         passtest = os.path.join(examples_path, "passtest.py")
         failtest = os.path.join(examples_path, "failtest.py")
         gendata = os.path.join(examples_path, "gendata.py")
         cmd = (
-            f"{AVOCADO} run --disable-sysinfo --dry-run "
-            f"--dry-run-no-cleanup --json - "
+            f"{AVOCADO} run --disable-sysinfo --dry-run --json - "
             f"-- {passtest} {failtest} {gendata}"
         )
         number_of_tests = 3

--- a/selftests/functional/plugin/runners/exec_test.py
+++ b/selftests/functional/plugin/runners/exec_test.py
@@ -7,7 +7,7 @@ from avocado.utils import script
 from selftests.utils import TestCaseTmpDir
 
 
-class ExecTestRunnerTest(Test, TestCaseTmpDir):
+class ExecTestRunnerTest(TestCaseTmpDir, Test):
     def test_env_variables(self):
         commands_path = os.path.join(self.tmpdir.name, "commands")
         script.make_script(commands_path, "uname -a")

--- a/selftests/functional/serial/requirements.py
+++ b/selftests/functional/serial/requirements.py
@@ -94,7 +94,7 @@ class FailTest(Test):
 '''
 
 
-class BasicTest(Test, TestCaseTmpDir):
+class BasicTest(TestCaseTmpDir, Test):
 
     """
     :avocado: dependency={"type": "package", "name": "podman", "action": "check"}


### PR DESCRIPTION
Some avocado selftests leave results in tmp directory. This is caused by wrong inheritance order when test class inherits from Test and TestCaseTmpDir classes. This PR fixes it.

Signed-off-by: Jan Richter <jarichte@redhat.com>