### PR TITLE
Fedora CI update from 36 to 38

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ansible (${{matrix.extra}})
     runs-on: ubuntu-latest
     container:
-      image: fedora:36
+      image: fedora:38
     env:
       RUN_BEFORE: 'dnf install -y git ansible'
       GIT_URL: 'https://github.com/${{github.repository}}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
          python3 setup.py bdist_egg
          mv dist/avocado_framework-*egg /tmp/avocado_framework.egg
          python3 setup.py clean --all
-         python3 -c 'import sys; sys.path.insert(0, "/tmp/avocado_framework.egg"); from avocado.core.main import main; sys.exit(main())' run --spawner=podman --spawner-podman-image=fedora:36 --spawner-podman-avocado-egg=file:///tmp/avocado_framework.egg -- /bin/true
+         python3 -c 'import sys; sys.path.insert(0, "/tmp/avocado_framework.egg"); from avocado.core.main import main; sys.exit(main())' run --spawner=podman --spawner-podman-image=fedora:38 --spawner-podman-avocado-egg=file:///tmp/avocado_framework.egg -- /bin/true
 
   podman_external_runner_task:
 
@@ -387,7 +387,7 @@ jobs:
     name: Fedora develop install/uninstall task
     runs-on: ubuntu-latest
     container:
-      image: fedora:36
+      image: fedora:38
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/selftests/functional/serial/requirements.py
+++ b/selftests/functional/serial/requirements.py
@@ -117,7 +117,7 @@ class BasicTest(TestCaseTmpDir, Test):
         spawner = self.params.get("spawner", default="process")
         spawner_command = ""
         if spawner == "podman":
-            spawner_command = "--spawner=podman --spawner-podman-image=fedora:36"
+            spawner_command = "--spawner=podman --spawner-podman-image=fedora:38"
         return f"{AVOCADO} run {spawner_command} --job-results-dir {self.tmpdir.name} {path}"
 
     @skipUnless(os.getenv("CI"), skip_package_manager_message)


### PR DESCRIPTION
Because Fedora 36 is at the end of its life-cycle the public package repositories has been removed, because of this change our CI is failing. Let's update the used Fedora images to 38.

Reference: https://github.com/avocado-framework/avocado/actions/runs/6979871118/job/18993993584?pr=5804