### PR TITLE
external_runner import error fix

### DIFF
--- a/scripts/external_runner.py
+++ b/scripts/external_runner.py
@@ -29,7 +29,7 @@ import argparse
 import sys
 
 from avocado.core.job import Job
-from avocado.core.nrunner import Runnable
+from avocado.core.nrunner.runnable import Runnable
 from avocado.core.suite import TestSuite
 from avocado.utils.path import find_command
 


### PR DESCRIPTION
the external_runner uses the old import path for Runnable. This path has been changed when the legacy runner was removed. This PR fixes that to avoid ImportErrors.

Reference: #5370