### PR TITLE
avocado-instrumented tearDown method during timeout 

### DIFF
--- a/avocado/core/exceptions.py
+++ b/avocado/core/exceptions.py
@@ -165,3 +165,13 @@ class TestCancel(TestBaseException):
     """
 
     status = "CANCEL"
+
+
+class TestInterrupt(TestBaseException):
+    """
+    Indicates that a test was interrupted.
+
+    Should be thrown when the test method is interrupted by user or timeout.
+    """
+
+    status = "INTERRUPTED"

--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -205,7 +205,7 @@ class Worker:
             task_id = str(terminated_task.task.identifier)
             job_id = terminated_task.task.job_id
             log_message = messages.LogMessage.get(
-                f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | Runner error occurred: {reason}",
+                f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} | Test interrupted: {reason}",
                 id=task_id,
                 job_id=job_id,
             )

--- a/selftests/functional/job_timeout.py
+++ b/selftests/functional/job_timeout.py
@@ -105,10 +105,10 @@ class JobTimeOutTest(TestCaseTmpDir):
         debug_log_paths = glob.glob(os.path.join(res_dir, f"{idx}-*", "debug.log"))
         debug_log = genio.read_file(debug_log_paths[0])
         self.assertIn(
-            "Runner error occurred: Timeout reached",
+            "Test interrupted: Timeout reached",
             debug_log,
             (
-                f"Runner error occurred: Timeout reached message not "
+                f"Test interrupted: Timeout reached message not "
                 f"in the {idx}st test's debug.log:\n{debug_log}"
             ),
         )

--- a/selftests/functional/job_timeout.py
+++ b/selftests/functional/job_timeout.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import tempfile
 import unittest
 import xml.dom.minidom
 
@@ -26,6 +27,22 @@ class Dummy(Test):
         pass
     def test02pass(self):
         pass
+
+    def tearDown(self):
+        self.log.info("tearDown")
+"""
+
+PYTHON_LONG_CONTENT = """#!/usr/bin/env python
+import time
+from avocado import Test
+
+class Dummy(Test):
+    def test00sleep(self):
+        time.sleep(10)
+
+    def tearDown(self):
+        time.sleep(5)
+        self.log.info("tearDown")
 """
 
 
@@ -48,6 +65,10 @@ class JobTimeOutTest(TestCaseTmpDir):
             "sleep_test.py", PYTHON_CONTENT, "avocado_timeout_functional"
         )
         self.py.save()
+        self.long_py = script.TemporaryScript(
+            "sleep_long.py", PYTHON_LONG_CONTENT, "avocado_timeout_functional"
+        )
+        self.long_py.save()
 
     def run_and_check(self, cmd_line, e_rc, e_ntests, terminated_tests):
         os.chdir(BASEDIR)
@@ -100,18 +121,22 @@ class JobTimeOutTest(TestCaseTmpDir):
                 f"Test {terminated_test} was not in {output}.",
             )
 
-    def _check_timeout_msg(self, idx):
+    def _check_timeout_msg(self, idx, message, negation=False):
         res_dir = os.path.join(self.tmpdir.name, "latest", "test-results")
         debug_log_paths = glob.glob(os.path.join(res_dir, f"{idx}-*", "debug.log"))
         debug_log = genio.read_file(debug_log_paths[0])
-        self.assertIn(
-            "Test interrupted: Timeout reached",
-            debug_log,
-            (
-                f"Test interrupted: Timeout reached message not "
-                f"in the {idx}st test's debug.log:\n{debug_log}"
-            ),
-        )
+        if not negation:
+            self.assertIn(
+                message,
+                debug_log,
+                f"{message} message not in the {idx}st test's debug.log:\n{debug_log}",
+            )
+        else:
+            self.assertNotIn(
+                message,
+                debug_log,
+                f"{message} message is in the {idx}st test's debug.log:\n{debug_log}",
+            )
 
     def test_sleep_short_timeout(self):
         cmd_line = (
@@ -132,7 +157,7 @@ class JobTimeOutTest(TestCaseTmpDir):
         self.run_and_check(
             cmd_line, exit_codes.AVOCADO_JOB_INTERRUPTED, 2, [self.script_long.path]
         )
-        self._check_timeout_msg(1)
+        self._check_timeout_msg(1, "Test interrupted: Timeout reached")
 
     def test_sleep_longer_timeout_all_ok(self):
         cmd_line = (
@@ -155,7 +180,7 @@ class JobTimeOutTest(TestCaseTmpDir):
             3,
             [f"{self.py.path}:Dummy.test00sleep"],
         )
-        self._check_timeout_msg(1)
+        self._check_timeout_msg(1, "Test interrupted: Timeout reached")
 
     def test_invalid_values(self):
         cmd_line = (
@@ -205,11 +230,62 @@ class JobTimeOutTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
 
+    def test_timout_with_tear_down(self):
+        cmd_line = (
+            f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
+            f"--disable-sysinfo "
+            f"--job-timeout=5 {self.py.path}"
+        )
+        self.run_and_check(
+            cmd_line,
+            exit_codes.AVOCADO_JOB_INTERRUPTED,
+            3,
+            [f"{self.py.path}:Dummy.test00sleep"],
+        )
+        self._check_timeout_msg(1, "tearDown")
+
+    def test_timeout_with_long_tear_down(self):
+        config = "[runner.task.interval]\nfrom_soft_to_hard_termination=10\n"
+        fd, config_file = tempfile.mkstemp(dir=self.tmpdir.name)
+        os.write(fd, config.encode())
+        os.close(fd)
+        cmd_line = (
+            f"{AVOCADO} --config {config_file} run --job-results-dir {self.tmpdir.name} "
+            f"--disable-sysinfo "
+            f"--job-timeout=5 {self.long_py.path}"
+        )
+        self.run_and_check(
+            cmd_line,
+            exit_codes.AVOCADO_JOB_INTERRUPTED,
+            1,
+            [f"{self.long_py.path}:Dummy.test00sleep"],
+        )
+        self._check_timeout_msg(1, "tearDown")
+
+    def test_timeout_with_long_tear_down_interupted(self):
+        config = "[runner.task.interval]\nfrom_soft_to_hard_termination=3\n"
+        fd, config_file = tempfile.mkstemp(dir=self.tmpdir.name)
+        os.write(fd, config.encode())
+        os.close(fd)
+        cmd_line = (
+            f"{AVOCADO} --config {config_file} run --job-results-dir {self.tmpdir.name} "
+            f"--disable-sysinfo "
+            f"--job-timeout=5 {self.long_py.path}"
+        )
+        self.run_and_check(
+            cmd_line,
+            exit_codes.AVOCADO_JOB_INTERRUPTED,
+            1,
+            [f"{self.long_py.path}:Dummy.test00sleep"],
+        )
+        self._check_timeout_msg(1, "tearDown", True)
+
     def tearDown(self):
         super().tearDown()
         self.script_short.remove()
         self.script_long.remove()
         self.py.remove()
+        self.long_py.remove()
 
 
 if __name__ == "__main__":

--- a/selftests/functional/plugin/runners/avocado_instrumented.py
+++ b/selftests/functional/plugin/runners/avocado_instrumented.py
@@ -13,6 +13,6 @@ class AvocadoInstrumentedRunnerTest(TestCaseTmpDir, Test):
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, AVOCADO_JOB_INTERRUPTED)
         self.assertIn(
-            "examples/tests/timeouttest.py:TimeoutTest.test:  INTERRUPTED: timeout",
+            "examples/tests/timeouttest.py:TimeoutTest.test:  INTERRUPTED: Test interrupted: Timeout reached",
             result.stdout_text,
         )


### PR DESCRIPTION
It introduces SIGTERM handling in avocado-instrumented tests to run a
tearDown method when the test has been interrupted. It uses
functionality from Test class, which already handles interruptions. It
only adds a monitoring loop to send all messages created by tearDown to
avocado core.

Reference: https://github.com/avocado-framework/avocado/issues/5707 https://github.com/avocado-framework/avocado/issues/5407
Signed-off-by: Jan Richter <jarichte@redhat.com>