### PR TITLE
robot compatibility for python3.7

### DIFF
--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -47,7 +47,11 @@ setup(
     url="http://avocado-framework.github.io/",
     packages=packages,
     include_package_data=True,
-    install_requires=[f"avocado-framework=={VERSION}", "robotframework>=4.1"],
+    install_requires=[
+        f"avocado-framework=={VERSION}",
+        "robotframework>=4.1, <=6.1.1; python_version < '3.8'",
+        "robotframework>=4.1; python_version >= '3.8'",
+    ],
     test_suite="tests",
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
robot framework doesn't support python3.7 in newer versions. Let's add requirements restrictions for robot plugin on python3.7

Reference: #5798