### PR TITLE
Dependencies weren't fulfilled fix

### DIFF
--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -7,6 +7,7 @@ import time
 from avocado.core.exceptions import JobFailFast
 from avocado.core.task.runtime import RuntimeTaskStatus
 from avocado.core.teststatus import STATUSES_NOT_OK
+from avocado.core.utils import messages
 
 LOG = logging.getLogger(__name__)
 
@@ -192,25 +193,14 @@ class Worker:
         for terminated_task in terminate_tasks:
             task_id = str(terminated_task.task.identifier)
             job_id = terminated_task.task.job_id
-            encoding = "utf-8"
-            log_message = {
-                "status": "running",
-                "type": "log",
-                "log": f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | "
-                f"Runner error occurred: {reason}".encode(encoding),
-                "encoding": encoding,
-                "time": time.monotonic(),
-                "id": task_id,
-                "job_id": job_id,
-            }
-            finish_message = {
-                "status": "finished",
-                "result": "interrupted",
-                "fail_reason": f"Test interrupted: {reason}",
-                "time": time.monotonic(),
-                "id": task_id,
-                "job_id": job_id,
-            }
+            log_message = messages.LogMessage.get(
+                f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | Runner error occurred: {reason}",
+                id=task_id,
+                job_id=job_id,
+            )
+            finish_message = messages.FinishedMessage.get(
+                "interrupted", f"Test interrupted: {reason}", id=task_id, job_id=job_id
+            )
             try:
                 current_status, _ = self._state_machine._status_repo._status[task_id]
             except KeyError:
@@ -298,31 +288,20 @@ class Worker:
                     if is_task_in_cache:
                         task_id = str(runtime_task.task.identifier)
                         job_id = runtime_task.task.job_id
-                        encoding = "utf-8"
-                        start_message = {
-                            "status": "started",
-                            "time": time.monotonic(),
-                            "output_dir": runtime_task.task.runnable.output_dir,
-                            "id": task_id,
-                            "job_id": job_id,
-                        }
-                        log_message = {
-                            "status": "running",
-                            "type": "log",
-                            "log": f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | "
-                            f"Dependency fulfilled from cache.".encode(encoding),
-                            "encoding": encoding,
-                            "time": time.monotonic(),
-                            "id": task_id,
-                            "job_id": job_id,
-                        }
-                        finish_message = {
-                            "status": "finished",
-                            "result": "pass",
-                            "time": time.monotonic(),
-                            "id": task_id,
-                            "job_id": job_id,
-                        }
+                        start_message = messages.StartedMessage.get(
+                            output_dir=runtime_task.task.runnable.output_dir,
+                            id=task_id,
+                            job_id=job_id,
+                        )
+                        log_message = messages.LogMessage.get(
+                            f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | "
+                            f"Dependency fulfilled from cache.",
+                            id=task_id,
+                            job_id=job_id,
+                        )
+                        finish_message = messages.FinishedMessage.get(
+                            "pass", id=task_id, job_id=job_id
+                        )
                         self._state_machine._status_repo.process_message(start_message)
                         self._state_machine._status_repo.process_message(log_message)
                         self._state_machine._status_repo.process_message(finish_message)

--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -60,6 +60,7 @@ class FinishedMessage(GenericMessage):
         class_name=None,
         fail_class=None,
         traceback=None,
+        **kwargs,
     ):  # pylint: disable=W0221
         """Creates finished message with all necessary information.
 
@@ -79,14 +80,13 @@ class FinishedMessage(GenericMessage):
         :return: finished message
         :rtype: dict
         """
-        return super().get(
-            result=result,
-            fail_reason=fail_reason,
-            returncode=returncode,
-            class_name=class_name,
-            fail_class=fail_class,
-            traceback=traceback,
-        )
+        kwargs["result"] = result
+        kwargs["fail_reason"] = fail_reason
+        kwargs["returncode"] = returncode
+        kwargs["class_name"] = class_name
+        kwargs["fail_class"] = fail_class
+        kwargs["traceback"] = traceback
+        return super().get(**kwargs)
 
 
 class GenericRunningMessage(GenericMessage):

--- a/selftests/functional/serial/requirements.py
+++ b/selftests/functional/serial/requirements.py
@@ -176,6 +176,10 @@ class BasicTest(TestCaseTmpDir, Test):
                 "SKIP 1",
                 result.stdout_text,
             )
+            self.assertIn(
+                "SKIP: Dependency was not fulfilled.",
+                result.stdout_text,
+            )
             self.assertNotIn(
                 "-foo-bar-",
                 result.stdout_text,


### PR DESCRIPTION
This PR adds information about skipping test due to the missing
dependencies.

Before this PR:
```
avocado run /tmp/test.py
JOB ID     : b17da893039e9d2deb33445a277ed2da40739a0d
JOB LOG    :
/home/janrichter/avocado/job-results/job-2023-04-20T13.55-b17da89/job.log
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 1 | WARN 0 | INTERRUPT 0 |
CANCEL 0
JOB HTML   :
/home/janrichter/avocado/job-results/job-2023-04-20T13.55-b17da89/results.html
JOB TIME   : 2.20 s
```

After this PR:
```
avocado run /tmp/test.py
JOB ID     : b17da893039e9d2deb33445a277ed2da40739a0d
JOB LOG    :
/home/janrichter/avocado/job-results/job-2023-04-20T13.55-b17da89/job.log
 (1/1) /tmp/test.py:PassTest.test: STARTED
 (1/1) /tmp/test.py:PassTest.test: SKIP: Dependecies wasn't fulfilled.
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 1 | WARN 0 | INTERRUPT 0 |
CANCEL 0
JOB HTML   :
/home/janrichter/avocado/job-results/job-2023-04-20T13.55-b17da89/results.html
JOB TIME   : 2.20 s
```

Reference: https://github.com/avocado-framework/avocado/issues/5657
Signed-off-by: Jan Richter <jarichte@redhat.com>