### PR TITLE
Test file import versus system module

### DIFF
--- a/avocado/core/utils/loader.py
+++ b/avocado/core/utils/loader.py
@@ -37,10 +37,7 @@ def load_test(test_factory):
             inspect.isclass(obj)
             and obj.__name__ == test_class
             and inspect.getmodule(obj) == test_module
+            and issubclass(obj, test.Test)
         ):
-            if issubclass(obj, test.Test):
-                test_class = obj
-                break
-    test_instance = test_class(**test_parameters)
-
-    return test_instance
+            return obj(**test_parameters)
+    raise ImportError(f'Failed to find/load class "{test_class}" in "{test_path}"')

--- a/avocado/core/utils/loader.py
+++ b/avocado/core/utils/loader.py
@@ -36,32 +36,32 @@ def load_test(test_factory):
         test_path = test_parameters.pop("modulePath")
     else:
         test_path = None
-    if isinstance(test_class, str):
-        module_name = os.path.basename(test_path).split(".")[0]
-        test_module_dir = os.path.abspath(os.path.dirname(test_path))
-        # Tests with local dir imports need this
-        try:
-            sys.path.insert(0, test_module_dir)
-            test_module = importlib.import_module(module_name)
-        except:  # pylint: disable=W0702
-            # On load_module exception we fake the test class and pass
-            # the exc_info as parameter to be logged.
-            test_parameters["methodName"] = "test"
-            exception = stacktrace.prepare_exc_info(sys.exc_info())
-            test_parameters["exception"] = exception
-            return TestError(**test_parameters)
-        finally:
-            if test_module_dir in sys.path:
-                sys.path.remove(test_module_dir)
-        for _, obj in inspect.getmembers(test_module):
-            if (
-                inspect.isclass(obj)
-                and obj.__name__ == test_class
-                and inspect.getmodule(obj) == test_module
-            ):
-                if issubclass(obj, test.Test):
-                    test_class = obj
-                    break
+
+    module_name = os.path.basename(test_path).split(".")[0]
+    test_module_dir = os.path.abspath(os.path.dirname(test_path))
+    # Tests with local dir imports need this
+    try:
+        sys.path.insert(0, test_module_dir)
+        test_module = importlib.import_module(module_name)
+    except:  # pylint: disable=W0702
+        # On load_module exception we fake the test class and pass
+        # the exc_info as parameter to be logged.
+        test_parameters["methodName"] = "test"
+        exception = stacktrace.prepare_exc_info(sys.exc_info())
+        test_parameters["exception"] = exception
+        return TestError(**test_parameters)
+    finally:
+        if test_module_dir in sys.path:
+            sys.path.remove(test_module_dir)
+    for _, obj in inspect.getmembers(test_module):
+        if (
+            inspect.isclass(obj)
+            and obj.__name__ == test_class
+            and inspect.getmodule(obj) == test_module
+        ):
+            if issubclass(obj, test.Test):
+                test_class = obj
+                break
     test_instance = test_class(**test_parameters)
 
     return test_instance

--- a/avocado/core/utils/loader.py
+++ b/avocado/core/utils/loader.py
@@ -4,21 +4,6 @@ import os
 import sys
 
 from avocado.core import test
-from avocado.utils import stacktrace
-
-
-class TestError(test.Test):
-    """
-    Generic test error.
-    """
-
-    def __init__(self, *args, **kwargs):
-        exception = kwargs.pop("exception")
-        test.Test.__init__(self, *args, **kwargs)
-        self.exception = exception
-
-    def test(self):
-        self.error(self.exception)
 
 
 def load_test(test_factory):
@@ -43,13 +28,6 @@ def load_test(test_factory):
     try:
         sys.path.insert(0, test_module_dir)
         test_module = importlib.import_module(module_name)
-    except:  # pylint: disable=W0702
-        # On load_module exception we fake the test class and pass
-        # the exc_info as parameter to be logged.
-        test_parameters["methodName"] = "test"
-        exception = stacktrace.prepare_exc_info(sys.exc_info())
-        test_parameters["exception"] = exception
-        return TestError(**test_parameters)
     finally:
         if test_module_dir in sys.path:
             sys.path.remove(test_module_dir)

--- a/avocado/core/utils/loader.py
+++ b/avocado/core/utils/loader.py
@@ -17,11 +17,12 @@ def load_test(test_factory):
     test_class, test_parameters = test_factory
     if "run.results_dir" in test_parameters:
         test_parameters["base_logdir"] = test_parameters.pop("run.results_dir")
-    if "modulePath" in test_parameters:
-        test_path = test_parameters.pop("modulePath")
-    else:
-        test_path = None
+    if "modulePath" not in test_parameters:
+        raise RuntimeError(
+            'Test factory parameters is missing the module\'s path ("modulePath")'
+        )
 
+    test_path = test_parameters.pop("modulePath")
     module_name = os.path.basename(test_path).split(".")[0]
     test_module_dir = os.path.abspath(os.path.dirname(test_path))
     # Tests with local dir imports need this

--- a/avocado/core/utils/loader.py
+++ b/avocado/core/utils/loader.py
@@ -25,10 +25,13 @@ def load_test(test_factory):
     test_path = test_parameters.pop("modulePath")
     module_name = os.path.basename(test_path).split(".")[0]
     test_module_dir = os.path.abspath(os.path.dirname(test_path))
-    # Tests with local dir imports need this
+    spec = importlib.util.spec_from_file_location(module_name, test_path)
+    test_module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = test_module
     try:
+        # Tests with local dir imports need this
         sys.path.insert(0, test_module_dir)
-        test_module = importlib.import_module(module_name)
+        spec.loader.exec_module(test_module)
     finally:
         if test_module_dir in sys.path:
             sys.path.remove(test_module_dir)


### PR DESCRIPTION
This fixes a condition on the test loader for avocado-instrumented, in which it can fail to load module from correct path.

More on https://github.com/avocado-framework/avocado/issues/5686