### PR TITLE
Add a quick guide for setting up the remote spawner

### DIFF
--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -35,3 +35,4 @@ Some of these plugins may have extra dependencies of their own.
    optional/results/index
    optional/robot
    optional/varianters/index
+   optional/spawner_remote

--- a/docs/source/plugins/optional/spawner_remote.rst
+++ b/docs/source/plugins/optional/spawner_remote.rst
@@ -1,0 +1,1 @@
+../../../../optional_plugins/spawner_remote/README.rst

--- a/optional_plugins/spawner_remote/README.rst
+++ b/optional_plugins/spawner_remote/README.rst
@@ -1,0 +1,39 @@
+=====================
+Remote Spawner Plugin
+=====================
+
+This plugin makes use of remote `aexpect
+<https://github.com/avocado-framework/aexpect/>`__ sessions (to remote
+hosts or equivalently remote containers behind remote hosts forwarded
+via specific ports) as slots to schedule test runs on.
+
+It mainly draws inspiration and mimics slot and other
+code from the LXC spawner with the exception of extra configurable
+test timeout that is enforced by aexpect as a dependency and fully
+specific to this type of spawner.
+
+To install the Remote Spawner plugin from pip, use::
+
+    $ sudo pip install avocado-framework-plugin-spawner-remote
+
+After it is installed, add a slot (e.g. "board") to your avocado
+config file::
+
+    [spawner.remote]
+    slots = ['board']
+
+Then you need a JSON file of the same name as the slot. Its contents
+are the command line parameters of aexpect's ``remote_login`` function
+of module ``remote``, e.g.::
+
+    {
+       "client": "telnet",
+       "host": "192.168.64.2",
+       "port": "23",
+       "username": "root",
+       "password": "",
+       "prompt": "#"
+    }
+
+Final important detail: the remote site also needs avocado
+installed.

--- a/optional_plugins/spawner_remote/setup.py
+++ b/optional_plugins/spawner_remote/setup.py
@@ -30,12 +30,18 @@ with open(os.path.join(BASE_PATH, "VERSION"), "r", encoding="utf-8") as version_
     VERSION = version_file.read().strip()
 
 
+def get_long_description():
+    with open(os.path.join(BASE_PATH, "README.rst"), "rt", encoding="utf-8") as readme:
+        readme_contents = readme.read()
+    return readme_contents
+
+
 setup(
     name="avocado-framework-plugin-spawner-remote",
     version=VERSION,
     description="Remote (host) based spawner",
-    long_description="Remote (host) based spawner",
-    long_description_content_type="text/plain",
+    long_description=get_long_description(),
+    long_description_content_type="text/x-rst",
     author="Avocado Developers",
     author_email="avocado-devel@redhat.com",
     url="http://avocado-framework.github.io/",


### PR DESCRIPTION
This Documents some crucial steps for a new user of the remote spawner plugin.

Reference: https://github.com/avocado-framework/avocado/issues/5838