### PR TITLE
avocado jobs show: fix retrieval of ERROR

### DIFF
--- a/avocado/plugins/jobs.py
+++ b/avocado/plugins/jobs.py
@@ -161,7 +161,7 @@ class Jobs(CLICmd):
         )
         results %= (
             results_data.get("pass", 0),
-            results_data.get("error", 0),
+            results_data.get("errors", 0),
             results_data.get("failures", 0),
             results_data.get("skip", 0),
             results_data.get("warn", 0),


### PR DESCRIPTION
The JSON results file stores the number of tests ended with ERROR in the "errors" key.