### PR TITLE
optional_plugins/spawner_remote: add missing manifest to include VERSION

### DIFF
--- a/Makefile.gh
+++ b/Makefile.gh
@@ -72,7 +72,7 @@ build-wheel: pip
 
 check-wheel: build-wheel
 	$(PYTHON) -m pip install twine
-	twine check ./PYPI_UPLOAD/*
+	twine check --strict ./PYPI_UPLOAD/*
 
 build-egg:
 	if test ! -d EGG_UPLOAD; then mkdir EGG_UPLOAD; fi

--- a/optional_plugins/spawner_remote/MANIFEST.in
+++ b/optional_plugins/spawner_remote/MANIFEST.in
@@ -1,0 +1,1 @@
+include VERSION

--- a/optional_plugins/spawner_remote/setup.py
+++ b/optional_plugins/spawner_remote/setup.py
@@ -34,6 +34,8 @@ setup(
     name="avocado-framework-plugin-spawner-remote",
     version=VERSION,
     description="Remote (host) based spawner",
+    long_description="Remote (host) based spawner",
+    long_description_content_type="text/plain",
     author="Avocado Developers",
     author_email="avocado-devel@redhat.com",
     url="http://avocado-framework.github.io/",


### PR DESCRIPTION
Without this, building packages (such as wheels) will fail for the plugin.