### PR TITLE
utils/cpu: add z16 on s390x

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -250,7 +250,7 @@ def get_family():
             LOG.warning(msg)
             raise FamilyException(msg)
     elif arch == "s390":
-        zfamily_map = {"2964": "z13", "3906": "z14", "8561": "z15"}
+        zfamily_map = {"2964": "z13", "3906": "z14", "8561": "z15", "3931": "z16"}
         try:
             family = zfamily_map[get_version()].lower()
         except KeyError as err:

--- a/selftests/unit/utils/cpu.py
+++ b/selftests/unit/utils/cpu.py
@@ -30,6 +30,14 @@ class Cpu(Test):
                 "builtins.open", return_value=self._get_data_mock("s390x_2")
             ):
                 self.assertEqual(len(cpu.online_list()), 4)
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("s390x_3")
+            ):
+                self.assertEqual(len(cpu.online_list()), 6)
+            with unittest.mock.patch(
+                "builtins.open", return_value=self._get_data_mock("s390x_4")
+            ):
+                self.assertEqual(len(cpu.online_list()), 16)
 
     def test_x86_64_cpu_online(self):
         with unittest.mock.patch(

--- a/selftests/unit/utils/cpu.py.data/s390x_4
+++ b/selftests/unit/utils/cpu.py.data/s390x_4
@@ -1,0 +1,90 @@
+vendor_id       : IBM/S390
+# processors    : 16
+bogomips per cpu: 3331.00
+max thread id   : 1
+features	: esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te vx vxd vxe gs vxe2 vxp sort dflt vxp2 nnpa pcimio sie 
+facilities      : 0 1 2 3 4 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 38 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 57 58 59 60 61 64 65 66 67 68 69 70 71 72 73 75 76 77 78 80 81 82 129 130 131 132 133 134 135 138 139 141 142 144 145 146 148 149 150 151 152 153 155 156 158 165 192 193 194 196 197
+cache0          : level=1 type=Data scope=Private size=128K line_size=256 associativity=8
+cache1          : level=1 type=Instruction scope=Private size=128K line_size=256 associativity=8
+cache2          : level=2 type=Unified scope=Private size=32768K line_size=256 associativity=16
+cache3          : level=3 type=Unified scope=Shared size=262144K line_size=256 associativity=128
+processor 0: version = 00,  identification = 285FA8,  machine = 3931
+processor 1: version = 00,  identification = 285FA8,  machine = 3931
+processor 2: version = 00,  identification = 285FA8,  machine = 3931
+processor 3: version = 00,  identification = 285FA8,  machine = 3931
+processor 4: version = 00,  identification = 285FA8,  machine = 3931
+processor 5: version = 00,  identification = 285FA8,  machine = 3931
+processor 6: version = 00,  identification = 285FA8,  machine = 3931
+processor 7: version = 00,  identification = 285FA8,  machine = 3931
+processor 8: version = 00,  identification = 285FA8,  machine = 3931
+processor 9: version = 00,  identification = 285FA8,  machine = 3931
+processor 10: version = 00,  identification = 285FA8,  machine = 3931
+processor 11: version = 00,  identification = 285FA8,  machine = 3931
+processor 12: version = 00,  identification = 285FA8,  machine = 3931
+processor 13: version = 00,  identification = 285FA8,  machine = 3931
+processor 14: version = 00,  identification = 285FA8,  machine = 3931
+processor 15: version = 00,  identification = 285FA8,  machine = 3931
+
+cpu number      : 0
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 1
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 2
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 3
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 4
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 5
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 6
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 7
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 8
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 9
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 10
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 11
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 12
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 13
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 14
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200
+
+cpu number      : 15
+cpu MHz dynamic : 5200
+cpu MHz static  : 5200


### PR DESCRIPTION
    
    Add recent z16 model. Without this tests on z16
    will end with a warning.
    
    Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
    Signed-off-by: Cleber Rosa <crosa@redhat.com>