### PR TITLE
Fixes for pylint 2.17.2 (Fedora 38)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -541,5 +541,5 @@ valid-metaclass-classmethod-first-arg=cls
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/avocado/utils/build.py
+++ b/avocado/utils/build.py
@@ -107,7 +107,7 @@ def make(
     :returns: exit status of the make process
     """
 
-    kwargs = dict(env=env, ignore_status=ignore_status)
+    kwargs = {"env": env, "ignore_status": ignore_status}
     if process_kwargs is not None:
         kwargs.update(process_kwargs)
     result = run_make(path, make, extra_args, kwargs)

--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -30,6 +30,10 @@ import re
 from avocado.utils.external import spark
 
 
+class GdbMiException(Exception):
+    pass
+
+
 class Token:
     def __init__(self, token_type, value=None):
         self.type = token_type
@@ -126,7 +130,7 @@ class GdbMiScannerBase(spark.GenericScanner):
 
     def t_default(self, s):  # pylint: disable=W0221
         r"( . | \n )+"
-        raise Exception(f"Specification error: unmatched input for '{s}'")
+        raise GdbMiException(f"Specification error: unmatched input for '{s}'")
 
     @staticmethod
     def __unescape(s):
@@ -200,7 +204,7 @@ class GdbMiParser(spark.GenericASTBuilder):
     def error(self, token, i=0, tokens=None):  # pylint: disable=W0221
         if i > 2:
             print(f"{tokens[i - 3]} {tokens[i - 2]} " f"{tokens[i - 1]} {tokens[i]}")
-        raise Exception(f"Syntax error at or near {int(i)}:'{token}' token")
+        raise GdbMiException(f"Syntax error at or near {int(i)}:'{token}' token")
 
 
 class GdbMiInterpreter(spark.GenericASTTraversal):
@@ -249,7 +253,7 @@ class GdbMiInterpreter(spark.GenericASTTraversal):
                     else:
                         node.value[n] = v
         else:
-            raise Exception("Invalid tuple")
+            raise GdbMiException("Invalid tuple")
         # print 'tuple: %s' % node.value
 
     @staticmethod

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -397,7 +397,9 @@ class GDB:
                 if result_response_received:
                     # raise an exception here, because no two result
                     # responses should come from a single command AFAIK
-                    raise Exception("Many result responses to a single cmd")
+                    raise UnexpectedResponseError(
+                        "Many result responses to a single cmd"
+                    )
                 result_response_received = True
                 cmd.result = parsed_response
             else:

--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -119,7 +119,7 @@ class KernelBuild:
             LOG.info("Uncompressing tarball")
             archive.extract(self.asset_path, self.work_dir)
         else:
-            raise Exception("Unable to find the tarball")
+            raise RuntimeError("Unable to find the tarball")
 
     def configure(self, targets=("defconfig"), extra_configs=None):
         """

--- a/examples/tests/multiple_tests.py
+++ b/examples/tests/multiple_tests.py
@@ -30,4 +30,4 @@ class MultipleTests(Test):
         """
         This method should never execute
         """
-        raise Exception("This action method should never be executed.")
+        raise RuntimeError("This action method should never be executed.")

--- a/examples/tests/uncaught_exception.py
+++ b/examples/tests/uncaught_exception.py
@@ -14,4 +14,4 @@ class ErrorTest(Test):
         """
         This should end with ERROR.
         """
-        raise Exception("This is a generic exception")
+        raise Exception("This is a generic exception")  # pylint: disable=W0719

--- a/selftests/.data/test_statuses.py
+++ b/selftests/.data/test_statuses.py
@@ -199,7 +199,7 @@ class ExitSetup(Test):
     def setUp(self):
         self.log.info("setup pre")
         sys.exit(-1)
-        self.log.info("setup post")
+        self.log.info("setup post")  # pylint: disable=W0101
 
     def test(self):
         self.log.info("test pre")
@@ -219,7 +219,7 @@ class ExitTest(Test):
     def test(self):
         self.log.info("test pre")
         sys.exit(-1)
-        self.log.info("test post")
+        self.log.info("test post")  # pylint: disable=W0101
 
     def tearDown(self):
         self.log.info("teardown pre")
@@ -240,7 +240,7 @@ class ExitTeardown(Test):
         self.log.info("teardown pre")
         self.log.info("teardown status: %s", self.status)
         sys.exit(-1)
-        self.log.info("teardown post")
+        self.log.info("teardown post")  # pylint: disable=W0101
 
 
 class ExceptionSetup(Test):


### PR DESCRIPTION
`make check` on the avocado sources fails on Fedora 38 due to pylint errors.  This seems to be because of new warnings introduced with a newer pylint.  Fix them.
