### PR TITLE
Check execution file method optimization

### DIFF
--- a/avocado/utils/iso9660.py
+++ b/avocado/utils/iso9660.py
@@ -57,10 +57,10 @@ def has_userland_tool(executable):
     :rtype: bool
     """
     if os.path.isabs(executable):
-        return os.path.exists(executable)
+        return os.path.isfile(executable)
     else:
-        for path in os.environ["PATH"].split(":"):
-            if os.path.exists(os.path.join(path, executable)):
+        for path in os.environ["PATH"].split(os.pathsep):
+            if os.path.isfile(os.path.join(path, executable)):
                 return True
     return False
 


### PR DESCRIPTION
Use os.pathsep instead of the hard coded path separator ':'. 
os.pathsep represents the path separator for the current operating system . 
Use os. path. isfile() instead of os. path. exists() to check if the given path is a file. 
This can avoid misjudging the directory as an executable file.