### PR TITLE
avocado/utils/ssh.py: add timeout functionality

### DIFF
--- a/avocado/utils/ssh.py
+++ b/avocado/utils/ssh.py
@@ -205,7 +205,7 @@ class Session:
         """
         return self._ssh_cmd(self.DEFAULT_OPTIONS, ("-q",), command)
 
-    def cmd(self, command, ignore_status=True):
+    def cmd(self, command, ignore_status=True, timeout=None):
         """
         Runs a command over the SSH session
 
@@ -217,12 +217,20 @@ class Session:
                               in case of either the command or ssh connection
                               returned with exit status other than zero.
         :type ignore_status: bool
+        :param timeout: Limit the command execution time, if you want the command
+                        to end within a few seconds, you can set a specific time.
+        :type timeout: float
         :returns: The command result object.
         :rtype: A :class:`avocado.utils.process.CmdResult` instance.
         """
+        if timeout:
+            command_argument = f"timeout {timeout} {command}"
+        else:
+            command_argument = command
         try:
             return process.run(
-                self.get_raw_ssh_command(command), ignore_status=ignore_status
+                self.get_raw_ssh_command(command_argument),
+                ignore_status=ignore_status,
             )
         except process.CmdError as exc:
             if exc.result.exit_status == 255:

--- a/examples/apis/utils/ssh_timeout.py
+++ b/examples/apis/utils/ssh_timeout.py
@@ -1,0 +1,18 @@
+import time
+
+from avocado.utils.ssh import Session
+
+with Session("host", user="root", key="/path/to/key") as s:
+    # baseline case
+    time_start = time.monotonic()
+    s.cmd("sleep 10")
+    total_time = time.monotonic() - time_start
+    print(total_time)
+    assert total_time >= 10
+
+    # check of timeout enforcement
+    time_start = time.monotonic()
+    s.cmd("sleep 10", timeout=1)
+    total_time = time.monotonic() - time_start
+    print(total_time)
+    assert total_time <= 10


### PR DESCRIPTION
This uses the remote side "timeout" command to implement a timeout for the actual command the user intends to run.  The arguments given are the simplest possible to be made compatible with "timeout" implementations such as the ones given by busybox.

While it's not possible to have a functional test at this point (because the test would need a second and properly configured machine), the example API script should serve as a proof that this implementation behaves correctly:

  $ python3 examples/apis/utils/ssh_timeout.py
  10.571667929994874
  1.4050129299866967

---

This is a follow up to https://github.com/avocado-framework/avocado/pull/5654 