### PR TITLE
Python unittest skip messages on 3.12 and later

### DIFF
--- a/selftests/unit/nrunner.py
+++ b/selftests/unit/nrunner.py
@@ -321,11 +321,18 @@ class Runner(unittest.TestCase):
         runner_klass = runnable.pick_runner_class()
         runner = runner_klass()
         results = [status for status in runner.run(runnable)]
-        output1 = (
-            b"----------------------------------------------------------------------\n"
-            b"Ran 1 test in "
-        )
-        output2 = b"s\n\nOK (skipped=1)\n"
+        if sys.version_info < (3, 12, 1):
+            output1 = (
+                b"----------------------------------------------------------------------\n"
+                b"Ran 1 test in "
+            )
+            output2 = b"s\n\nOK (skipped=1)\n"
+        else:
+            output1 = (
+                b"----------------------------------------------------------------------\n"
+                b"Ran 0 tests in "
+            )
+            output2 = b"\n\nNO TESTS RAN (skipped=1)\n"
         output = results[-2]
         result = results[-1]
         self.assertEqual(result["status"], "finished")


### PR DESCRIPTION
On Python 3.12 and later (introduce in commit 76632b836), the message given when no tests are run is more precise and verbose.  Let's adapt the nrunner selftest to take that into consideration.