### PR TITLE
INTERRUPTED status overwrite fix

### DIFF
--- a/avocado/core/task/statemachine.py
+++ b/avocado/core/task/statemachine.py
@@ -416,7 +416,8 @@ class Worker:
                 try:
                     self._state_machine.monitored.remove(runtime_task)
                 except ValueError:
-                    pass
+                    # runtime_task has been terminated, there is no need to continue
+                    return
         else:
             LOG.debug(
                 'Task "%s" was very short lived, this may be '

--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -662,8 +662,9 @@ class Test(unittest.TestCase, TestData):
             raise
         except:  # avoid old-style exception failures pylint: disable=W0702
             stacktrace.log_exc_info(sys.exc_info(), logger=self.log)
-            details = sys.exc_info()[1]
-            raise exceptions.TestSetupFail(details)
+            if self.status != "INTERRUPTED":
+                details = sys.exc_info()[1]
+                raise exceptions.TestSetupFail(details)
 
     def _setup_environment_variables(self):
         os.environ["AVOCADO_VERSION"] = VERSION

--- a/selftests/.data/test_statuses.py
+++ b/selftests/.data/test_statuses.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 from avocado import Test, skip
 
@@ -287,6 +288,26 @@ class ExceptionTeardown(Test):
 
     def test(self):
         self.log.info("test pre")
+        self.log.info("test post")
+
+    def tearDown(self):
+        self.log.info("teardown pre")
+        self.log.info("teardown status: %s", self.status)
+        raise ValueError
+        # pylint: disable=W0101
+        self.log.info("teardown post")
+
+
+class ExceptionTeardownSleep(Test):
+    timeout = 3
+
+    def setUp(self):
+        self.log.info("setup pre")
+        self.log.info("setup post")
+
+    def test(self):
+        self.log.info("test pre")
+        time.sleep(10)
         self.log.info("test post")
 
     def tearDown(self):

--- a/selftests/functional/statuses.py
+++ b/selftests/functional/statuses.py
@@ -174,6 +174,16 @@ EXPECTED_RESULTS = {
             "teardown status: PASS",
         ],
     ),
+    "ExceptionTeardownSleep.test": (
+        "INTERRUPTED",
+        [
+            "setup pre",
+            "setup post",
+            "test pre",
+            "teardown pre",
+            "teardown status: INTERRUPTED",
+        ],
+    ),
 }
 
 


### PR DESCRIPTION
When avocado-instrumented test is interrupted, the avocado runner will call a tearDown method to clean the test environment. If some error is raised during the tearDown phase, the `INTERRUPTED` status is overwritten by this error. This is not desired behavior, because the reason for the error was interruption of the test. This fix keeps logging of the tearDown error without change of the `INTERRUPTED` status.

Reference: #5801