### PR TITLE
utils/cpu: Add utility to get VA address size in bits

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -179,6 +179,20 @@ def get_revision():
     return rev
 
 
+def get_va_bits():
+    """
+    Check for VA address bit size in /proc/cpuinfo
+
+    :return: VA address bit size
+    :rtype: str
+    """
+    cpu_info = genio.read_file("/proc/cpuinfo")
+    for line in cpu_info.splitlines():
+        if "address sizes" in line:
+            return line.split()[-3].strip()
+    return ""
+
+
 def get_arch():
     """Work out which CPU architecture we're running on."""
     cpu_table = [


### PR DESCRIPTION
Add support to get VA address size in bits from /proc/cpuinfo.

$ cat /proc/cpuinfo
.............
.............
address sizes   : 48 bits physical, 48 bits virtual
.............

Here, 48 bits virtual => VA address size in bits