### PR TITLE
Remove simpletest.* settings

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -48,60 +48,6 @@ def register_core_options():
     )
 
     help_msg = (
-        "Python regular expression that will make the test status WARN when matched."
-    )
-    stgs.register_option(
-        section="simpletests.status",
-        key="warn_regex",
-        default="^WARN$",
-        help_msg=help_msg,
-    )
-
-    help_msg = (
-        "Location to search the regular expression on. "
-        "Accepted values: all, stdout, stderr."
-    )
-    stgs.register_option(
-        section="simpletests.status",
-        key="warn_location",
-        default="all",
-        help_msg=help_msg,
-    )
-
-    help_msg = (
-        "Python regular expression that will make the test status SKIP when matched."
-    )
-    stgs.register_option(
-        section="simpletests.status",
-        key="skip_regex",
-        default="^SKIP$",
-        help_msg=help_msg,
-    )
-
-    help_msg = (
-        "Location to search the regular expression on. "
-        "Accepted values: all, stdout, stderr."
-    )
-    stgs.register_option(
-        section="simpletests.status",
-        key="skip_location",
-        default="all",
-        help_msg=help_msg,
-    )
-
-    help_msg = (
-        "Fields to include in the presentation of executable test "
-        "failures.  Accepted values: status, stdout, stderr."
-    )
-    stgs.register_option(
-        section="simpletests.status",
-        key="failure_fields",
-        key_type=list,
-        default=["status", "stdout", "stderr"],
-        help_msg=help_msg,
-    )
-
-    help_msg = (
         "The amount of time to wait between asking nicely for a task "
         "to be terminated (say sending a signal) and proceeding with "
         "a more forceful termination. This may allow runners within "

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -29,7 +29,7 @@ TEST_SIZE = {
     "nrunner-requirement": 16,
     "unit": 667,
     "jobs": 11,
-    "functional-parallel": 302,
+    "functional-parallel": 301,
     "functional-serial": 4,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -13,7 +13,6 @@ from avocado.utils import path as utils_path
 from avocado.utils import process, script
 from selftests.utils import (
     AVOCADO,
-    BASEDIR,
     TestCaseTmpDir,
     python_module_available,
     skipOnLevelsInferiorThan,
@@ -1121,36 +1120,6 @@ class RunnerReferenceFromConfig(TestCaseTmpDir):
             expected_rc,
             f"Avocado did not return rc {expected_rc}:\n{result}",
         )
-
-    def tearDown(self):
-        super().tearDown()
-        self.config_file.remove()
-
-
-class RunnerExecTestFailureFields(TestCaseTmpDir):
-    def setUp(self):
-        super().setUp()
-        self.config_file = script.TemporaryScript(
-            "avocado.conf",
-            "[simpletests.status]\nfailure_fields = ['stdout', 'stderr']\n",
-        )
-        self.config_file.save()
-
-    def test_exec_test_failure_fields(self):
-        fail_test = os.path.join(BASEDIR, "examples", "tests", "failtest.sh")
-        cmd_line = (
-            f"{AVOCADO} --config {self.config_file.path} run "
-            f"--job-results-dir {self.tmpdir.name} "
-            f"--disable-sysinfo -- {fail_test}"
-        )
-        result = process.run(cmd_line, ignore_status=True)
-        expected_rc = exit_codes.AVOCADO_TESTS_FAIL
-        self.assertEqual(
-            result.exit_status,
-            expected_rc,
-            f"Avocado did not return rc {expected_rc}:\n{result}",
-        )
-        self.assertNotIn("Exited with status: '1'", result.stdout_text)
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
The "SIMPLE" test is a legacy runner terminology, and while most of its features were migrated to "exec-test", theses simpletest.* settings were not.

Let's drop the settings and a test which currently accomplishes nothing.