### PR TITLE
Avocado-instrumented default timeout removal

### DIFF
--- a/avocado/plugins/runners/avocado_instrumented.py
+++ b/avocado/plugins/runners/avocado_instrumented.py
@@ -42,8 +42,6 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
         "job.run.store_logging_stream",
     ]
 
-    DEFAULT_TIMEOUT = 86400
-
     @staticmethod
     def _create_params(runnable):
         """Create params for the test"""
@@ -145,7 +143,7 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
 
             time_started = time.monotonic()
 
-            timeout = float(self.DEFAULT_TIMEOUT)
+            timeout = float("inf")
             next_status_time = None
             while True:
                 time.sleep(RUNNER_RUN_CHECK_INTERVAL)
@@ -161,7 +159,7 @@ class AvocadoInstrumentedTestRunner(BaseRunner):
                 else:
                     message = queue.get()
                     if message.get("type") == "early_state":
-                        timeout = float(message.get("timeout") or self.DEFAULT_TIMEOUT)
+                        timeout = float(message.get("timeout") or float("inf"))
                     else:
                         yield message
                     if message.get("status") == "finished":

--- a/selftests/functional/plugin/runners/avocado_instrumented.py
+++ b/selftests/functional/plugin/runners/avocado_instrumented.py
@@ -1,0 +1,18 @@
+from avocado import Test
+from avocado.core.exit_codes import AVOCADO_JOB_INTERRUPTED
+from avocado.utils import process
+from selftests.utils import AVOCADO, TestCaseTmpDir
+
+
+class AvocadoInstrumentedRunnerTest(TestCaseTmpDir, Test):
+    def test_timeout(self):
+        cmd_line = (
+            f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+            f"-- examples/tests/timeouttest.py "
+        )
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, AVOCADO_JOB_INTERRUPTED)
+        self.assertIn(
+            "examples/tests/timeouttest.py:TimeoutTest.test:  INTERRUPTED: timeout",
+            result.stdout_text,
+        )


### PR DESCRIPTION
This will remove unsystematic timeout inside avocado-instrumented runner. This timeout has been set to 24 hours and users haven't had a way how to change it. Because we solved problems with `task.timeout.running` in #5383 and `job-timeout` in #5295 this default timeout is not needed anymore. After this change, the users will have more power over timeouts and will be able to run instrumented tests longer than 24 hours.

Reference: #5394