### PR TITLE
output: support for kitty

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -86,6 +86,7 @@ class TermSupport:
             "linux",
             "xterm",
             "xterm-256color",
+            "xterm-kitty",
             "vt100",
             "screen",
             "screen-256color",


### PR DESCRIPTION
Yours truly happens to use the "kitty" terminal emulator, and would love to get the same treatment from Avocado.