### PR TITLE
Adding check if the test interface tested is a bonding slave

### DIFF
--- a/avocado/utils/network/hosts.py
+++ b/avocado/utils/network/hosts.py
@@ -74,8 +74,9 @@ class Host:
     def get_interface_by_hwaddr(self, mac):
         """Return an interface that has a specific mac."""
         for interface in self.interfaces:
-            if mac in interface.get_hwaddr():
-                return interface
+            if not interface.is_bond_slave():
+                if mac in interface.get_hwaddr():
+                    return interface
 
     def get_all_hwaddr(self):
         """Get a list of all mac address in the host

--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -615,6 +615,20 @@ class NetworkInterface:
             LOG.debug(msg)
             return False
 
+    def is_bond_slave(self):
+        """Check if interface is a bonding slave
+
+        This method checks if the interface is a bonding slave or not
+
+        rtype: bool
+        """
+        try:
+            if "SLAVE" in self._get_interface_details().get("flags"):
+                return True
+        except (NWException, IndexError):
+            raise NWException("Could not get interface detail.")
+            return False
+
     def is_veth(self):
         """Check if interface is a Virtual Ethernet.
 


### PR DESCRIPTION
The patch is to test if the interface is a slave interface or a regular one. when mac address is passed as test param, return only for a regular interface or a bond master interface.