### PR TITLE
exist_ok in utils.path.init_dir

### DIFF
--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -72,7 +72,7 @@ def init_dir(*args):
     """
     directory = os.path.join(*args)
     if not os.path.isdir(directory):
-        os.makedirs(directory)
+        os.makedirs(directory, exist_ok=True)
     return directory
 
 


### PR DESCRIPTION
When we are creating path with utils.path.init_dir method, we might get FileExistsError when part of this directory have already existed. This issue created failure of
`selftests.functiona.job_api_features:Test.test_runnable_output_dir` test. Let's set exist_ok to True to avoid FileExistsError.

https://download.copr.fedorainfracloud.org/results/packit/avocado-framework-avocado-5744/fedora-38-aarch64/06259385-python-avocado/builder-live.log.gz