### PR TITLE
status server uris sync up

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -36,6 +36,8 @@ from avocado.core.status.server import StatusServer
 from avocado.core.task.runtime import RuntimeTaskGraph
 from avocado.core.task.statemachine import TaskStateMachine, Worker
 
+DEFAULT_SERVER_URI = "127.0.0.1:8888"
+
 
 class RunnerInit(Init):
 
@@ -69,12 +71,14 @@ class RunnerInit(Init):
 
         help_msg = (
             'URI where status server will listen on. Usually a "HOST:PORT" '
-            'string. This is only effective if "status_server_auto" is disabled'
+            'string. This is only effective if "status_server_auto" is disabled. '
+            'If "status_server_uri" is not set, the value from "status_server_listen " '
+            "will be used."
         )
         settings.register_option(
             section=section,
             key="status_server_listen",
-            default="127.0.0.1:8888",
+            default=DEFAULT_SERVER_URI,
             metavar="HOST:PORT",
             help_msg=help_msg,
         )
@@ -84,11 +88,13 @@ class RunnerInit(Init):
             'a "HOST:PORT" string. Use this if your status server '
             "is in another host, or different port. This is only "
             'effective if "status_server_auto" is disabled'
+            'If "status_server_listen" is not set. Value from "status_server_uri" '
+            "will be used."
         )
         settings.register_option(
             section=section,
             key="status_server_uri",
-            default="127.0.0.1:8888",
+            default=DEFAULT_SERVER_URI,
             metavar="HOST:PORT",
             help_msg=help_msg,
         )
@@ -229,7 +235,23 @@ class Runner(SuiteRunner):
                 return os.path.join(self.status_server_dir.name, ".status_server.sock")
         return test_suite.config.get(config_key)
 
+    def _sync_status_server_urls(self, config):
+        server_listen = config.get("run.status_server_listen")
+        server_uri = config.get("run.status_server_uri")
+        if not config.get("run.status_server_auto"):
+            if (
+                server_uri is not DEFAULT_SERVER_URI
+                and server_listen is DEFAULT_SERVER_URI
+            ):
+                config["run.status_server_listen"] = server_uri
+            if (
+                server_uri is DEFAULT_SERVER_URI
+                and server_listen is not DEFAULT_SERVER_URI
+            ):
+                config["run.status_server_uri"] = server_listen
+
     def _create_status_server(self, test_suite, job):
+        self._sync_status_server_urls(test_suite.config)
         listen = self._determine_status_server(test_suite, "run.status_server_listen")
         # pylint: disable=W0201
         self.status_repo = StatusRepo(job.unique_id)

--- a/selftests/functional/plugin/runner_nrunner.py
+++ b/selftests/functional/plugin/runner_nrunner.py
@@ -1,0 +1,16 @@
+from avocado.core.exit_codes import AVOCADO_ALL_OK
+from avocado.utils import process
+from selftests.utils import AVOCADO, TestCaseTmpDir
+
+
+class NrunnerTest(TestCaseTmpDir):
+    def test_status_server_uri(self):
+        result = process.run(
+            f"{AVOCADO} run "
+            f"--job-results-dir {self.tmpdir.name} "
+            f"--disable-sysinfo --status-server-disable-auto "
+            f"--status-server-uri 127.0.0.1:9999 "
+            f"examples/tests/true",
+        )
+        self.assertIn("PASS 1 ", result.stdout_text)
+        self.assertEqual(result.exit_status, AVOCADO_ALL_OK)


### PR DESCRIPTION
When user sets only one of the status server values (uri, listen) Then the avocado will stop working because it will listen on different uri than the messages will be sent. This change will synchronize these values if the user sets only one of them.

Reference: #5740