### PR TITLE
failjob.py: fix wrong usage of Job API.

### DIFF
--- a/examples/jobs/failjob.py
+++ b/examples/jobs/failjob.py
@@ -6,5 +6,5 @@ from avocado.core.job import Job
 
 config = {"resolver.references": ["examples/tests/failtest.py:FailTest.test"]}
 
-with Job(config) as j:
+with Job.from_config(job_config=config) as j:
     sys.exit(j.run())


### PR DESCRIPTION
Use of `Job(config=conf)` met `Unable to resolve any reference or "resolver.references" is empty.`. I think this may not as expected.

Before this fix:

![企业微信截图_16945895074929](https://github.com/avocado-framework/avocado/assets/22901336/faab2f8b-d4bd-41c1-8fe2-4087f0ba13c7)

After this fix:

![企业微信截图_16945895277727](https://github.com/avocado-framework/avocado/assets/22901336/f0c5164d-4c06-4e40-b337-b94e55dda1ff)

