### PR TITLE
CI: fix use of different OS images for egg and version tasks

### DIFF
--- a/.github/actions/egg/action.yml
+++ b/.github/actions/egg/action.yml
@@ -1,0 +1,14 @@
+name: Egg
+description: Test running avocado from eggs
+runs:
+  using: composite
+  steps:
+    - name: Test running avocado from eggs
+      shell: sh
+      run: |
+       python3 setup.py bdist_egg
+       mv dist/avocado_framework-*egg /tmp
+       python3 setup.py clean --all
+       python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
+       cd /tmp
+       python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -1,0 +1,10 @@
+name: Version
+description: Installs and run avocado --version
+runs:
+  using: composite
+  steps:
+    - name: Install and run avocado --version
+      shell: sh
+      run: |
+        python3 setup.py develop --user
+        python3 -m avocado --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,68 +284,209 @@ jobs:
           retention-days: 1
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
+  version_task_fedora_37:
 
-  version_task:
-
-    name: Version task (${{ matrix.container }})
+    name: Version task fedora:37
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        container: ["fedora:37",
-                    "fedora:38",
-                    "registry.access.redhat.com/ubi8/ubi:8.8",
-                    "registry.access.redhat.com/ubi9/ubi:9.2",
-                    "debian:10.10",
-                    "debian:11.0",
-                    "ubuntu:21.10",
-                    "ubuntu:20.04"]
+    container:
+      image: fedora:37
+    steps:
+      - name: Install Python dependencies
+        run: dnf -y install python3 python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/version
+
+  version_task_fedora_38:
+
+    name: Version task fedora:38
+    runs-on: ubuntu-20.04
+    container:
+      image: fedora:38
+    steps:
+      - name: Install Python dependencies
+        run: dnf -y install python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/version
+
+  version_task_ubi_8:
+
+    name: Version task ubi:8.8
+    runs-on: ubuntu-20.04
+    container:
+      image: registry.access.redhat.com/ubi8/ubi:8.8
+    steps:
+      - name: Install Python dependencies
+        run: dnf -y install python3.11 python3.11-setuptools python3.11-setuptools-rust
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/version
+
+  version_task_ubi_9:
+
+    name: Version task ubi:9.2
+    runs-on: ubuntu-20.04
+    container:
+      image: registry.access.redhat.com/ubi9/ubi:9.2
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Install and run avocado --version
-        run: |
-         if ! command -v dnf &> /dev/null
-         then
-           python3 -c 'import setuptools' || dnf -y install python3 python3-setuptools
-         else
-           python3 --version || (apt update && apt -y install python3 python3-setuptools ca-certificates)
-         fi
-         python3 setup.py develop --user
-         python3 -m avocado --version
+      - uses: ./.github/actions/version
 
+  version_task_debian_12:
 
-  egg_task:
-
-    name: Egg task (${{ matrix.container }})
+    name: Version task debian:12.4
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        container: ["fedora:37",
-                    "fedora:38",
-                    "registry.access.redhat.com/ubi8/ubi:8.8",
-                    "registry.access.redhat.com/ubi9/ubi:9.2",
-                    "debian:10.10",
-                    "debian:11.0",
-                    "ubuntu:21.10",
-                    "ubuntu:20.04"]
+    container:
+      image: debian:12.4
+    steps:
+      - name: Install Python dependencies
+        run: apt update && apt -y install python3 python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/version
+
+  version_task_debian_11:
+
+    name: Version task debian:11.0
+    runs-on: ubuntu-20.04
+    container:
+      image: debian:11.0
+    steps:
+      - name: Install Python dependencies
+        run: apt update && apt -y install python3 python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/version
+
+  version_task_ubuntu_22:
+
+    name: Version task ubuntu:22.04
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:22.04
+    steps:
+      - name: Install Python dependencies
+        run: apt update && apt -y install python3 python3-setuptools ca-certificates
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/version
+
+  version_task_ubuntu_20:
+
+    name: Version task ubuntu:20.04
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:20.04
+    steps:
+      - name: Install Python dependencies
+        run: apt update && apt -y install python3 python3-setuptools ca-certificates
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/version
+
+  egg_task_fedora_37:
+
+    name: Egg task fedora:37
+    runs-on: ubuntu-20.04
+    container:
+      image: fedora:37
+    steps:
+      - name: Install Python dependencies
+        run: dnf -y install python3 python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/egg
+
+  egg_task_fedora_38:
+
+    name: Egg task fedora:38
+    runs-on: ubuntu-20.04
+    container:
+      image: fedora:38
+    steps:
+      - name: Install Python dependencies
+        run: dnf -y install python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/egg
+
+  egg_task_ubi_8:
+
+    name: Egg task ubi:8.8
+    runs-on: ubuntu-20.04
+    container:
+      image: registry.access.redhat.com/ubi8/ubi:8.8
+    steps:
+      - name: Install Python dependencies
+        run: dnf -y install python38 python38-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/egg
+
+  egg_task_ubi_9:
+
+    name: Egg task ubi:9.2
+    runs-on: ubuntu-20.04
+    container:
+      image: registry.access.redhat.com/ubi9/ubi:9.2
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Test running avocado from eggs
-        run: |
-         if ! command -v dnf &> /dev/null
-         then
-           python3 -c 'import setuptools' || dnf -y install python3 python3-setuptools
-         else
-           python3 --version || (apt update && apt -y install python3 python3-setuptools)
-         fi
-         python3 setup.py bdist_egg
-         mv dist/avocado_framework-*egg /tmp
-         python3 setup.py clean --all
-         python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
-         cd /tmp
-         python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
+      - uses: ./.github/actions/egg
 
+  egg_task_debian_12:
+
+    name: Egg task debian:12.4
+    runs-on: ubuntu-20.04
+    container:
+      image: debian:12.4
+    steps:
+      - name: Install Python dependencies
+        run: apt update && apt -y install python3 python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/egg
+
+  egg_task_debian_11:
+
+    name: Egg task debian:11.0
+    runs-on: ubuntu-20.04
+    container:
+      image: debian:11.0
+    steps:
+      - name: Install Python dependencies
+        run: apt update && apt -y install python3 python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/egg
+
+  egg_task_ubuntu_22:
+
+    name: Egg task ubuntu:22.04
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:22.04
+    steps:
+      - name: Install Python dependencies
+        run: apt update && apt -y install python3 python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/egg
+
+  egg_task_ubuntu_20:
+
+    name: Egg task ubuntu:20.04
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:20.04
+    steps:
+      - name: Install Python dependencies
+        run: apt update && apt -y install python3 python3-setuptools
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/egg
 
   podman_egg_task:
 


### PR DESCRIPTION
The "version" and "egg" tasks are not effectively setting the container image that should be used.  This effectively means that instead of covering a number of different platforms, it's re-running the same checks on the base OS given in the "runs-on" setting.

These container images for the different OSs may use either DNF or APT as a package manager, and may or may not have Python or setuptools. In theory:

 * it should be a matter of setting the "container" and then "image" directives on the GitHub actions YAML
 * have a common script that conditionally installs the needed packages

In practice, GH Actions is terminating the execution of the script given in "run" when it has conditionals in varied ways:

 * fedora:37 Run if python3 -c "import setuptools"; then Traceback (most recent call last): File "<string>", line 1, in <module> ModuleNotFoundError: No module named 'setuptools' 4.18.0 Installed: dnf-0:4.18.0-2.fc37.noarch at Sun Nov 26 05:48:57 2023
     Built    : Fedora Project at Thu Oct 19 09:04:15 2023

     Installed: rpm-0:4.18.2-1.fc37.x86_64 at Sun Nov 26 05:48:56 2023
     Built    : Fedora Project at Mon Nov 13 15:50:44 2023
   Error: The operation was canceled.

 * ubuntu:20.04 'build/scripts-3.8' does not exist -- can't clean it Error: The operation was canceled.

I've tried to reproduce the behavior on the same images, using the same shells, and the same command to execute the shells (incuding "bash ... -e -o pipefail", etc), but couldn't.

In the end, this change expands the tasks, each with its own Operating System.  While doing that it breaks the installation of the Python dependencies into their own step.

Because ubuntu 21.10 is EOLed, it was updated to 22.04.