### PR TITLE
Spawner: make terminate_task return success or failure

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -101,18 +101,6 @@ def register_core_options():
         help_msg=help_msg,
     )
 
-    help_msg = (
-        "The amount of time to give to the test process after "
-        "it it has been interrupted (such as with CTRL+C)"
-    )
-    stgs.register_option(
-        section="runner.timeout",
-        key="after_interrupted",
-        key_type=int,
-        help_msg=help_msg,
-        default=60,
-    )
-
     # Let's assume that by default, cache will be located under the user's
     # umbrella. This will make it easy for our deployments and it is a common
     # place for other applications too.
@@ -164,30 +152,6 @@ def register_core_options():
         key_type=prepend_base_path,
         default=default,
         help_msg=help_msg,
-    )
-
-    help_msg = (
-        "The amount of time to wait after a test has reported "
-        "status but the test process has not finished"
-    )
-    stgs.register_option(
-        section="runner.timeout",
-        key="process_alive",
-        key_type=int,
-        help_msg=help_msg,
-        default=60,
-    )
-
-    help_msg = (
-        "The amount of to wait for a test status after the "
-        "process has been noticed to be dead"
-    )
-    stgs.register_option(
-        section="runner.timeout",
-        key="process_died",
-        key_type=int,
-        help_msg=help_msg,
-        default=10,
     )
 
     help_msg = "Whether to display colored output in terminals that support it"

--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -101,6 +101,39 @@ def register_core_options():
         help_msg=help_msg,
     )
 
+    help_msg = (
+        "The amount of time to wait between asking nicely for a task "
+        "to be terminated (say sending a signal) and proceeding with "
+        "a more forceful termination. This may allow runners within "
+        "tasks to perform clean ups. Spawners are free to implement "
+        "a behavior that is suitable to their isolation model, "
+        "including ignoring this configuration."
+    )
+    stgs.register_option(
+        section="runner.task.interval",
+        key="from_soft_to_hard_termination",
+        key_type=int,
+        help_msg=help_msg,
+        default=1,
+    )
+
+    help_msg = (
+        "The amount of time to wait between executing a more forceful "
+        "termination of a task, and the verification of the actual "
+        "termination. This may allow spawners to give the necessary "
+        "time for their isolation models to fully terminate a task. "
+        "Spawners are free to implement a behavior that is suitable "
+        "to their isolation model, including ignoring this "
+        "configuration."
+    )
+    stgs.register_option(
+        section="runner.task.interval",
+        key="from_hard_termination_to_verification",
+        key_type=int,
+        help_msg=help_msg,
+        default=0,
+    )
+
     # Let's assume that by default, cache will be located under the user's
     # umbrella. This will make it easy for our deployments and it is a common
     # place for other applications too.

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -372,6 +372,8 @@ class Spawner(Plugin):
         :param runtime_task: wrapper for a Task with additional runtime
                              information.
         :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
+        :returns: whether the task has been fully terminated or not
+        :rtype: bool
         """
 
     @staticmethod

--- a/avocado/core/status/repo.py
+++ b/avocado/core/status/repo.py
@@ -43,9 +43,9 @@ class StatusRepo:
         if result is not None and result.upper() not in STATUSES:
             overridden = "error"
             message["result"] = overridden
-            message["fail_reason"] = (
-                f"Runner error occurred: Test reports " f'unsupported status "{result}"'
-            )
+            message[
+                "fail_reason"
+            ] = f'Runner error occurred: Test reports unsupported status "{result}"'
             LOG.error(
                 'Task "%s" finished message with unsupported status '
                 '"%s", changing to "%s"',

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -459,7 +459,9 @@ class Worker:
 
     async def _terminate_task(self, runtime_task, task_status):
         runtime_task.status = task_status
-        await self._spawner.terminate_task(runtime_task)
+        terminate_result = await self._spawner.terminate_task(runtime_task)
+        if not terminate_result:
+            LOG.error('Could not terminate task "%s"', runtime_task.task.identifier)
 
     async def _terminate_tasks(self, task_status):
         await self._state_machine.abort(task_status)

--- a/avocado/plugins/spawners/lxc.py
+++ b/avocado/plugins/spawners/lxc.py
@@ -291,6 +291,7 @@ class LXCSpawner(Spawner, SpawnerMixin):
         # if not container.destroy():
         #     LOG.error("Failed to destroy the container.")
         #     return False
+        return True
 
     @staticmethod
     async def check_task_requirements(runtime_task):

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -367,10 +367,25 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
 
     async def terminate_task(self, runtime_task):
         try:
+            await self.podman.execute(
+                "kill", "--signal=TERM", runtime_task.spawner_handle
+            )
+        except PodmanException as ex:
+            LOG.error("Could not signal termination to task on container: %s", ex)
+            return False
+        soft_interval = self.config.get(
+            "runner.task.interval.from_soft_to_hard_termination"
+        )
+        await asyncio.sleep(soft_interval)
+        try:
             await self.podman.stop(runtime_task.spawner_handle)
         except PodmanException as ex:
             LOG.error("Could not stop container: %s", ex)
             return False
+        hard_interval = self.config.get(
+            "runner.task.interval.from_hard_termination_to_verification"
+        )
+        await asyncio.sleep(hard_interval)
         info = await self.podman.get_container_info(runtime_task.spawner_handle)
         return info.get("Exited", False)
 

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -371,6 +371,8 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
         except PodmanException as ex:
             LOG.error("Could not stop container: %s", ex)
             return False
+        info = await self.podman.get_container_info(runtime_task.spawner_handle)
+        return info.get("Exited", False)
 
     @staticmethod
     async def check_task_requirements(runtime_task):

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -76,6 +76,14 @@ class ProcessSpawner(Spawner, SpawnerMixin):
     @staticmethod
     async def terminate_task(runtime_task):  # pylint: disable=W0221
         runtime_task.spawner_handle.process.terminate()
+        returncode = None
+        try:
+            returncode = await asyncio.wait_for(
+                runtime_task.spawner_handle.process.wait(), 1
+            )
+        except asyncio.TimeoutError:
+            pass
+        return returncode is not None
 
     @staticmethod
     async def check_task_requirements(runtime_task):

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -12,19 +12,34 @@ ENVIRONMENT_TYPE = "local"
 ENVIRONMENT = socket.gethostname()
 
 
+class ProcessSpawnerHandle:
+    def __init__(self, process):
+        self.process = process
+        self._wait_task = None
+
+    def create_wait_task(self):
+        if self._wait_task is None:
+            loop = asyncio.get_event_loop()
+            self._wait_task = loop.create_task(self.process.wait())
+
+    @property
+    def wait_task(self):
+        self.create_wait_task()
+        return self._wait_task
+
+
 class ProcessSpawner(Spawner, SpawnerMixin):
 
     description = "Process based spawner"
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
 
-    async def _collect_task(self, task_handle):
-        await task_handle.wait()
-
     @staticmethod
     def is_task_alive(runtime_task):
         if runtime_task.spawner_handle is None:
             return False
-        return runtime_task.spawner_handle.returncode is None
+        if runtime_task.spawner_handle.wait_task.done():
+            return False
+        return True
 
     async def spawn_task(self, runtime_task):
         self.create_task_output_dir(runtime_task)
@@ -35,7 +50,7 @@ class ProcessSpawner(Spawner, SpawnerMixin):
 
         # pylint: disable=E1133
         try:
-            runtime_task.spawner_handle = await asyncio.create_subprocess_exec(
+            proc = await asyncio.create_subprocess_exec(
                 runner,
                 *args,
                 stdout=asyncio.subprocess.DEVNULL,
@@ -44,7 +59,7 @@ class ProcessSpawner(Spawner, SpawnerMixin):
             )
         except (FileNotFoundError, PermissionError):
             return False
-        asyncio.ensure_future(self._collect_task(runtime_task.spawner_handle))
+        runtime_task.spawner_handle = ProcessSpawnerHandle(proc)
         return True
 
     def create_task_output_dir(self, runtime_task):
@@ -56,11 +71,11 @@ class ProcessSpawner(Spawner, SpawnerMixin):
 
     @staticmethod
     async def wait_task(runtime_task):  # pylint: disable=W0221
-        await runtime_task.spawner_handle.wait()
+        await runtime_task.spawner_handle.wait_task
 
     @staticmethod
     async def terminate_task(runtime_task):  # pylint: disable=W0221
-        runtime_task.spawner_handle.terminate()
+        runtime_task.spawner_handle.process.terminate()
 
     @staticmethod
     async def check_task_requirements(runtime_task):

--- a/examples/plugins/tests/rogue/avocado_rogue/__init__.py
+++ b/examples/plugins/tests/rogue/avocado_rogue/__init__.py
@@ -1,0 +1,1 @@
+MAGIC_WORD = "x-avocado-runner-rogue"

--- a/examples/plugins/tests/rogue/avocado_rogue/resolver.py
+++ b/examples/plugins/tests/rogue/avocado_rogue/resolver.py
@@ -1,0 +1,44 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2023
+# Authors: Cleber Rosa <crosa@redhat.com>
+
+"""
+Test resolver for the "rogue" magic word
+"""
+
+from avocado_rogue import MAGIC_WORD
+
+from avocado.core.nrunner.runnable import Runnable
+from avocado.core.plugin_interfaces import Resolver
+from avocado.core.resolver import ReferenceResolution, ReferenceResolutionResult
+
+
+class RogueResolver(Resolver):
+
+    name = "rogue"
+    description = "Test resolver for rogue magic word"
+
+    @staticmethod
+    def resolve(reference):  # pylint: disable=W0221
+        if reference != MAGIC_WORD:
+            return ReferenceResolution(
+                reference,
+                ReferenceResolutionResult.NOTFOUND,
+                info=f'Word "{reference}" is not the magic word',
+            )
+
+        return ReferenceResolution(
+            reference,
+            ReferenceResolutionResult.SUCCESS,
+            [Runnable("rogue", reference)],
+        )

--- a/examples/plugins/tests/rogue/avocado_rogue/runner.py
+++ b/examples/plugins/tests/rogue/avocado_rogue/runner.py
@@ -1,0 +1,59 @@
+import signal
+import time
+
+from avocado_rogue import MAGIC_WORD
+
+from avocado.core.nrunner.app import BaseRunnerApp
+from avocado.core.nrunner.runner import RUNNER_RUN_STATUS_INTERVAL, BaseRunner
+from avocado.core.utils.messages import FinishedMessage, RunningMessage, StartedMessage
+
+
+class RogueRunner(BaseRunner):
+    """A rogue runner (that doesn't like to be stopped)
+
+    When creating the Runnable, use the following attributes:
+
+     * kind: should be 'rogue';
+
+     * uri: the rogue magic word (-*-*-magic-word-for-rogue-*-*-)
+
+     * args: not used;
+
+     * kwargs: not used;
+
+    Example:
+
+       runnable = Runnable(kind='rogue',
+                           uri='x-avocado-runner-rogue')
+    """
+
+    name = "rogue"
+    description = "A rogue runner (that doesn't like to be stopped)"
+
+    def run(self, runnable):
+        yield StartedMessage.get()
+        if runnable.uri == MAGIC_WORD:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            signal.signal(signal.SIGQUIT, signal.SIG_IGN)
+            signal.signal(signal.SIGTSTP, signal.SIG_IGN)
+            while True:
+                yield RunningMessage.get()
+                time.sleep(RUNNER_RUN_STATUS_INTERVAL)
+        else:
+            yield FinishedMessage.get("error")
+
+
+class RunnerApp(BaseRunnerApp):
+    PROG_NAME = "avocado-runner-rogue"
+    PROG_DESCRIPTION = "nrunner application for rogue tests"
+    RUNNABLE_KINDS_CAPABLE = ["rogue"]
+
+
+def main():
+    app = RunnerApp(print)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plugins/tests/rogue/setup.py
+++ b/examples/plugins/tests/rogue/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+name = "rogue"
+module = "avocado_rogue"
+resolver_ep = f"{name} = {module}.resolver:RogueResolver"
+runner_ep = f"{name} = {module}.runner:RogueRunner"
+runner_script = f"avocado-runner-{name} = {module}.runner:main"
+
+
+if __name__ == "__main__":
+    setup(
+        name="avocado-rogue",
+        version="1.0",
+        description='Avocado "rogue" test type',
+        long_description=(
+            "This is a plugin that contains a rogue runner, that is, "
+            "a runner that will try to never allow to be terminated."
+        ),
+        py_modules=[module],
+        entry_points={
+            "avocado.plugins.resolver": [resolver_ep],
+            "avocado.plugins.runnable.runner": [runner_ep],
+            "console_scripts": [runner_script],
+        },
+    )

--- a/selftests/functional/plugin/spawners/process.py
+++ b/selftests/functional/plugin/spawners/process.py
@@ -1,8 +1,10 @@
 import json
 import os
+import unittest
 
+from avocado.core.job import Job
 from avocado.utils import process, script
-from selftests.utils import AVOCADO, TestCaseTmpDir
+from selftests.utils import AVOCADO, TestCaseTmpDir, python_module_available
 
 TEST_LOGDIR = """from avocado import Test
 
@@ -31,3 +33,31 @@ class ProcessSpawnerTest(TestCaseTmpDir):
         with open(logfile, "r", encoding="utf-8") as debug_file:
             expected = f"logdir is: {testdir}"
             self.assertIn(expected, debug_file.read())
+
+    @unittest.skipUnless(
+        python_module_available("avocado-rogue"), "avocado-rogue not available"
+    )
+    def test_rogue_runner(self):
+        config = {
+            "resolver.references": ["x-avocado-runner-rogue"],
+            "run.results_dir": self.tmpdir.name,
+            "task.timeout.running": 2,
+            "run.spawner": "process",
+            "sysinfo.collect.enabled": False,
+        }
+
+        with Job.from_config(job_config=config) as job:
+            job.run()
+
+        self.assertEqual(1, job.result.interrupted)
+        self.assertEqual(0, job.result.passed)
+        self.assertEqual(0, job.result.skipped)
+        self.assertEqual(
+            "Test interrupted: Timeout reached", job.result.tests[0]["fail_reason"]
+        )
+
+        logfile = os.path.join(self.tmpdir.name, "latest", "full.log")
+        with open(logfile, "r", encoding="utf-8") as full_log:
+            self.assertIn(
+                'Could not terminate task "1-1-x-avocado-runner-rogue"', full_log.read()
+            )

--- a/selftests/unit/plugin/spawner.py
+++ b/selftests/unit/plugin/spawner.py
@@ -1,10 +1,11 @@
+import asyncio
 import unittest
 
 from avocado.core.nrunner.runnable import Runnable
 from avocado.core.nrunner.task import Task
 from avocado.core.spawners.mock import MockRandomAliveSpawner, MockSpawner
 from avocado.core.task.runtime import RuntimeTask
-from avocado.plugins.spawners.process import ProcessSpawner
+from avocado.plugins.spawners.process import ProcessSpawner, ProcessSpawnerHandle
 
 
 class Process(unittest.TestCase):
@@ -21,6 +22,43 @@ class Process(unittest.TestCase):
     def test_never_spawned(self):
         self.assertFalse(self.spawner.is_task_alive(self.runtime_task))
         self.assertFalse(self.spawner.is_task_alive(self.runtime_task))
+
+
+class MockProcessFinishQuickly:
+    async def wait(self):
+        return 0
+
+
+class MockProcessNeverFinish:
+    async def wait(self):
+        await asyncio.sleep(float("inf"))
+
+
+class ProcessHandle(unittest.TestCase):
+    def test_finishes(self):
+        handle = ProcessSpawnerHandle(MockProcessFinishQuickly())
+
+        async def await_wait_task():
+            _ = handle.wait_task
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(await_wait_task())
+        self.assertIsInstance(handle.wait_task, asyncio.Task)
+        self.assertTrue(handle.wait_task.done())
+        self.assertEqual(handle.wait_task.result(), 0)
+
+    def test_never_finishes(self):
+        handle = ProcessSpawnerHandle(MockProcessNeverFinish())
+
+        async def await_wait_task():
+            _ = handle.wait_task
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(asyncio.wait_for(await_wait_task(), 2.0))
+        self.assertIsInstance(handle.wait_task, asyncio.Task)
+        self.assertFalse(handle.wait_task.done())
+        with self.assertRaises(asyncio.InvalidStateError):
+            handle.wait_task.result()
 
 
 class Mock(Process):


### PR DESCRIPTION
While "terminating a task", Avocado would simply request the termination, without checking on its success.  This change alters the interface of the terminate_task Spawner plugin interface when it comes to the expected return.
    
Then the statemachine is able to, at the very least, log the information about the failure to terminate a task.

Reference: https://github.com/avocado-framework/avocado/issues/4994