### PR TITLE
Docs: use the rtd theme also on readthedocs.org

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,5 +20,6 @@ sphinx:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
+    - requirements: requirements-doc.txt
     - method: pip
       path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -217,7 +217,7 @@ extensions = [
 
 master_doc = "index"  # pylint: disable=C0103
 project = "Avocado"  # pylint: disable=C0103
-copyright = "2014-2019, Red Hat"  # pylint: disable=W0622,C0103
+copyright = "2014-2023, Red Hat"  # pylint: disable=W0622,C0103
 
 VERSION_FILE = os.path.join(ROOT_PATH, "VERSION")
 VERSION = genio.read_file(VERSION_FILE).strip()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,9 +19,6 @@ ROOT_PATH = os.path.abspath(os.path.join("..", ".."))
 sys.path.insert(0, ROOT_PATH)
 
 
-# Flag that tells if the docs are being built on readthedocs.org
-ON_RTD = os.environ.get("READTHEDOCS", None) == "True"
-
 #
 # Auto generate API documentation
 #
@@ -213,6 +210,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
+    "sphinx_rtd_theme",
 ]
 
 master_doc = "index"  # pylint: disable=C0103
@@ -224,16 +222,7 @@ VERSION = genio.read_file(VERSION_FILE).strip()
 version = VERSION  # pylint: disable=C0103
 release = VERSION  # pylint: disable=C0103
 
-if not ON_RTD:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-
-        html_theme = "sphinx_rtd_theme"  # pylint: disable=C0103
-        html_theme_path = [
-            sphinx_rtd_theme.get_html_theme_path()
-        ]  # pylint: disable=C0103
-    except ImportError:
-        html_theme = "default"  # pylint: disable=C0103
+html_theme = "sphinx_rtd_theme"  # pylint: disable=C0103
 
 htmlhelp_basename = "avocadodoc"  # pylint: disable=C0103
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
It looks like readthedocs.org no longer overrides the theme when it's building the docs.  Let's always try to se the rtd theme, unless it's not available, that includes on readthedocs.org (where it should always be available).