### PR TITLE
KERNEL: Optimize source code to build the kernel

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -176,15 +176,12 @@ class KernelBuild:
         make_args = []
         LOG.info("Starting build the kernel")
 
-        if njobs is None:
-            make_args.append("-j")
-        elif njobs > 0:
-            make_args.extend(["-j", str(njobs)])
+        if njobs is not None and njobs > 0:
+            make_args.append("-j" + str(njobs))
         make_args.extend(["-C", self._build_dir])
 
-        if binary_package is True:
-            if self.distro.name == "Ubuntu":
-                make_args.append("deb-pkg")
+        if binary_package and self.distro.name == "Ubuntu":
+            make_args.append("deb-pkg")
 
         build.make(self._build_dir, extra_args=" ".join(make_args))
 


### PR DESCRIPTION
Omitted the requirement for multiprocessing. CPU_ Call count() and use None as the default value for njobs. We will check if njobs is a positive number, and if so, link the '- j' option with its value and add it to make_ Args list. Then, based on the binary_ Determine whether to add 'deb pkg' to make based on the conditions of package and distribution name_ Args list. Finally, we use spaces to make_ Connect the strings in the args list and call the build. make() function to perform the build operation