### PR TITLE
output: support for rxvt-unicode

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -84,13 +84,15 @@ class TermSupport:
         self.enabled = True
         allowed_terms = [
             "linux",
-            "xterm",
-            "xterm-256color",
-            "xterm-kitty",
-            "vt100",
+            "rxvt-unicode",
+            "rxvt-unicode-256color",
             "screen",
             "screen-256color",
             "screen.xterm-256color",
+            "vt100",
+            "xterm",
+            "xterm-256color",
+            "xterm-kitty",
         ]
         term = os.environ.get("TERM")
         config = settings.as_dict()


### PR DESCRIPTION
Add color support for the terminal I happen to use. Also, sort the entries to prevent duplicates in the future.