### PR TITLE
avocado/core/loader.py: support Python 3.12 by using importlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,11 @@ jobs:
   smokecheck-osx:
 
     name: OS X with Python ${{ matrix.python-version }}
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10.0]
+        python-version: [3.11.1]
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
+      - name: Install Python 3.6 compatible urllib3
+        if: ${{ matrix.python-version == 3.6 }}
+        run: python3 -m pip install urllib3==1.26.16
       - name: Installing Avocado in develop mode
         run: python3 setup.py develop --user
       - name: Avocado version

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -26,7 +26,7 @@ setup(name='avocado-framework-plugin-robot',
       packages=find_packages(),
       include_package_data=True,
       install_requires=['avocado-framework==%s' % VERSION,
-                        'robotframework>=4.1'],
+                        'robotframework>=4.1,<6.0'],
       test_suite='tests',
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
The imp module is no longer available on Python 3.12.  Besides enabling usage under Python 3.12, also works as a backport for a test file location import fix.

This also enables RPM builds under Fedora 39.

Reference: https://github.com/avocado-framework/avocado/issues/5686
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=2220126