### PR TITLE
Variable optimization for absolute path checking methods

### DIFF
--- a/avocado/core/utils/path.py
+++ b/avocado/core/utils/path.py
@@ -29,10 +29,8 @@ def system_wide_or_base_path(file_path):
     :type file_path: str
     :rtype: str
     """
-    if os.path.isabs(file_path):
-        abs_path = file_path
-    else:
-        abs_path = os.path.join(os.path.sep, file_path)
-    if os.path.exists(abs_path):
-        return abs_path
-    return prepend_base_path(file_path)
+    if not os.path.isabs(file_path):
+        file_path = os.path.join(os.path.sep, file_path)
+    if not os.path.exists(file_path):
+        return prepend_base_path(file_path)
+    return file_path


### PR DESCRIPTION
The optimized method avoids creating unnecessary intermediate variable abs_path.
and directly processes on the original variable file_path, making the code more concise.

Signed-off-by: wulei01 <wulei@uniontech.com>