### PR TITLE
Twine check for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build tarballs and wheels
-      run: make -f Makefile.gh build-wheel
+      run: make -f Makefile.gh build-wheel check-wheel
     - name: Save tarballs and wheels as artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           github_token: ${{ secrets.RELEASE_TOKEN }}
           branch: ${{ github.ref }}
       - name: Build wheel
-        run: make -f Makefile.gh build-wheel
+        run: make -f Makefile.gh build-wheel check-wheel
       - name: Save wheel as artifact
         uses: actions/upload-artifact@v3
         with:

--- a/Makefile.gh
+++ b/Makefile.gh
@@ -70,6 +70,10 @@ build-wheel: pip
 		fi;\
 	done
 
+check-wheel: build-wheel
+	$(PYTHON) -m pip install twine
+	twine check ./PYPI_UPLOAD/*
+
 build-egg:
 	if test ! -d EGG_UPLOAD; then mkdir EGG_UPLOAD; fi
 	$(PYTHON) setup.py bdist_egg -d EGG_UPLOAD

--- a/optional_plugins/ansible/setup.py
+++ b/optional_plugins/ansible/setup.py
@@ -28,6 +28,8 @@ VERSION = open("VERSION", "r", encoding="utf-8").read().strip()
 setup(
     name="avocado-framework-plugin-ansible",
     description="Adds to Avocado the ability to use ansible modules as dependencies for tests",
+    long_description="Adds to Avocado the ability to use ansible modules as dependencies for tests",
+    long_description_content_type="text/x-rst",
     version=VERSION,
     author="Avocado Developers",
     author_email="avocado-devel@redhat.com",

--- a/optional_plugins/varianter_pict/setup.py
+++ b/optional_plugins/varianter_pict/setup.py
@@ -14,6 +14,7 @@
 # Author: Cleber Rosa <crosa@redhat.com>
 
 import os
+import re
 
 from setuptools import setup
 
@@ -33,7 +34,7 @@ with open(os.path.join(BASE_PATH, "VERSION"), "r", encoding="utf-8") as version_
 def get_long_description():
     with open(os.path.join(BASE_PATH, "README.rst"), "rt", encoding="utf-8") as readme:
         readme_contents = readme.read()
-    return readme_contents
+    return re.sub(r":[a-zA-Z]+:", "", readme_contents)
 
 
 setup(

--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -14,6 +14,7 @@
 # Author: Cleber Rosa <crosa@redhat.com>
 
 import os
+import re
 
 from setuptools import setup
 
@@ -33,7 +34,7 @@ with open(os.path.join(BASE_PATH, "VERSION"), "r", encoding="utf-8") as version_
 def get_long_description():
     with open(os.path.join(BASE_PATH, "README.rst"), "rt", encoding="utf-8") as readme:
         readme_contents = readme.read()
-    return readme_contents
+    return re.sub(r":[a-zA-Z]+:", "", readme_contents)
 
 
 setup(


### PR DESCRIPTION
This PR adds twine check for each package, before publishing it.
With this change, we will avoid problems with publishing the packages in
the future.

Reference: https://github.com/avocado-framework/avocado/issues/5713
Signed-off-by: Jan Richter <jarichte@redhat.com>