### PR TITLE
utils.network.hosts: Make subclass of Host instantiable

### DIFF
--- a/avocado/utils/network/hosts.py
+++ b/avocado/utils/network/hosts.py
@@ -48,7 +48,7 @@ class Host:
     """
 
     def __init__(self, host):
-        if isinstance(self, Host):
+        if type(self) == Host:  # pylint: disable=C0123
             raise TypeError("Host class should not be instantiated")
         self.host = host
 


### PR DESCRIPTION
A regression bug was introduced by 94fb7a8,which results Host's subclass LocalHost can not be instantiated. Existing instantiation methods the same as "localhost = LocalHost()" will no longer fail after changed.

ID:2219366
Signed-off-by: Lei Yang <leiyang@redhat.com>