### PR TITLE
man: add manpages all binaries

### DIFF
--- a/man/avocado-runner-avocado-instrumented.rst
+++ b/man/avocado-runner-avocado-instrumented.rst
@@ -1,0 +1,30 @@
+:title: avocado-runner-avocado-instrumented
+:subtitle: nrunner application for avocado-instrumented tests
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner-avocado-instrumented [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+nrunner application for avocado-instrumented tests
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner-dry-run.rst
+++ b/man/avocado-runner-dry-run.rst
@@ -1,0 +1,30 @@
+:title: avocado-runner-dry-run
+:subtitle: nrunner application for dry run
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner-dry-run [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+It performs no action before reporting FINISHED status with cancel result.
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner-exec-test.rst
+++ b/man/avocado-runner-exec-test.rst
@@ -1,0 +1,32 @@
+:title: avocado-runner-exec-test
+:subtitle: nrunner application for standalone executables treated as tests
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner-exec-test [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+This is similar in concept to the Avocado "SIMPLE" test type, in which an
+executable returning 0 means that a test passed, and anything else means
+that a test failed.
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner-noop.rst
+++ b/man/avocado-runner-noop.rst
@@ -1,0 +1,30 @@
+:title: avocado-runner-noop
+:subtitle: nrunner application that performs no action before reporting FINISHED status
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner-noop [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+Sample runner that performs no action before reporting FINISHED status.
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner-python-unittest.rst
+++ b/man/avocado-runner-python-unittest.rst
@@ -1,0 +1,32 @@
+:title: avocado-runner-python-unittest
+:subtitle: nrunner application for Python unittests
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner-python-unittest [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+The runnable uri is used as the test name that the native unittest
+TestLoader will use to find the test. A native unittest test runner
+(TextTestRunner) will be used to execute the test.
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner-requirement-asset.rst
+++ b/man/avocado-runner-requirement-asset.rst
@@ -1,0 +1,30 @@
+:title: avocado-runner-requirement-asset
+:subtitle: nrunner application for requirements of type asset
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+nrunner application for requirements of type asset [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+nrunner base application
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner-requirement-package.rst
+++ b/man/avocado-runner-requirement-package.rst
@@ -1,0 +1,30 @@
+:title: avocado-runner-requirement-package
+:subtitle: nrunner application for requirements of type package
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner-requirement-package [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+nrunner application for requirements of type package
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner-sysinfo.rst
+++ b/man/avocado-runner-sysinfo.rst
@@ -1,0 +1,30 @@
+:title: avocado-runner-sysinfo
+:subtitle: nrunner application for gathering sysinfo
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner-sysinfo [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+nrunner application for gathering sysinfo
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner-tap.rst
+++ b/man/avocado-runner-tap.rst
@@ -1,0 +1,30 @@
+:title: avocado-runner-tap
+:subtitle: nrunner application for executable tests that produce TAP
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner-tap [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+nrunner application for executable tests that produce TAP
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-runner.rst
+++ b/man/avocado-runner.rst
@@ -1,0 +1,30 @@
+:title: avocado-runner
+:subtitle: nrunner base application
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-runner [-h]
+{capabilities,runnable-run,runnable-run-recipe,task-run,task-run-recipe} ...
+
+DESCRIPTION
+===========
+
+nrunner base application
+
+OPTIONS
+=======
+
+Positional arguments::
+
+    capabilities        Outputs capabilities, including runnables and commands
+    runnable-run        Runs a runnable definition from arguments
+    runnable-run-recipe Runs a runnable definition from a recipe
+    task-run            Runs a task from arguments
+    task-run-recipe     Runs a task from a recipe
+
+Optional arguments::
+
+    -h, --help          Show this help message and exit

--- a/man/avocado-software-manager.rst
+++ b/man/avocado-software-manager.rst
@@ -1,0 +1,25 @@
+:title: avocado-software-manager
+:subtitle: avocado software manager
+:title_upper: AVOCADO
+:manual_section: 1
+
+SYNOPSIS
+========
+
+avocado-software-manager
+{install|remove|check-installed|list-all|list-files|add-repo|remove-repo| \
+upgrade|what-provides|install-what-provides}
+[-h] [--verbose]
+
+DESCRIPTION
+===========
+
+avocado software manager
+
+OPTIONS
+=======
+
+Optional arguments::
+
+    -h, --help          show this help message and exit
+    --verbose           include debug messages in console output

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,16 @@ class Clean(clean):
             "./build",
             "./dist",
             "./man/avocado.1",
+            "./man/avocado-runner-avocado-instrumented.1",
+            "./man/avocado-runner-dry-run.1",
+            "./man/avocado-runner-exec-test.1",
+            "./man/avocado-runner-noop.1",
+            "./man/avocado-runner-python-unittest.1",
+            "./man/avocado-runner-requirement-asset.1",
+            "./man/avocado-runner-requirement-package.1",
+            "./man/avocado-runner-sysinfo.1",
+            "./man/avocado-runner-tap.1",
+            "./man/avocado-software-manager.1",
             "./docs/build",
         ]
 
@@ -281,6 +291,71 @@ class Man(SimpleCommand):
 
         try:
             run([cmd, "man/avocado.rst", "man/avocado.1"], check=True)
+            run(
+                [
+                    cmd,
+                    "man/avocado-runner-avocado-instrumented.rst",
+                    "man/avocado-runner-avocado-instrumented.1",
+                ],
+                check=True,
+            )
+            run(
+                [cmd, "man/avocado-runner-dry-run.rst", "man/avocado-runner-dry-run.1"],
+                check=True,
+            )
+            run(
+                [
+                    cmd,
+                    "man/avocado-runner-exec-test.rst",
+                    "man/avocado-runner-exec-test.1",
+                ],
+                check=True,
+            )
+            run(
+                [cmd, "man/avocado-runner-noop.rst", "man/avocado-runner-noop.1"],
+                check=True,
+            )
+            run(
+                [
+                    cmd,
+                    "man/avocado-runner-python-unittest.rst",
+                    "man/avocado-runner-python-unittest.1",
+                ],
+                check=True,
+            )
+            run(
+                [
+                    cmd,
+                    "man/avocado-runner-requirement-asset.rst",
+                    "man/avocado-runner-requirement-asset.1",
+                ],
+                check=True,
+            )
+            run(
+                [
+                    cmd,
+                    "man/avocado-runner-requirement-package.rst",
+                    "man/avocado-runner-requirement-package.1",
+                ],
+                check=True,
+            )
+            run(
+                [cmd, "man/avocado-runner-sysinfo.rst", "man/avocado-runner-sysinfo.1"],
+                check=True,
+            )
+            run(
+                [cmd, "man/avocado-runner-tap.rst", "man/avocado-runner-tap.1"],
+                check=True,
+            )
+            run([cmd, "man/avocado-runner.rst", "man/avocado-runner.1"], check=True)
+            run(
+                [
+                    cmd,
+                    "man/avocado-software-manager.rst",
+                    "man/avocado-software-manager.1",
+                ],
+                check=True,
+            )
         except CalledProcessError as e:
             print("Failed manpage build: ", e)
             sys.exit(128)


### PR DESCRIPTION
To match Debian Policy every binary should have manpage.  Add RST docs for every binary which has --help command.

For the runners, actual description was taken from their sources.

Reference: https://github.com/avocado-framework/avocado/pull/5050