### PR TITLE
modify PMemException method

### DIFF
--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -28,6 +28,7 @@ class PMemException(Exception):
     """
 
     def __init__(self, additional_text=None):  # pylint: disable=W0231
+        super().__init__()
         self.additional_text = additional_text
 
     def __str__(self):


### PR DESCRIPTION
In the above code, we use the super() function to call the __init__ method of the parent class, which ensures the consistency of the code when inheriting