### PR TITLE
Result upload plugin: Mark as not zip_safe

### DIFF
--- a/optional_plugins/result_upload/setup.py
+++ b/optional_plugins/result_upload/setup.py
@@ -48,6 +48,7 @@ setup(
     packages=packages,
     include_package_data=True,
     install_requires=[f"avocado-framework=={VERSION}"],
+    zip_safe=False,
     entry_points={
         "avocado.plugins.cli": [
             "results_upload = avocado_result_upload.result_upload:ResultUploadCLI",


### PR DESCRIPTION
Installing the upload plugin from source went fine, but invoking avocado then resulted in:

Failed to load plugin from module "avocado_result_upload.result_upload": ModuleNotFoundError("No module named 'avocado_result_upload'")

It works, though, when the egg file gets extracted instead of copied. So, update the setup code accordingly.

Frankly, I did not invesitigate why plain copy is not enough. Maybe something is wrong on my side? No python expert here.