### PR TITLE
Status server help message fix

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -87,8 +87,8 @@ class RunnerInit(Init):
             "URI for connecting to the status server, usually "
             'a "HOST:PORT" string. Use this if your status server '
             "is in another host, or different port. This is only "
-            'effective if "status_server_auto" is disabled'
-            'If "status_server_listen" is not set. Value from "status_server_uri" '
+            'effective if "status_server_auto" is disabled. '
+            'If "status_server_listen" is not set, the value from "status_server_uri" '
             "will be used."
         )
         settings.register_option(

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -193,8 +193,8 @@ Options for subcommand `run` (`avocado run --help`)::
                             URI for connecting to the status server, usually a
                             "HOST:PORT" string. Use this if your status server is
                             in another host, or different port. This is only
-                            effective if "status_server_auto" is disabledIf
-                            "status_server_listen" is not set. Value from
+                            effective if "status_server_auto" is disabled.  If
+                            "status_server_listen" is not set, the value from
                             "status_server_uri" will be used.
       --max-parallel-tasks NUMBER_OF_TASKS
                             Number of maximum number tasks running in parallel.


### PR DESCRIPTION
A simple fix of for the help message of the --status-server-uri command line option.