### PR TITLE
Python 3.13 enablement

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -23,8 +23,8 @@ import inspect
 import io
 import logging
 import os
-import pipes
 import re
+import shlex
 import shutil
 import sys
 import tempfile
@@ -1119,7 +1119,7 @@ class SimpleTest(Test):
                                       "file": [lambda: file_datadir]}
         self._command = None
         if self.filename is not None:
-            self._command = pipes.quote(self.filename)
+            self._command = shlex.quote(self.filename)
 
     @property
     def filename(self):


### PR DESCRIPTION
Avocado fails to build with Python 3.13.0a1, due to:

   ModuleNotFoundError: No module named 'pipes'

This is a simple fix, as the function under the pipes module has really been an import from the shlex module for a while.

Reference: https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-pep594
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=2244836
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=2250847