### PR TITLE
Insecure temporary file removal

### DIFF
--- a/optional_plugins/html/tests/html_result.py
+++ b/optional_plugins/html/tests/html_result.py
@@ -82,8 +82,8 @@ class HtmlResultTest(unittest.TestCase):
 
     def test_output_compatible_setup_2(self):
         prefix = "avocado_" + __name__
-        tmpfile = tempfile.mktemp(prefix=prefix, dir=self.tmpdir.name)
-        tmpfile2 = tempfile.mktemp(prefix=prefix, dir=self.tmpdir.name)
+        tmpfile = os.path.join(self.tmpdir.name, f"{prefix}_result.xml")
+        tmpfile2 = os.path.join(self.tmpdir.name, f"{prefix}_result.json")
         tmpdir = tempfile.mkdtemp(prefix=prefix, dir=self.tmpdir.name)
         tmpfile3 = os.path.join(tmpdir, "result.html")
         cmd_line = (

--- a/selftests/functional/output.py
+++ b/selftests/functional/output.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 import shlex
-import tempfile
 import unittest
 from xml.dom import minidom
 
@@ -362,7 +361,7 @@ class OutputPluginTest(TestCaseTmpDir):
         )
 
     def test_output_compatible_setup(self):
-        tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
+        tmpfile = os.path.join(self.tmpdir.name, f"avocado_{__name__}.xml")
         cmd_line = (
             f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
             f"--disable-sysinfo --journal --xunit {tmpfile} "
@@ -380,7 +379,7 @@ class OutputPluginTest(TestCaseTmpDir):
         minidom.parse(tmpfile)
 
     def test_output_compatible_setup_2(self):
-        tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
+        tmpfile = os.path.join(self.tmpdir.name, f"avocado_{__name__}.json")
         cmd_line = (
             f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
             f"--disable-sysinfo --xunit - --json {tmpfile} "
@@ -401,8 +400,8 @@ class OutputPluginTest(TestCaseTmpDir):
         minidom.parseString(result.stdout_text)
 
     def test_output_compatible_setup_nooutput(self):
-        tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
-        tmpfile2 = tempfile.mktemp(dir=self.tmpdir.name)
+        tmpfile = os.path.join(self.tmpdir.name, f"avocado_{__name__}.xml")
+        tmpfile2 = os.path.join(self.tmpdir.name, f"avocado_{__name__}.json")
         # Verify --show=none can be supplied as app argument
         cmd_line = (
             f"{AVOCADO} --show=none run "
@@ -490,7 +489,7 @@ class OutputPluginTest(TestCaseTmpDir):
         self.assertEqual(result.stdout, b"")
 
     def test_verify_whiteboard_save(self):
-        tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
+        tmpfile = os.path.join(self.tmpdir.name, f"avocado_{__name__}.json")
         config = os.path.join(self.tmpdir.name, "conf.ini")
         content = (
             "[datadir.paths]\nlogs_dir = %s"  # pylint: disable=C0209
@@ -527,7 +526,7 @@ class OutputPluginTest(TestCaseTmpDir):
                 )
 
     def test_gendata(self):
-        tmpfile = tempfile.mktemp(dir=self.tmpdir.name)
+        tmpfile = os.path.join(self.tmpdir.name, f"avocado_{__name__}.json")
         cmd_line = (
             f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
             f"--disable-sysinfo "
@@ -555,7 +554,9 @@ class OutputPluginTest(TestCaseTmpDir):
             )
 
     def test_redirect_output(self):
-        redirected_output_path = tempfile.mktemp(dir=self.tmpdir.name)
+        redirected_output_path = os.path.join(
+            self.tmpdir.name, f"avocado_{__name__}_output"
+        )
         cmd_line = (
             f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
             f"--disable-sysinfo examples/tests/passtest.py > {redirected_output_path}"


### PR DESCRIPTION
The tmpfile.mktemp function for creating tmp files has been deprecated since 2.3 and has security issues. Let's remove it and use tmpdir instead.

Reference:
https://github.com/avocado-framework/avocado/security/code-scanning/278