### PR TITLE
Re-enable basic functional tests

### DIFF
--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -8,7 +8,6 @@ import unittest
 import xml.dom.minidom
 import zipfile
 
-from avocado import Test
 from avocado.core import exit_codes
 from avocado.utils import path as utils_path
 from avocado.utils import process, script
@@ -884,7 +883,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             )
 
 
-class DryRunTest(Test):
+class DryRunTest(unittest.TestCase):
     def test_dry_run(self):
         examples_path = os.path.join("examples", "tests")
         passtest = os.path.join(examples_path, "passtest.py")


### PR DESCRIPTION
Some of the functional tests have been masked out due to a safeloader issue (#5817).

This works around that limitation, *but* it also flags tests that are actually broken and have not been running.

PS: The CI will fail, until the issues with these tests are resolved.