### PR TITLE
Release next.rst

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -121,3 +121,4 @@ Regular Releases
    0_27_0
    0_26_0
    0_25_0
+   next

--- a/docs/source/releases/next.rst
+++ b/docs/source/releases/next.rst
@@ -1,0 +1,38 @@
+========================
+104.0 - TBD
+========================
+
+The Avocado team is proud to present another release: Avocado 104.0,
+AKA "TBD", is now available!
+
+Release documentation: `Avocado 104.0
+<http://avocado-framework.readthedocs.io/en/104.0/>`_
+
+Users/Test Writers
+==================
+
+* 
+
+Utility Modules
+===============
+
+* 
+
+Bug Fixes
+=========
+
+* 
+
+Additional information
+======================
+
+For more information, please check out the complete
+`Avocado changelog
+<https://github.com/avocado-framework/avocado/compare/103.0...104.0>`_.
+
+For more information on the actual issues addressed, please check out
+the `milestone information
+<https://github.com/avocado-framework/avocado/milestone/30>`_.
+
+For more information on the release codename, please refer to `IMDb
+<TBD>`_.

--- a/docs/source/releases/next.rst
+++ b/docs/source/releases/next.rst
@@ -11,7 +11,14 @@ Release documentation: `Avocado 104.0
 Users/Test Writers
 ==================
 
-* 
+* The result.json test attributes related to time has been renamed in version 104.0
+  to correspond to `job.result.tests` in Job API. The Difference between new and old::
+
+    time_start = start
+    actual_time_start = actual_start
+    time_end = end
+    actual_time_end = actual_end
+    time_elapsed = time
 
 Utility Modules
 ===============


### PR DESCRIPTION
This PR adds a new `next.rst` file to our release docs. This file can be
used to write release notes during the sprint based on main changes.

Signed-off-by: Jan Richter <jarichte@redhat.com>