### PR TITLE
utils/cpu: add z16 on s390x

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -219,7 +219,8 @@ def get_family():
     elif arch == 's390':
         zfamily_map = {'2964': 'z13',
                        '3906': 'z14',
-                       '8561': 'z15'
+                       '8561': 'z15',
+                       '3931': 'z16'
                        }
         try:
             family = zfamily_map[get_version()].lower()


### PR DESCRIPTION
https://github.com/avocado-framework/avocado/pull/5807 against 92lts

Add recent z16 model. Without this tests on z16
will end with a warning.