### PR TITLE
AvocadoConfigParser

### DIFF
--- a/avocado/core/jobdata.py
+++ b/avocado/core/jobdata.py
@@ -22,13 +22,11 @@ import os
 
 from avocado.core.nrunner.config import ConfigDecoder, ConfigEncoder
 from avocado.core.output import LOG_JOB, LOG_UI
-from avocado.core.settings import settings
 from avocado.core.varianter import VARIANTS_FILENAME
 from avocado.utils.astring import string_to_safe_path
 from avocado.utils.path import init_dir
 
 JOB_DATA_DIR = "jobdata"
-CONFIG_FILENAME = "config"
 TEST_REFERENCES_FILENAME = "test_references"
 PWD_FILENAME = "pwd"
 JOB_CONFIG_FILENAME = "args.json"
@@ -54,8 +52,8 @@ def record(job, cmdline=None):
     """
     Records all required job information.
     """
+
     base_dir = init_dir(job.logdir, JOB_DATA_DIR)
-    path_cfg = os.path.join(base_dir, CONFIG_FILENAME)
     path_references = os.path.join(base_dir, TEST_REFERENCES_FILENAME)
     path_pwd = os.path.join(base_dir, PWD_FILENAME)
     path_job_config = os.path.join(base_dir, JOB_CONFIG_FILENAME)
@@ -67,11 +65,6 @@ def record(job, cmdline=None):
             references_file.write(f"{references}")
             references_file.flush()
             os.fsync(references_file)
-
-    with open(path_cfg, "w", encoding="utf-8") as config_file:
-        settings.config.write(config_file)
-        config_file.flush()
-        os.fsync(config_file)
 
     for idx, suite in enumerate(job.test_suites, 1):
         if suite.name:
@@ -142,16 +135,6 @@ def retrieve_job_config(resultsdir):
     if recorded_job_config:
         with open(recorded_job_config, "r", encoding="utf-8") as job_config_file:
             return json.load(job_config_file, cls=ConfigDecoder)
-
-
-def retrieve_config(resultsdir):
-    """
-    Retrieves the job settings from the results directory.
-    """
-    recorded_config = _retrieve(resultsdir, CONFIG_FILENAME)
-    if recorded_config is None:
-        return None
-    return recorded_config
 
 
 def retrieve_cmdline(resultsdir):

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -29,7 +29,7 @@ TEST_SIZE = {
     "nrunner-requirement": 16,
     "unit": 667,
     "jobs": 11,
-    "functional-parallel": 298,
+    "functional-parallel": 299,
     "functional-serial": 4,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,

--- a/selftests/functional/replay.py
+++ b/selftests/functional/replay.py
@@ -64,7 +64,6 @@ class ReplayTests(TestCaseTmpDir):
         """
         file_list = [
             "variants-1.json",
-            "config",
             "test_references",
             "pwd",
             "args.json",

--- a/selftests/functional/settings.py
+++ b/selftests/functional/settings.py
@@ -1,0 +1,28 @@
+import os
+
+from avocado import Test
+from avocado.utils import process
+from selftests.utils import AVOCADO
+
+WRONG_CONFIG = """
+[job.output.testlogs]
+statuses = ["CANCEL", "SKIP", "FAIL"]
+	foo moo
+"""
+
+
+class SettingsTest(Test):
+    def test_wrong_config(self):
+        config_path = os.path.join(self.workdir, "config")
+        with open(config_path, mode="w", encoding="utf-8") as config_file:
+            config_file.write(WRONG_CONFIG)
+        result = process.run(
+            f"{AVOCADO} --config={config_path} run "
+            f"--job-results-dir {self.workdir} "
+            f"--disable-sysinfo -- examples/tests/passtest.py",
+            ignore_status=True,
+        )
+        self.assertIn(
+            f'Avocado crashed unexpectedly: Syntax error in config file {config_path}, please check the value ["CANCEL", "SKIP", "FAIL"]\nfoo moo \n',
+            result.stderr_text,
+        )


### PR DESCRIPTION
This commit introduces `AvocadoConfigParser` which uses `configparser.ConfigParser` to parse INI files with avocado configuration. During the parsing process, it preserves the config files path, which is used for creating error messages when the files are badly formatted. And it removes the `config` file from jobdata directory since it is not used anymore.

Before this PR:
```
...
  File "<unknown>", line 2
    foo moo
    ^^^
SyntaxError: invalid syntax

```
After this PR:
```
...
    raise SyntaxError(
SyntaxError: Syntax error in config file ../testing/config, please check the value ["CANCEL", "SKIP", "FAIL"]
foo moo
```
Reference: #5857 #5643 