### PR TITLE
IRC channel doc removal

### DIFF
--- a/docs/source/guides/contributor/chapters/contact.rst
+++ b/docs/source/guides/contributor/chapters/contact.rst
@@ -2,5 +2,4 @@ Contact information
 ===================
 
 - Avocado-devel mailing list: `https://www.redhat.com/mailman/listinfo/avocado-devel <https://www.redhat.com/mailman/listinfo/avocado-devel>`_
-- Avocado IRC channel: `irc.oftc.net #avocado <irc://irc.oftc.net/#avocado>`_
 - Avocado GitHub repository: `https://github.com/avocado-framework/avocado/ <https://github.com/avocado-framework/avocado/>`_

--- a/docs/source/guides/contributor/chapters/how.rst
+++ b/docs/source/guides/contributor/chapters/how.rst
@@ -180,7 +180,7 @@ Request, but some conditions have to be fulfilled before merging the code:
 Pull Requests failing in CI will not be merged, and reviews won't be given to
 them until all the problems are sorted out. In case of a weird failure, or
 false-negative (eg. due to too many commits in a single PR), please reach the
-developers by @name/email/irc or other means.
+developers by @name/email or other means.
 
 While reviewing the code, one should:
 


### PR DESCRIPTION
Since avocado IRC channel is not operational anymore, we need to remove it from our contact info.