### PR TITLE
Selftest refactoring to fix masked tests 

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -209,9 +209,7 @@ class Job:
     def __start_job_logging(self):
         # Enable test logger
         full_log = os.path.join(self.logdir, "full.log")
-        fmt = (
-            "%(asctime)s %(module)-16.16s L%(lineno)-.4d %(levelname)-5.5s| %(message)s"
-        )
+        fmt = "%(asctime)s %(name)s %(module)-16.16s L%(lineno)-.4d %(levelname)-5.5s| %(message)s"
         output.add_log_handler(
             LOG_JOB,
             logging.FileHandler,

--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -249,7 +249,7 @@ def start_logging(config, queue):
     log_handler = RunnerLogHandler(queue, "log")
     stdout_handler = RunnerLogHandler(queue, "stdout")
     stderr_handler = RunnerLogHandler(queue, "stderr")
-    fmt = "%(asctime)s %(module)-16.16s L%(lineno)-.4d %(levelname)-5.5s| %(message)s"
+    fmt = "%(asctime)s %(name)s %(module)-16.16s L%(lineno)-.4d %(levelname)-5.5s| %(message)s"
     formatter = logging.Formatter(fmt=fmt)
     log_handler.setFormatter(formatter)
     stdout_handler.setFormatter(formatter)

--- a/docs/source/guides/writer/chapters/writing.rst
+++ b/docs/source/guides/writer/chapters/writing.rst
@@ -29,6 +29,13 @@ leveraging its API power.
 As can be seen in the example above, an Avocado test is a method that starts
 with ``test`` in a class that inherits from :mod:`avocado.Test`.
 
+.. warning:: Note that combining unittests and avocado-instrumented tests within
+             the same file is not feasible. If a class inherits from :mod:`avocado.Test`,
+             and another class inherits from :class:`unittest.TestCase` in the same file,
+             the unittest class will be excluded from testing. In such instances, it is
+             advisable to segregate these tests into separate files.
+
+
 .. note:: Avocado also supports coroutines as tests.  Simply declare
           your test method using the ``async def`` syntax, and Avocado
           will run it inside an asyncio loop.

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -8,7 +8,6 @@ import unittest
 import xml.dom.minidom
 import zipfile
 
-from avocado import Test
 from avocado.core import exit_codes
 from avocado.utils import path as utils_path
 from avocado.utils import process, script
@@ -904,7 +903,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             )
 
 
-class DryRunTest(Test):
+class DryRunTest(unittest.TestCase):
     def test_dry_run(self):
         examples_path = os.path.join("examples", "tests")
         passtest = os.path.join(examples_path, "passtest.py")

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -507,7 +507,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             expected_rc,
             f"Avocado did not return rc {expected_rc}:\n{result}",
         )
-        self.assertIn("timeout", result_json["tests"][0]["fail_reason"])
+        self.assertIn("Timeout reached", result_json["tests"][0]["fail_reason"])
         # Ensure no test aborted error messages show up
         self.assertNotIn(b"TestAbortError: Test aborted unexpectedly", output)
 
@@ -553,9 +553,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         )
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_ALL_OK)
-        self.assertIn(
-            b"Plant.test_plant_organic: preparing soil on row 0", result.stdout
-        )
+        self.assertIn(b"preparing soil on row 0", result.stdout)
         lines = result.stdout.split(b"\n")
         self.assertEqual(
             len(lines), len(set(lines)), "The --show option has duplicities"
@@ -783,9 +781,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         with open(progress_info, encoding="utf-8") as file:
             stream_line = file.readline()
             self.assertIn(
-                "avocado.test.progress INFO | "
-                "1-examples/tests/logging_streams.py:Plant.test_plant_organic: "
-                "preparing soil on row 0",
+                "logging_streams  L0017 INFO | preparing soil on row 0",
                 stream_line,
             )
 
@@ -805,10 +801,10 @@ class RunnerOperationTest(TestCaseTmpDir):
         self.assertTrue(os.path.exists(progress_info))
         with open(progress_info, encoding="utf-8") as file:
             stream = file.read()
-            self.assertIn("avocado.job", stream)
-            self.assertIn("avocado.core", stream)
-            self.assertIn("avocado.test", stream)
-            self.assertIn("avocado.app", stream)
+            self.assertIn("INFO | Avocado config:", stream)
+            self.assertIn("requested -> triagin", stream)
+            self.assertIn("preparing soil on row 0", stream)
+            self.assertIn("INFO | RESULTS    : PASS 1 |", stream)
 
     @unittest.skipUnless(
         os.getenv("CI"),
@@ -891,7 +887,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         with open(progress_info, encoding="utf-8") as file:
             stream_line = file.readline()
             self.assertIn(
-                "avocado.test.progress ERROR| Avocados are Gone",
+                "logging_streams  L0037 ERROR| Avocados are Gone",
                 stream_line,
             )
         progress_info = os.path.join(
@@ -903,7 +899,7 @@ class RunnerOperationTest(TestCaseTmpDir):
         with open(progress_info, encoding="utf-8") as file:
             stream_line = file.readline()
             self.assertIn(
-                "avocado.test.progress ERROR| 1-examples/tests/logging_streams.py:Plant.test_plant_organic: Avocados are Gone",
+                "logging_streams  L0037 ERROR| Avocados are Gone",
                 stream_line,
             )
 

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -820,7 +820,7 @@ class RunnerOperationTest(TestCaseTmpDir):
             self.assertTrue(os.path.exists(file_path))
             with open(file_path, encoding="utf-8") as file:
                 stream = file.read()
-                self.assertIn("matplotlib DEBUG|", stream)
+                self.assertIn("matplotlib __init__         L0337 DEBUG|", stream)
 
         log_dir = os.path.join(self.tmpdir.name, "latest")
         test_log_dir = os.path.join(


### PR DESCRIPTION
Some functional tests have been masked out due to a safeloader behavior
from https://github.com/avocado-framework/avocado/issues/5817. This commit fixes this problem by changing the tests classes
from unittests to avocado instrumented, where it is needed. Also, it
adds warning to avocado documentation about this behavior.

Reference: https://github.com/avocado-framework/avocado/issues/5817
Signed-off-by: Jan Richter <jarichte@redhat.com>