### PR TITLE
CPU: Optimizing the Method of Obtaining CPU Version Information

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -134,13 +134,13 @@ def get_version():
     }
     cpu_info = _get_info()
     arch = get_arch()
-    try:
-        version_pattern[arch]
-    except KeyError as Err:
-        LOG.warning("No pattern string for arch: %s\n Error: %s", arch, Err)
-        return None
+    pattern = version_pattern.get(arch)
+    if not pattern:
+        LOG.warning("No pattern string for arch: %s", arch)
+        return ""
+
     for line in cpu_info:
-        version_out = re.findall(version_pattern[arch], line)
+        version_out = re.findall(pattern, line)
         if version_out:
             return version_out[0].decode("utf-8")
     return ""


### PR DESCRIPTION
1.By using the get() method to obtain matching patterns, it avoids using try exception to capture KeyError exceptions. 2.Immediately return the result after finding the version number to avoid unnecessary iteration. 
3.Use an empty string as the default return result to avoid returning None