### PR TITLE
Doc fixes before LTS - Avocado User’s Guide

### DIFF
--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -1,3 +1,5 @@
+.. _writing_plugin:
+
 *************************
 Writing an Avocado plugin
 *************************

--- a/docs/source/guides/contributor/chapters/runners.rst
+++ b/docs/source/guides/contributor/chapters/runners.rst
@@ -81,6 +81,8 @@ doing::
 To be able to complete such a command, Avocado needs to find the tests, and
 then to execute them.  Those two major steps are described next.
 
+.. _finding_tests:
+
 Finding tests
 ~~~~~~~~~~~~~
 

--- a/docs/source/guides/user/chapters/advanced.rst
+++ b/docs/source/guides/user/chapters/advanced.rst
@@ -8,18 +8,15 @@ In some cases, you might have a wrapper as an entry point for the tests, so
 Avocado will use only the wrapper as test id. For instance, imagine a Makefile
 with some targets ('foo', 'bar') and each target is one test. Having a single
 test suite with a test calling `foo`, it will make Avocado print something like
-this:
+this::
 
-
-```
-JOB ID     : b6e5bdf2c891382bbde7f24e906a168af351154a
-JOB LOG    : ~/avocado/job-results/job-2021-09-24T17.39-b6e5bdf/job.log
- (1/1) make: STARTED
- (1/1) make: PASS (2.72 s)
-RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
-JOB HTML   : ~/avocado/job-results/job-2021-09-24T17.39-b6e5bdf/results.html
-JOB TIME   : 5.49 s
-```
+ JOB ID     : b6e5bdf2c891382bbde7f24e906a168af351154a
+ JOB LOG    : ~/avocado/job-results/job-2021-09-24T17.39-b6e5bdf/job.log
+  (1/1) make: STARTED
+  (1/1) make: PASS (2.72 s)
+ RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
+ JOB HTML   : ~/avocado/job-results/job-2021-09-24T17.39-b6e5bdf/results.html
+ JOB TIME   : 5.49 s
 
 This is happening because Avocado is using the 'uri' as identifier with in the
 current Runnables.
@@ -33,17 +30,15 @@ identifier_format = "{uri}-{args[0]}"
 ```
 
 With the above adjustment, running the same suite it will produce something
-like this:
+like this::
 
-```
-JOB ID     : 577b70b079e9a6f325ff3e73fd9b93f80ee7f221
-JOB LOG    : /home/local/avocado/job-results/job-2021-11-23T13.12-577b70b/job.log
- (1/1) "/usr/bin/make-foo": STARTED
- (1/1) "/usr/bin/make-foo": PASS (0.01 s)
-RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
-JOB HTML   : ~/avocado/job-results/job-2021-11-23T13.12-577b70b/results.html
-JOB TIME   : 0.97 s
-```
+ JOB ID     : 577b70b079e9a6f325ff3e73fd9b93f80ee7f221
+ JOB LOG    : /home/local/avocado/job-results/job-2021-11-23T13.12-577b70b/job.log
+  (1/1) "/usr/bin/make-foo": STARTED
+  (1/1) "/usr/bin/make-foo": PASS (0.01 s)
+ RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
+ JOB HTML   : ~/avocado/job-results/job-2021-11-23T13.12-577b70b/results.html
+ JOB TIME   : 0.97 s
 
 For the `identifier_format` you can use any f-string that it will use `{uri}`,
 `{args}` or `{kwargs}`. By default it will use `{uri}`.

--- a/docs/source/guides/user/chapters/configuring.rst
+++ b/docs/source/guides/user/chapters/configuring.rst
@@ -81,7 +81,7 @@ So the file parsing order is:
   * ``avocado.plugins.settings`` plugins (but they can insert to any location)
 
         - For more information about this, visit the "Contributor's Guide"
-          section named "Writing an Avocado plugin"
+          section named :ref:`writing_plugin`
 
   * ``~/.config/avocado/avocado.conf``
 
@@ -228,10 +228,6 @@ Example using the command-line:
 .. code-block:: bash
 
   $ avocado run --verbose /bin/true
-
-.. note:: Currently we still have some "old style boolean" options where you
-  should pass "on" or "off" on the command-line. i.e: ``--json-job-result=off``.
-  Those options are going to be replaced soon.
 
 Lists
 ~~~~~

--- a/docs/source/guides/user/chapters/datadirs.rst
+++ b/docs/source/guides/user/chapters/datadirs.rst
@@ -49,6 +49,3 @@ place temporary files used by tests. That directory will be in normal circumstan
 ``/var/tmp/avocado_XXXXX``, (where ``XXXXX`` is in actuality a random string) securely
 created on ``/var/tmp/``, unless the user has the ``$TMPDIR`` environment variable set,
 since that is customary among unix programs.
-
-The next section of the documentation explains how you can see and set config
-values that modify the behavior for the Avocado utilities and plugins.

--- a/docs/source/guides/user/chapters/dependencies.rst
+++ b/docs/source/guides/user/chapters/dependencies.rst
@@ -3,8 +3,6 @@
 Managing Dependencies
 =====================
 
-.. note:: Test dependencies are supported only on the nrunner runner.
-
 A test's dependency can be fulfilled by the Dependencies Resolver feature.
 
 Test's dependencies are specified in the test definition and are fulfilled

--- a/docs/source/guides/user/chapters/installing.rst
+++ b/docs/source/guides/user/chapters/installing.rst
@@ -19,7 +19,7 @@ Installing from PyPI
 --------------------
 
 The simplest installation method is through ``pip``.  On most POSIX systems
-with Python 3.4 (or later) and ``pip`` available, installation can be performed
+with Python 3.7 (or later) and ``pip`` available, installation can be performed
 with a single command::
 
   $ pip3 install --user avocado-framework
@@ -56,7 +56,7 @@ version 29.  To subscribe to the latest version stream, run::
 
 Or, to use the LTS (Long Term Stability) version stream, run::
 
-  $ dnf module enable avocado:82lts
+  $ dnf module enable avocado:103lts
 
 Then proceed to install a module profile or individual packages.  If you're
 unsure about what to do, simply run::
@@ -127,7 +127,7 @@ Then to install Avocado from the git repository run::
     $ cd avocado
     $ python3 setup.py install --user
 
-Optionally, to install the plugins run:
+Optionally, to install the plugins run::
 
     $ python3 setup.py plugin --install=golang --user
     $ python3 setup.py plugin --install=html --user

--- a/docs/source/guides/user/chapters/introduction.rst
+++ b/docs/source/guides/user/chapters/introduction.rst
@@ -13,11 +13,13 @@ test reference, which could be either a path to the file, or a recognizable
 name::
 
     $ avocado run /bin/true
-    JOB ID     : 3a5c4c51ceb5369f23702efb10b4209b111141b2
-    JOB LOG    : $HOME/avocado/job-results/job-2019-10-31T10.34-3a5c4c5/job.log
-     (1/1) /bin/true: PASS (0.04 s)
+    JOB ID     : 89b5d609d4832c784f04cf14f4ec2d17917d419a
+    JOB LOG    : $HOME/avocado/job-results/job-2023-09-06T15.52-89b5d60/job.log
+     (1/1) /bin/true: STARTED
+     (1/1) /bin/true: PASS (0.01 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
-    JOB TIME   : 0.15 s
+    JOB HTML   : $HOME/avocado/job-results/job-2023-09-06T15.52-89b5d60/results.html
+    JOB TIME   : 1.49 s
 
 You probably noticed that we used ``/bin/true`` as a test, and in
 accordance with our expectations, it passed! These are known as
@@ -57,19 +59,19 @@ instrumented and executable tests::
 Using a different runner
 ------------------------
 
-Currently Avocado has two test runners: ``nrunner`` (the new runner) and
-``runner`` (legacy).  You can find a list of current runners installed with the
+Currently Avocado has only one runner: ``nrunner`` (the new runner)
+But some plugins may use their own runners.
+You can find a list of current runners installed with the
 ``avocado plugins`` command::
 
   $ avocado plugins
   Plugins that run test suites on a job (runners):
   nrunner nrunner based implementation of job compliant runner
-  runner  The conventional test runner
 
 During the test execution, you can select the runner using the option
-``--test-runner``, where the default is the nrunner one::
+``--suite-runner``, where the default is the nrunner one::
 
-  $ avocado run --test-runner='runner' /bin/true
+  $ avocado run --suite-runner='runner' /bin/true
 
 
 Interrupting tests
@@ -170,7 +172,8 @@ them to tests. If one or more test references can not be resolved to tests, the
 Job will not be created. Example::
 
     $ avocado run examples/tests/passtest.py badtest.py
-    Unable to resolve reference(s) 'badtest.py' with plugins(s) 'file', 'robot', try running 'avocado -V list badtest.py' to see the details.
+    No tests found for given test references: badtest.py
+    Try 'avocado -V list badtest.py' for details
 
 But if you want to execute the Job anyway, with the tests that could be
 resolved, you can use ``--ignore-missing-references``, a boolean command-line
@@ -366,7 +369,7 @@ Avocado features. A reasonable effort will be made to not break backwards
 compatibility with applications that parse the current form of its JSON result.
 
 
- **3. TAP:**
+**3. TAP:**
 
 Provides the basic `TAP <https://testanything.org/>`__ (Test Anything Protocol)
 results, currently in v12. Unlike most existing Avocado machine readable
@@ -377,7 +380,7 @@ outputs this one is streamlined (per test results)::
     ok 1 examples/tests/sleeptest.py:SleepTest.test
 
 
- **4. Beaker:**
+**4. Beaker:**
 
 When avocaodo finds itself running inside a beaker task the
 beaker_report plugin will send the test results and log files to the
@@ -396,16 +399,14 @@ In order to do that, you can use ``avocado --show=job run ...``::
 
     $ avocado --show=job run examples/tests/sleeptest.py
     ...
-    Job ID: f9ea1742134e5352dec82335af584d1f151d4b85
+    
+    avocado.job: Job ID: c9ca6a96d34fd0355f5f121af7fa87eef734a196
+    avocado.job:
+    avocado.job: examples/tests/sleeptest.py:SleepTest.test: STARTED
+    avocado.job: examples/tests/sleeptest.py:SleepTest.test: PASS
+    avocado.job: More information in $HOME/avocado/job-results/job-2023-09-08T15.27-c9ca6a9/test-results/1-examples_tests_sleeptest.py_SleepTest.test
+    avocado.job: Test results available in $HOME/avocado/job-results/job-2023-09-08T15.27-c9ca6a9
 
-    START 1-sleeptest.py:SleepTest.test
-
-    PARAMS (key=timeout, path=*, default=None) => None
-    PARAMS (key=sleep_length, path=*, default=1) => 1
-    Sleeping for 1.00 seconds
-    PASS 1-sleeptest.py:SleepTest.test
-
-    Test results available in $HOME/avocado/job-results/job-2015-06-02T10.45-f9ea174
 
 As you can see, the UI output is suppressed and only the job log is shown,
 making this a useful feature for test development and debugging.

--- a/docs/source/guides/user/chapters/operations.rst
+++ b/docs/source/guides/user/chapters/operations.rst
@@ -15,8 +15,10 @@ from the command line, such as::
   $ avocado run /bin/true /bin/false
   JOB ID     : 42c60bea72e6d55756bfc784eb2b354f788541cf
   JOB LOG    : $HOME/avocado/job-results/job-2020-08-13T11.23-42c60be/job.log
+   (1/2) /bin/true: STARTED
+   (2/2) /bin/false: STARTED
    (1/2) /bin/true: PASS (0.01 s)
-   (2/2) /bin/false: FAIL: Exited with status: '1', stdout: '' stderr: '' (0.08 s)
+   (2/2) /bin/false: FAIL (0.01 s)
   RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB HTML   : $HOME/avocado/job-results/job-2020-08-13T11.23-42c60be/results.html
   JOB TIME   : 0.41 s
@@ -31,8 +33,10 @@ Resulting in::
   JOB ID     : f3139826f1b169a0b456e0e880ffb83ed26d9858
   SRC JOB ID : latest
   JOB LOG    : $HOME/avocado/job-results/job-2020-08-13T11.24-f313982/job.log
-   (1/2) /bin/true: PASS (0.01 s)
-   (2/2) /bin/false: FAIL: Exited with status: '1', stdout: '' stderr: '' (0.07 s)
+   (1-2/2) /bin/false: STARTED
+   (1-1/2) /bin/true: STARTED
+   (1-2/2) /bin/false: FAIL (0.01 s)
+   (1-1/2) /bin/true: PASS (0.01 s)
   RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
   JOB HTML   : $HOME/avocado/job-results/job-2020-08-13T11.24-f313982/results.html
   JOB TIME   : 0.39 s
@@ -159,7 +163,8 @@ using the ``--dry-run`` argument::
     $ avocado run /bin/true --dry-run
     JOB ID     : 0000000000000000000000000000000000000000
     JOB LOG    : /var/tmp/avocado-dry-run-k2i_uiqx/job-2020-09-02T09.09-0000000/job.log
-     (1/1) /bin/true: CANCEL: Test cancelled due to --dry-run (0.01 s)
+     (1/1) /bin/true: STARTED
+     (1/1) /bin/true: CANCEL: Test cancelled due to --dry-run (0.00 s)
     RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
     JOB HTML   : /var/tmp/avocado-dry-run-k2i_uiqx/job-2020-09-02T09.09-0000000/results.html
     JOB TIME   : 0.29 s
@@ -205,4 +210,4 @@ tests::
 Notice that the verbose flag also adds summary information.
 
 .. seealso:: To read more about test discovery, visit the section
-  "Understanding the test discovery (Avocado Loaders)".
+  :ref:`finding_tests`.

--- a/docs/source/guides/user/chapters/plugins.rst
+++ b/docs/source/guides/user/chapters/plugins.rst
@@ -92,7 +92,7 @@ developers to make execution more effective. To list the plugins in execution
 order, you can use ``avocado plugins --ordered``.
 
 .. note:: For more information about how the execution order is set, please
-   visit visit the Plugin section on Contributor's Guide.
+   visit the :ref:`writing_plugin` section on Contributor's Guide.
 
 Changing the plugin execution order
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,7 +109,7 @@ That configuration sets the ``job.prepost.myplugin`` plugin to execute before
 the standard Avocado ``job.prepost.jobscripts`` does.
 
 .. note:: If you are interested on how plugins works and how to create your own
-  plugin, visit the Plugin section on Contributor's Guide.
+  plugin, visit the :ref:`writing_plugin` section on Contributor's Guide.
 
 Pre and post plugins
 --------------------

--- a/docs/source/guides/user/chapters/results.rst
+++ b/docs/source/guides/user/chapters/results.rst
@@ -8,7 +8,7 @@ name includes a timestamp, such as ``job-2021-09-28T14.21-e0775d9``. A typical
 results directory structure can be seen below ::
 
     $HOME/avocado/job-results/job-2021-09-28T14.21-e0775d9/
-    ├── avocado.core.DEBUG
+    ├── full.log
     ├── id
     ├── jobdata
     │   ├── args.json
@@ -16,7 +16,7 @@ results directory structure can be seen below ::
     │   ├── config
     │   ├── pwd
     │   ├── test_references
-    │   └── variants-1.json
+    │   └── variants-1-1.json
     ├── job.log
     ├── results.html
     ├── results.json
@@ -84,27 +84,33 @@ results directory structure can be seen below ::
     │   │   └── version
     │   └── profile
     └── test-results
-        ├── 1-examples_tests_sleeptest.py_SleepTest.test
+        ├── 1-1-_bin_true
         │   ├── debug.log
-        │   └── whiteboard
-        ├── 2-examples_tests_sleeptest.py_SleepTest.test
+        │   ├── stderr
+        │   └── stdout
+        ├── 1-2-_bin_false
         │   ├── debug.log
-        │   └── whiteboard
-        └── 3-examples_tests_sleeptest.py_SleepTest.test
-            ├── debug.log
-            └── whiteboard
+        │   ├── stderr
+        │   └── stdout
+        └── by-status
+            ├── FAIL
+            │   └── 1-2-_bin_false -> ../../1-2-_bin_false
+            └── PASS
+                └── 1-1-_bin_true -> ../../1-1-_bin_true
 
 From what you can see, the results directory has:
 
 1) A human readable ``id`` in the top level, with the job SHA1.
 2) A human readable ``job.log`` in the top level, with human readable logs of
    the task
-3) Subdirectory ``jobdata``, that contains machine readable data about the job.
-4) A machine readable ``results.xml`` and ``results.json`` in the top level,
+3) A human readable ``full.log`` in the top level, with human readable logs of
+   anything generated inside the job.
+4) Subdirectory ``jobdata``, that contains machine readable data about the job.
+5) A machine readable ``results.xml`` and ``results.json`` in the top level,
    with a summary of the job information in xUnit/json format.
-5) A top level ``sysinfo`` dir, with sub directories ``pre``, ``post`` and
+6) A top level ``sysinfo`` dir, with sub directories ``pre``, ``post`` and
    ``profile``, that store sysinfo files pre/post/during job, respectively.
-6) Subdirectory ``test-results``, that contains a number of subdirectories
+7) Subdirectory ``test-results``, that contains a number of subdirectories
    (filesystem-friendly test ids). Those test ids represent instances of test
    execution results.
 
@@ -113,7 +119,7 @@ Test execution instances specification
 
 The instances should have:
 
-1) A top level human readable ``job.log``, with job debug information
+1) A top level human readable ``job.log`` and ``full.log``, with job debug information
 2) A ``sysinfo`` subdirectory, with sub directories ``pre``, ``post`` and
    ``profile`` that store sysinfo files pre test, post test and
    profiling info while the test was running, respectively.

--- a/docs/source/guides/user/chapters/tags.rst
+++ b/docs/source/guides/user/chapters/tags.rst
@@ -158,5 +158,5 @@ could use::
 
 
 .. seealso:: If you would like to understand how write plugins and how describe
-  tags inside a plugin, please visit the section: `Writing Tests` on Avocado Test
+  tags inside a plugin, please visit the :ref:`writing_tests` on Avocado Test
   Writer's Guide.

--- a/docs/source/guides/user/chapters/tags.rst
+++ b/docs/source/guides/user/chapters/tags.rst
@@ -1,9 +1,6 @@
 Filtering tests by tags
 =======================
 
-.. warning:: The example perf.py is not distributed with avocado anymore.
-             This is an old example that needs to be updated.
-
 Avocado allows tests to be given tags, which can be used to create test
 categories. With tags set, users can select a subset of the tests found by the
 test resolver.
@@ -11,18 +8,22 @@ test resolver.
 Usually, listing and executing tests with the Avocado test runner
 would reveal all three tests::
 
-  $ avocado list perf.py
-  avocado-instrumented perf.py:Disk.test_device
-  avocado-instrumented perf.py:Network.test_latency
-  avocado-instrumented perf.py:Network.test_throughput
-  avocado-instrumented perf.py:Idle.test_idle
+  $ avocado list examples/tests/tags.py
+  avocado-instrumented examples/tests/tags.py:FastTest.test_fast
+  avocado-instrumented examples/tests/tags.py:FastTest.test_fast_other
+  avocado-instrumented examples/tests/tags.py:SlowTest.test_slow
+  avocado-instrumented examples/tests/tags.py:SlowUnsafeTest.test_slow_unsafe
+  avocado-instrumented examples/tests/tags.py:SafeTest.test_safe
+  avocado-instrumented examples/tests/tags.py:SafeX86Test.test_safe_x86
+  avocado-instrumented examples/tests/tags.py:NoTagsTest.test_no_tags
+  avocado-instrumented examples/tests/tags.py:SafeAarch64Test.test_safe_aarch64
 
 If you want to list or run only the network based tests, you can do so
 by requesting only tests that are tagged with ``net``::
 
-  $ avocado list perf.py --filter-by-tags=net
-  avocado-instrumented perf.py:Network.test_latency
-  avocado-instrumented perf.py:Network.test_throughput
+  $ avocado list examples/tests/tags.py --filter-by-tags=net
+  avocado-instrumented examples/tests/tags.py:FastTest.test_fast
+  avocado-instrumented examples/tests/tags.py:FastTest.test_fast_other
 
 Now, suppose you're not in an environment where you're comfortable
 running a test that will write to your raw disk devices (such as your
@@ -30,16 +31,21 @@ development workstation).  You know that some tests are tagged
 with ``safe`` while others are tagged with ``unsafe``.  To only
 select the "safe" tests you can run::
 
-  $ avocado list perf.py --filter-by-tags=safe
-  avocado-instrumented perf.py:Network.test_latency
-  avocado-instrumented perf.py:Network.test_throughput
+  $ avocado list examples/tests/tags.py --filter-by-tags=safe
+  avocado-instrumented examples/tests/tags.py:SafeTest.test_safe
+  avocado-instrumented examples/tests/tags.py:SafeX86Test.test_safe_x86
+  avocado-instrumented examples/tests/tags.py:SafeAarch64Test.test_safe_aarch64
 
 But you could also say that you do **not** want the "unsafe" tests
 (note the *minus* sign before the tag)::
 
-  $ avocado list perf.py --filter-by-tags=-unsafe
-  avocado-instrumented perf.py:Network.test_latency
-  avocado-instrumented perf.py:Network.test_throughput
+  $ avocado list examples/tests/tags.py --filter-by-tags=-unsafe
+  avocado-instrumented examples/tests/tags.py:FastTest.test_fast
+  avocado-instrumented examples/tests/tags.py:FastTest.test_fast_other
+  avocado-instrumented examples/tests/tags.py:SlowTest.test_slow
+  avocado-instrumented examples/tests/tags.py:SafeTest.test_safe
+  avocado-instrumented examples/tests/tags.py:SafeX86Test.test_safe_x86
+  avocado-instrumented examples/tests/tags.py:SafeAarch64Test.test_safe_aarch64
 
 
 .. tip:: The ``-`` sign may cause issues with some shells.  One know
@@ -52,13 +58,13 @@ But you could also say that you do **not** want the "unsafe" tests
 If you require tests to be tagged with **multiple** tags, just add
 them separate by commas.  Example::
 
-  $ avocado list perf.py --filter-by-tags=disk,slow,superuser,unsafe
-  avocado-instrumented perf.py:Disk.test_device
+  $ avocado list examples/tests/tags.py --filter-by-tags=disk,slow,unsafe
+  avocado-instrumented examples/tests/tags.py:SlowUnsafeTest.test_slow_unsafe
 
 If no test contains **all tags** given on a single ``--filter-by-tags``
 parameter, no test will be included::
 
-  $ avocado list perf.py --filter-by-tags=disk,slow,superuser,safe | wc -l
+  $ avocado list examples/tests/tags.py --filter-by-tags=disk,slow,safe | wc -l
   0
 
 Multiple tags (AND vs OR)
@@ -72,10 +78,11 @@ operation).
 For instance To include all tests that have the ``disk`` tag and all
 tests that have the ``net`` tag, you can run::
 
-  $ avocado list perf.py --filter-by-tags=disk --filter-by-tags=net
-  avocado-instrumented perf.py:Disk.test_device
-  avocado-instrumented perf.py:Network.test_latency
-  avocado-instrumented perf.py:Network.test_throughput
+  $ avocado list examples/tests/tags.py --filter-by-tags=disk --filter-by-tags=net
+  avocado-instrumented examples/tests/tags.py:FastTest.test_fast
+  avocado-instrumented examples/tests/tags.py:FastTest.test_fast_other
+  avocado-instrumented examples/tests/tags.py:SlowTest.test_slow
+  avocado-instrumented examples/tests/tags.py:SlowUnsafeTest.test_slow_unsafe
 
 Including tests without tags
 ----------------------------
@@ -88,17 +95,19 @@ For instance, you may want to include tests of certain types that do
 not have support for tags (such as executable tests) or tests that have
 not (yet) received tags.  Consider this command::
 
-  $ avocado list perf.py /bin/true --filter-by-tags=disk
-  avocado-instrumented perf.py:Disk.test_device
+  $ avocado list examples/tests/tags.py /bin/true --filter-by-tags=disk
+  avocado-instrumented examples/tests/tags.py:SlowTest.test_slow
+  avocado-instrumented examples/tests/tags.py:SlowUnsafeTest.test_slow_unsafe
 
 Since it requires the ``disk`` tag, only one test was returned.  By
 using the ``--filter-by-tags-include-empty`` option, you can force the
 inclusion of tests without tags::
 
-  $ avocado list perf.py /bin/true --filter-by-tags=disk --filter-by-tags-include-empty
-  exec-test /bin/true
-  avocado-instrumented perf.py:Idle.test_idle
-  avocado-instrumented perf.py:Disk.test_device
+  $ avocado list examples/tests/tags.py /bin/true --filter-by-tags=disk --filter-by-tags-include-empty
+  avocado-instrumented examples/tests/tags.py:SlowTest.test_slow
+  avocado-instrumented examples/tests/tags.py:SlowUnsafeTest.test_slow_unsafe
+  avocado-instrumented examples/tests/tags.py:NoTagsTest.test_no_tags
+  exec-test            /bin/true
 
 Using further categorization with keys and values
 -------------------------------------------------

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -1,3 +1,5 @@
+.. _writing_tests:
+
 Writing Avocado Tests with Python
 =================================
 

--- a/examples/tests/tags.py
+++ b/examples/tests/tags.py
@@ -1,0 +1,79 @@
+import time
+
+from avocado import Test
+
+
+class DisabledTest(Test):
+    """
+    :avocado: disable
+    :avocado: tags=fast,net
+    """
+
+    def test_disabled(self):
+        pass
+
+
+class FastTest(Test):
+    """
+    :avocado: tags=fast
+    """
+
+    def test_fast(self):
+        """
+        :avocado: tags=net
+        """
+
+    def test_fast_other(self):
+        """
+        :avocado: tags=net
+        """
+
+
+class SlowTest(Test):
+    """
+    :avocado: tags=slow,disk
+    """
+
+    def test_slow(self):
+        time.sleep(1)
+
+
+class SlowUnsafeTest(Test):
+    """
+    :avocado: tags=slow,disk,unsafe
+    """
+
+    def test_slow_unsafe(self):
+        time.sleep(1)
+
+
+class SafeTest(Test):
+    """
+    :avocado: tags=safe
+    """
+
+    def test_safe(self):
+        pass
+
+
+class SafeX86Test(Test):
+    """
+    :avocado: tags=safe,arch:x86_64
+    """
+
+    def test_safe_x86(self):
+        pass
+
+
+class NoTagsTest(Test):
+    def test_no_tags(self):
+        pass
+
+
+class SafeAarch64Test(Test):
+    """
+    :avocado: tags=safe,arch:aarch64
+    """
+
+    def test_safe_aarch64(self):
+        pass

--- a/selftests/functional/list.py
+++ b/selftests/functional/list.py
@@ -154,9 +154,9 @@ class ListTestFunctional(TestCaseTmpDir):
         )
         stdout_lines = result.stdout_text.splitlines()
         self.assertIn("TEST TYPES SUMMARY", stdout_lines)
-        self.assertIn("avocado-instrumented: 2", stdout_lines)
+        self.assertIn("avocado-instrumented: 4", stdout_lines)
         self.assertIn("TEST TAGS SUMMARY", stdout_lines)
-        self.assertIn("fast: 2", stdout_lines)
+        self.assertIn("fast: 4", stdout_lines)
 
     @skipOnLevelsInferiorThan(2)
     def test_sleep_a_lot(self):

--- a/selftests/unit/tags.py
+++ b/selftests/unit/tags.py
@@ -1,82 +1,15 @@
+import os
 import stat
 import unittest
 
 from avocado.core import resolver, tags
 from avocado.utils import script
+from selftests.utils import BASEDIR
 
 #: What is commonly known as "0664" or "u=rw,g=rw,o=r"
 DEFAULT_NON_EXEC_MODE = (
     stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH
 )
-
-
-AVOCADO_TEST_TAGS = """from avocado import Test
-
-import time
-
-class DisabledTest(Test):
-    '''
-    :avocado: disable
-    :avocado: tags=fast,net
-    '''
-    def test_disabled(self):
-        pass
-
-class FastTest(Test):
-    '''
-    :avocado: tags=fast
-    '''
-    def test_fast(self):
-        '''
-        :avocado: tags=net
-        '''
-        pass
-
-    def test_fast_other(self):
-        '''
-        :avocado: tags=net
-        '''
-        pass
-
-class SlowTest(Test):
-    '''
-    :avocado: tags=slow,disk
-    '''
-    def test_slow(self):
-        time.sleep(1)
-
-class SlowUnsafeTest(Test):
-    '''
-    :avocado: tags=slow,disk,unsafe
-    '''
-    def test_slow_unsafe(self):
-        time.sleep(1)
-
-class SafeTest(Test):
-    '''
-    :avocado: tags=safe
-    '''
-    def test_safe(self):
-        pass
-
-class SafeX86Test(Test):
-    '''
-    :avocado: tags=safe,arch:x86_64
-    '''
-    def test_safe_x86(self):
-        pass
-
-class NoTagsTest(Test):
-    def test_no_tags(self):
-        pass
-
-class SafeAarch64Test(Test):
-    '''
-    :avocado: tags=safe,arch:aarch64
-    '''
-    def test_safe_aarch64(self):
-        pass
-"""
 
 
 AVOCADO_TEST_OK = """from avocado import Test
@@ -123,14 +56,9 @@ class DerivedTwo(Derived):
 
 class TagFilter(unittest.TestCase):
     def setUp(self):
-        with script.TemporaryScript(
-            "tags.py",
-            AVOCADO_TEST_TAGS,
-            "avocado_resolver_tag_unittest",
-            DEFAULT_NON_EXEC_MODE,
-        ) as test_script:
-            self.result = resolver.resolve([test_script.path])
-            self.input_file_path = test_script.path
+        tags_example = os.path.join(BASEDIR, "examples", "tests", "tags.py")
+        self.result = resolver.resolve([tags_example])
+        self.input_file_path = tags_example
 
     def test_no_tag_filter(self):
         self.assertEqual(len(self.result), 1)


### PR DESCRIPTION
Updates to documentation in `Avocado User’s Guide` section to respects
the latest changes.

Reference: https://github.com/avocado-framework/avocado/issues/5757