### PR TITLE
Patch to rectify the attribute decode issue.

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -836,9 +836,9 @@ class NetworkInterface:
                 f"cat /sys/class/net/{self.name}/device/devspec | "
                 f"awk -F/ '{{print $3}}'"
             )
-            interface_type = process.run(cmd, shell=True, ignore_status=True).decode(
-                "utf-8"
-            )
+            interface_type = process.system_output(
+                cmd, shell=True, ignore_status=True
+            ).decode("utf-8")
             cmd = f"echo {interface_type} | sed 's/@/-/' "
             interface_type = process.system_output(
                 cmd, shell=True, ignore_status=True


### PR DESCRIPTION

This patch includes the fix for "ERROR: 'CmdResult' object has no attribute 'decode'".

Run logs
-------------

without patch 
--------------------

ltcden4-lp12:~/avocado-fvt-wrapper/tests/avocado-misc-tests/io/net # avocado run irqbalance.py -m irqbalance.py.data/irqbalance_network.yaml --max-parallel-tasks=1
JOB ID     : 289cf143a056fa246812f6e8ed20db603beedd65
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-12-30T06.19-289cf14/job.log
 (1/4) irqbalance.py:irq_balance.test_irq_balance;run-41ce: STARTED
 (1/4) irqbalance.py:irq_balance.test_irq_balance;run-41ce: ERROR: 'CmdResult' object has no attribute 'decode' (4.32 s)
 (2/4) irqbalance.py:irq_balance.test_cpu_serial_off_on;run-41ce: STARTED
 (2/4) irqbalance.py:irq_balance.test_cpu_serial_off_on;run-41ce: ERROR: 'CmdResult' object has no attribute 'decode' (4.17 s)
 (3/4) irqbalance.py:irq_balance.test_smt_toggle;run-41ce: STARTED
 (3/4) irqbalance.py:irq_balance.test_smt_toggle;run-41ce: ERROR: 'CmdResult' object has no attribute 'decode' (4.22 s)
 (4/4) irqbalance.py:irq_balance.test_taskset;run-41ce: STARTED
 (4/4) irqbalance.py:irq_balance.test_taskset;run-41ce: ERROR: 'CmdResult' object has no attribute 'decode' (4.22 s)
RESULTS    : PASS 0 | ERROR 4 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-12-30T06.19-289cf14/results.html
JOB TIME   : 51.34 s



with latest patch
--------------------
ltcden4-lp12:~/avocado-fvt-wrapper/tests/avocado-misc-tests/io/net # avocado run irqbalance.py -m irqbalance.py.data/irqbalance_network.yaml --max-parallel-tasks=1
JOB ID     : cb3805fb124b50c0dc823c2f12b580b0977f6fa6
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-12-30T06.22-cb3805f/job.log
 (1/4) irqbalance.py:irq_balance.test_irq_balance;run-41ce: STARTED
 (1/4) irqbalance.py:irq_balance.test_irq_balance;run-41ce: PASS (910.94 s)
 (2/4) irqbalance.py:irq_balance.test_cpu_serial_off_on;run-41ce: STARTED
 (2/4) irqbalance.py:irq_balance.test_cpu_serial_off_on;run-41ce: PASS (8.20 s)
 (3/4) irqbalance.py:irq_balance.test_smt_toggle;run-41ce: STARTED
 (3/4) irqbalance.py:irq_balance.test_smt_toggle;run-41ce: PASS (9.05 s)
 (4/4) irqbalance.py:irq_balance.test_taskset;run-41ce: STARTED
 (4/4) irqbalance.py:irq_balance.test_taskset;run-41ce: PASS (5.00 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-12-30T06.22-cb3805f/results.html
JOB TIME   : 975.05 s