### PR TITLE
avocado.utils.download.url_open() log message update

### DIFF
--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -51,7 +51,10 @@ def url_open(url, data=None, timeout=5):
         log.error(msg)
         return None
 
-    msg = 'Retrieved URL "%s": content-length %s, date: "%s", last-modified: "%s"'
+    msg = (
+        'Opened URL "%s" and received response with headers including: '
+        'content-length %s, date: "%s", last-modified: "%s"'
+    )
     log.debug(
         msg,
         url,


### PR DESCRIPTION
The log message of avocado.utils.download.url_open() might be misleading because it tells that a URL has been retrieved at a stage where only a response was obtained. This commit will update the message to be more precise.

Reference: #5742