### PR TITLE
Remove special egg handling for 103.0

### DIFF
--- a/contrib/scripts/avocado-fetch-eggs.py
+++ b/contrib/scripts/avocado-fetch-eggs.py
@@ -49,9 +49,13 @@ def main():
     configure_logging_settings()
     for version in ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]:
         url = get_egg_url(python_version=version)
-        asset = Asset(url, cache_dirs=CACHE_DIRS)
-        asset.fetch()
-    return True
+        try:
+            asset = Asset(url, cache_dirs=CACHE_DIRS)
+            asset.fetch()
+        except OSError:
+            LOG.error("Failed to fetch Avocado egg for Python version %s", version)
+            return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/contrib/scripts/avocado-fetch-eggs.py
+++ b/contrib/scripts/avocado-fetch-eggs.py
@@ -47,21 +47,10 @@ def get_egg_url(avocado_version=None, python_version=None):
 
 def main():
     configure_logging_settings()
-    for version in ["3.7", "3.8", "3.9", "3.10", "3.11"]:
+    for version in ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]:
         url = get_egg_url(python_version=version)
         asset = Asset(url, cache_dirs=CACHE_DIRS)
         asset.fetch()
-    # for version 3.12, it'll only be available after 103.0 is released
-    # TODO: remove after 103.0 is released
-    url = get_egg_url(python_version="3.12")
-    try:
-        asset = Asset(url, cache_dirs=CACHE_DIRS)
-        asset.fetch()
-    except OSError:
-        LOG.warning(
-            "Failed to fetch eggs for Python 3.12: these will only "
-            "be available after the release of Avocado 103.0"
-        )
     return True
 
 

--- a/contrib/scripts/avocado-fetch-eggs.py
+++ b/contrib/scripts/avocado-fetch-eggs.py
@@ -34,7 +34,14 @@ def configure_logging_settings():
     logger_handler.setFormatter(formatter)
 
 
-def get_egg_url(avocado_version=None, python_version=None):
+def get_setuptools_egg_url(python_version=None):
+    if python_version is None:
+        version = sys.version_info
+        python_version = f"{version.major}.{version.minor}"
+    return f"https://github.com/avocado-framework/setuptools/releases/download/v59.2.0/setuptools-59.2.0-py{python_version}.egg"
+
+
+def get_avocado_egg_url(avocado_version=None, python_version=None):
     if avocado_version is None:
         avocado_version = VERSION
     if python_version is None:
@@ -48,12 +55,19 @@ def get_egg_url(avocado_version=None, python_version=None):
 def main():
     configure_logging_settings()
     for version in ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]:
-        url = get_egg_url(python_version=version)
+        url = get_avocado_egg_url(python_version=version)
         try:
             asset = Asset(url, cache_dirs=CACHE_DIRS)
             asset.fetch()
         except OSError:
             LOG.error("Failed to fetch Avocado egg for Python version %s", version)
+            return 1
+        url = get_setuptools_egg_url(python_version=version)
+        try:
+            asset = Asset(url, cache_dirs=CACHE_DIRS)
+            asset.fetch()
+        except OSError:
+            LOG.error("Failed to fetch setuptools egg for Python version %s", version)
             return 1
     return 0
 


### PR DESCRIPTION
The ``contrib/scripts/avocado-fetch-eggs.py`` file, as can be seen in PR https://github.com/avocado-framework/avocado/pull/5789, has a TODO to have the special handling after 103.0 is released.

This is a removal of that special handling, and a couple of extra improvements.