### PR TITLE
readthedocs.org: install Avocado instead of devel requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,5 @@ sphinx:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-  - requirements: requirements-dev.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
Avocado itself is not being installed with the current readthedocs configuration, while the devel requirements are.