### PR TITLE
Example plugins for test types: enable them during development mode

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
       - name: Installing Avocado in develop mode
-        run: python3 setup.py develop --user --skip-optional-plugins
+        run: python3 setup.py develop --user --skip-optional-plugins --skip-examples-plugins-tests
       - name: Avocado version
         run: avocado --version
       - name: Tree static check, unittests and fast functional tests without plugins

--- a/examples/plugins/tests/magic/avocado_magic/resolver.py
+++ b/examples/plugins/tests/magic/avocado_magic/resolver.py
@@ -17,8 +17,9 @@ Test resolver for magic test words
 """
 
 from avocado.core.nrunner.runnable import Runnable
-from avocado.core.plugin_interfaces import Discoverer, Resolver
+from avocado.core.plugin_interfaces import Discoverer, Init, Resolver
 from avocado.core.resolver import ReferenceResolution, ReferenceResolutionResult
+from avocado.core.settings import settings
 
 VALID_MAGIC_WORDS = ["pass", "fail"]
 
@@ -42,14 +43,28 @@ class MagicResolver(Resolver):
         )
 
 
+class MagicInit(Init):
+
+    description = "Initialization for magic words plugin"
+
+    def initialize(self):
+        settings.register_option(
+            section="examples.plugins.magic.discover",
+            key="enabled",
+            key_type=bool,
+            help_msg="Whether to enable the discovery of pass and fail",
+            default=False,
+        )
+
+
 class MagicDiscoverer(Discoverer):
 
     name = "magic-discoverer"
     description = "Test discoverer for magic words"
 
-    @staticmethod
-    def discover():  # pylint: disable=W0221
+    def discover(self):  # pylint: disable=W0221
         resolutions = []
-        for reference in VALID_MAGIC_WORDS:
-            resolutions.append(MagicResolver.resolve(reference))
+        if self.config.get("examples.plugins.magic.discover.enabled"):
+            for reference in VALID_MAGIC_WORDS:
+                resolutions.append(MagicResolver.resolve(reference))
         return resolutions

--- a/examples/plugins/tests/magic/avocado_magic/runner.py
+++ b/examples/plugins/tests/magic/avocado_magic/runner.py
@@ -22,6 +22,8 @@ class MagicRunner(BaseRunner):
                            uri='pass')
     """
 
+    description = "Runner for magic words"
+
     def run(self, runnable):
         yield StartedMessage.get()
         if runnable.uri in ["pass", "fail"]:

--- a/examples/plugins/tests/magic/setup.py
+++ b/examples/plugins/tests/magic/setup.py
@@ -2,6 +2,7 @@ from setuptools import find_packages, setup
 
 name = "magic"
 module = "avocado_magic"
+init_ep = f"{name} = {module}.resolver:MagicInit"
 resolver_ep = f"{name} = {module}.resolver:MagicResolver"
 discoverer_ep = f"{name} = {module}.resolver:MagicDiscoverer"
 runner_ep = f"{name} = {module}.runner:MagicRunner"
@@ -15,6 +16,7 @@ if __name__ == "__main__":
         description='Avocado "magic" test type',
         py_modules=[module],
         entry_points={
+            "avocado.plugins.init": [init_ep],
             "avocado.plugins.resolver": [resolver_ep],
             "avocado.plugins.discoverer": [discoverer_ep],
             "avocado.plugins.runnable.runner": [runner_ep],


### PR DESCRIPTION
This will enable all example plugins for new test types during development mode.  The benefits are:
    
1) bit rot or bad examples are avoided when the plugins are enabled (as can be seen in the description fix for the magic plugin)
2) example plugins can be used in self tests