### PR TITLE
Whiteboard save removed from Test class

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -35,7 +35,7 @@ from avocado.core.settings import settings
 from avocado.core.test_id import TestID
 from avocado.core.teststatus import STATUSES_NOT_OK
 from avocado.core.version import VERSION
-from avocado.utils import asset, astring, data_structures, genio
+from avocado.utils import asset, astring, data_structures
 from avocado.utils import path as utils_path
 from avocado.utils import stacktrace
 
@@ -719,8 +719,6 @@ class Test(unittest.TestCase, TestData):
         self._setup_environment_variables()
         self._catch_test_status(self._run_test)
         self._catch_test_status(self._tearDown)
-        whiteboard_file = os.path.join(self.logdir, "whiteboard")
-        genio.write_file(whiteboard_file, self.whiteboard)
         self.__phase = "FINISHED"
         self._tag_end()
         self._report()

--- a/selftests/functional/output.py
+++ b/selftests/functional/output.py
@@ -525,6 +525,12 @@ class OutputPluginTest(TestCaseTmpDir):
                 os.path.exists(whiteboard_path),
                 f"Missing whiteboard file {whiteboard_path}",
             )
+            with open(whiteboard_path, "r", encoding="utf-8") as whiteboard_file:
+                self.assertEqual(
+                    whiteboard_file.read(),
+                    "TXkgbWVzc2FnZSBlbmNvZGVkIGluIGJhc2U2NA==\n",
+                    "Whiteboard message is wrong.",
+                )
 
     def test_gendata(self):
         tmpfile = tempfile.mktemp(dir=self.tmpdir.name)

--- a/selftests/unit/test.py
+++ b/selftests/unit/test.py
@@ -162,13 +162,6 @@ class TestClassTest(unittest.TestCase):
     def test_class_attributes_time_elapsed(self):
         self.assertIsInstance(self.tst_instance_pass.time_elapsed, float)
 
-    def test_whiteboard_save(self):
-        whiteboard_file = os.path.join(self.tst_instance_pass.logdir, "whiteboard")
-        self.assertTrue(os.path.isfile(whiteboard_file))
-        with open(whiteboard_file, "r", encoding="utf-8") as whiteboard_file_obj:
-            whiteboard_contents = whiteboard_file_obj.read().strip()
-            self.assertTrue(whiteboard_contents, "foo")
-
     def tearDown(self):
         self.base_logdir.cleanup()
 


### PR DESCRIPTION
Because of nrunner architecture, it is no need to save whiteboard by Test class. All logs which have to be stored to files are transmitted by messages and stored by avocado core. Whiteboard logs had been stored by Test class and avocado core, which created duplicates in whiteboard file. Removing it from Test class solves this issue. And we can do it because saving of whiteboard by Test class is legacy behavior.

Reference: #5770