### PR TITLE
Bump cryptography to avoid security alerts

### DIFF
--- a/optional_plugins/ansible/setup.py
+++ b/optional_plugins/ansible/setup.py
@@ -36,7 +36,12 @@ setup(
     url="http://avocado-framework.github.io/",
     packages=packages,
     include_package_data=True,
-    install_requires=[f"avocado-framework=={VERSION}", "ansible-core"],
+    install_requires=[
+        f"avocado-framework=={VERSION}",
+        "cffi",
+        "pycparser",
+        "ansible-core",
+    ],
     test_suite="tests",
     entry_points={
         "console_scripts": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,5 @@ docutils==0.17.1
 jsonschema==3.2.0
 
 # For ansible plugin nested dep, compatible with Python 3.6
-setuptools_rust==1.1.2
-
-# For ansible plugin nested dep
-cryptography==41.0.2
+setuptools_rust==1.1.2; python_version < '3.7'
+setuptools_rust; python_version >= '3.7'


### PR DESCRIPTION
Based on the Dependabot the cryptography has two minor security alerts which can be solved by upgrading the version. Because the cryptography package is dependency only for Ansible plugin, this commit will move it the plugin setup.

Reference: https://github.com/avocado-framework/avocado/pull/5769