### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11, 3.12.0]
       fail-fast: false
 
     steps:
@@ -58,6 +58,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install setuptools on Python 3.12
+        run: python3 -c 'import setuptools' || python3 -m pip install setuptools
       - name: Avocado smokecheck
         run: make smokecheck
 
@@ -69,7 +71,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11, 3.12.0]
       fail-fast: false
 
     steps:
@@ -86,6 +88,8 @@ jobs:
         run: python -V --version
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
+      - name: Install setuptools on Python 3.12
+        run: python3 -c 'import setuptools' || python3 -m pip install setuptools
       - name: Installing Avocado in develop mode
         run: python3 setup.py develop --user
       - name: Avocado version
@@ -179,7 +183,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10.0, 3.11]
+        python-version: [3.9, 3.10.0, 3.11, 3.12.0]
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
@@ -191,6 +195,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -V --version
+      - name: Install setuptools on Python 3.12
+        run: python -c 'import setuptools' || python -m pip install setuptools
       - name: Install avocado
         run: python setup.py develop --user
       - name: Show avocado help
@@ -208,7 +214,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11, 3.12.0]
       fail-fast: false
 
     steps:
@@ -217,6 +223,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install setuptools on Python 3.12
+      run: python3 -c 'import setuptools' || python3 -m pip install setuptools
     - name: Build tarballs and wheels
       run: make -f Makefile.gh build-wheel check-wheel
     - name: Save tarballs and wheels as artifacts
@@ -233,7 +241,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10.0, 3.11, 3.12.0]
       fail-fast: false
 
     steps:
@@ -242,6 +250,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install setuptools on Python 3.12
+      run: python3 -c 'import setuptools' || python3 -m pip install setuptools
     - name: Build eggs
       run: make -f Makefile.gh build-egg
     - name: Save eggs as artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        python-version: [3.7.15, 3.8.16, 3.9.16, 3.10.9, 3.11.1]
+        python-version: [3.7.15, 3.8.16, 3.9.16, 3.10.9, 3.11.1, 3.12.0]
       fail-fast: false
 
     steps:

--- a/contrib/scripts/avocado-fetch-eggs.py
+++ b/contrib/scripts/avocado-fetch-eggs.py
@@ -51,6 +51,17 @@ def main():
         url = get_egg_url(python_version=version)
         asset = Asset(url, cache_dirs=CACHE_DIRS)
         asset.fetch()
+    # for version 3.12, it'll only be available after 103.0 is released
+    # TODO: remove after 103.0 is released
+    url = get_egg_url(python_version="3.12")
+    try:
+        asset = Asset(url, cache_dirs=CACHE_DIRS)
+        asset.fetch()
+    except OSError:
+        LOG.warning(
+            "Failed to fetch eggs for Python 3.12: these will only "
+            "be available after the release of Avocado 103.0"
+        )
     return True
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,8 @@ pycdlib==1.13.0
 netifaces==0.11.0
 
 # For tests that validate the produced XUnit output
-xmlschema==1.7.0
+xmlschema==1.7.0; python_version < '3.12'
+xmlschema==2.5.0; python_version >= '3.12'
 
 # For building the manpage
 docutils==0.17.1

--- a/setup.py
+++ b/setup.py
@@ -354,6 +354,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
         ],
         packages=find_packages(exclude=("selftests*",)),
         include_package_data=True,


### PR DESCRIPTION
This adds support for testing the coverage of Avocado under Python 3.12, and advertises it as supporting it.

xmlschema is bumped to a version that supports Python 3.12, but left as is on older Python versions.

---

`setuptools` installation handling is required by https://github.com/python/cpython/issues/95299