### PR TITLE
Seltests / Containers / CI: Bump Fedora to 38

### DIFF
--- a/contrib/containers/ci/selftests/magic.docker
+++ b/contrib/containers/ci/selftests/magic.docker
@@ -4,7 +4,7 @@
 # is by running:
 # $ cd examples/plugins/tests
 # $ buildah bud -f ../../../contrib/containers/ci/selftests/magic.docker
-FROM fedora:36
+FROM fedora:38
 LABEL description "Image that contains the example magic plugin"
 RUN dnf -y install python3-setuptools
 COPY magic /tmp/magic

--- a/contrib/containers/fedora-38-latest-copr.docker
+++ b/contrib/containers/fedora-38-latest-copr.docker
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:38
 LABEL description "Fedora image with the latest Avocado COPR build"
 RUN dnf -y install dnf-plugins-core
 RUN dnf -y copr enable @avocado/avocado-latest

--- a/selftests/functional/plugin/podman_image.py
+++ b/selftests/functional/plugin/podman_image.py
@@ -6,18 +6,18 @@ class PodmanImageTest(Test):
     async def test(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
-        :avocado: dependency={"type": "podman-image", "uri": "registry.fedoraproject.org/fedora:36"}
+        :avocado: dependency={"type": "podman-image", "uri": "registry.fedoraproject.org/fedora:38"}
         """
         podman = Podman()
         _, stdout, _ = await podman.execute(
             "images",
             "--filter",
-            "reference=registry.fedoraproject.org/fedora:36",
+            "reference=registry.fedoraproject.org/fedora:38",
             "--format",
             "{{.Repository}}:{{.Tag}}",
         )
         self.assertIn(
-            "registry.fedoraproject.org/fedora:36",
+            "registry.fedoraproject.org/fedora:38",
             stdout.decode().splitlines(),
             "Podman image does not seem to have been pulled",
         )

--- a/selftests/functional/plugin/spawners/podman.py
+++ b/selftests/functional/plugin/spawners/podman.py
@@ -29,7 +29,7 @@ class PassTest(Test):
 class PodmanSpawnerTest(Test):
     """
     :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
-    :avocado: dependency={"type": "podman-image", "uri": "registry.fedoraproject.org/fedora:36"}
+    :avocado: dependency={"type": "podman-image", "uri": "registry.fedoraproject.org/fedora:38"}
     """
 
     def test_avocado_instrumented(self):
@@ -41,7 +41,7 @@ class PodmanSpawnerTest(Test):
                 f"{AVOCADO} run "
                 f"--job-results-dir {self.workdir} "
                 f"--disable-sysinfo --spawner=podman "
-                f"--spawner-podman-image=fedora:36 -- "
+                f"--spawner-podman-image=fedora:38 -- "
                 f"{test}",
                 ignore_status=True,
             )
@@ -54,7 +54,7 @@ class PodmanSpawnerTest(Test):
             f"{AVOCADO} run "
             f"--job-results-dir {self.workdir} "
             f"--disable-sysinfo --spawner=podman "
-            f"--spawner-podman-image=fedora:36 -- "
+            f"--spawner-podman-image=fedora:38 -- "
             f"/bin/true",
             ignore_status=True,
         )
@@ -72,7 +72,7 @@ class PodmanSpawnerTest(Test):
                 "run.results_dir": self.workdir,
                 "task.timeout.running": 2,
                 "run.spawner": "podman",
-                "spawner.podman.image": "fedora:36",
+                "spawner.podman.image": "fedora:38",
             }
 
             with Job.from_config(job_config=config) as job:
@@ -92,7 +92,7 @@ class PodmanSpawnerTest(Test):
             ],
             "run.results_dir": self.workdir,
             "run.spawner": "podman",
-            "spawner.podman.image": "fedora:36",
+            "spawner.podman.image": "fedora:38",
         }
 
         with Job.from_config(job_config=config) as job:
@@ -109,7 +109,7 @@ class PodmanSpawnerTest(Test):
             f"{AVOCADO} run "
             f"--job-results-dir {self.workdir} "
             f"--disable-sysinfo --spawner=podman "
-            f"--spawner-podman-image=fedora:36 -- "
+            f"--spawner-podman-image=fedora:38 -- "
             f"{test}",
             ignore_status=True,
         )

--- a/selftests/functional/utils/distro.py
+++ b/selftests/functional/utils/distro.py
@@ -32,15 +32,15 @@ class Distro(Test):
         with open(stdout_path, "rb") as stdout:
             self.assertEqual(stdout.read(), output)
 
-    def test_fedora_36(self):
+    def test_fedora_38(self):
         """
-        :avocado: dependency={"type": "podman-image", "uri": "registry.fedoraproject.org/fedora:36"}
+        :avocado: dependency={"type": "podman-image", "uri": "registry.fedoraproject.org/fedora:38"}
         """
         self.run_job(
-            "registry.fedoraproject.org/fedora:36",
+            "registry.fedoraproject.org/fedora:38",
             b"Detected distribution: fedora ("
             + os.uname().machine.encode()
-            + b") version 36 release 0\n",
+            + b") version 38 release 0\n",
         )
 
     def test_rhel_9_1(self):

--- a/selftests/functional/utils/podman.py
+++ b/selftests/functional/utils/podman.py
@@ -6,21 +6,21 @@ class PodmanTest(Test):
     async def test_python_version(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
-        :avocado: dependency={"type": "podman-image", "uri": "fedora:36"}
+        :avocado: dependency={"type": "podman-image", "uri": "fedora:38"}
         :avocado: tags=slow
         """
         podman = Podman()
-        result = await podman.get_python_version("fedora:36")
-        self.assertEqual(result, (3, 10, "/usr/bin/python3"))
+        result = await podman.get_python_version("fedora:38")
+        self.assertEqual(result, (3, 11, "/usr/bin/python3"))
 
     async def test_container_info(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
-        :avocado: dependency={"type": "podman-image", "uri": "fedora:36"}
+        :avocado: dependency={"type": "podman-image", "uri": "fedora:38"}
         :avocado: tags=slow
         """
         podman = Podman()
-        _, stdout, _ = await podman.execute("create", "fedora:36", "/bin/bash")
+        _, stdout, _ = await podman.execute("create", "fedora:38", "/bin/bash")
         container_id = stdout.decode().strip()
         result = await podman.get_container_info(container_id)
         self.assertEqual(result["Id"], container_id)


### PR DESCRIPTION
This is a follow up to 48c0c1b7b that bumps pretty much all usages of Fedora 36 to 38.