### PR TITLE
Robot Framework Plugin: pin compatibility with series 6

### DIFF
--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         f"avocado-framework=={VERSION}",
         "robotframework>=4.1, <=6.1.1; python_version < '3.8'",
-        "robotframework>=4.1; python_version >= '3.8'",
+        "robotframework>=4.1, <7.0; python_version >= '3.8'",
     ],
     test_suite="tests",
     entry_points={


### PR DESCRIPTION
Robot framework version 7 is in pre-release, and has different behavior that our plugin is not really validated with.

Let's pin it to require a version 6.x only.