### PR TITLE
Podman Spawner:  tag created images with meaningful names

### DIFF
--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -65,6 +65,18 @@ class PodmanSpawnerInit(Init):
             section=section, key="avocado_spawner_egg", help_msg=help_msg, default=None
         )
 
+        help_msg = (
+            "Prefix to use when tagging images that are created by the "
+            "Podman spawner."
+        )
+
+        settings.register_option(
+            section=section,
+            key="image_tag_prefix",
+            help_msg=help_msg,
+            default="avocado_generated",
+        )
+
 
 class PodmanCLI(CLI):
 
@@ -411,6 +423,22 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
             return False
         return True
 
+    async def _create_and_tag_image(self, runtime_task):
+        _, stdout, _ = await self.podman.execute(
+            "commit", "-q", runtime_task.spawner_handle
+        )
+        image_id = stdout.decode().strip()
+        tag_prefix = self.config.get("spawner.podman.image_tag_prefix")
+        base_image = self.config.get("spawner.podman.image")
+        kind = runtime_task.task.runnable.kind
+        name = runtime_task.task.runnable.kwargs.get("name")
+        tag = f"{tag_prefix}_{base_image}_{kind}_{name}".replace(":", "_")
+        try:
+            _, _, _ = await self.podman.execute("tag", image_id, tag)
+        except PodmanException as ex:
+            LOG.warning("Could not tag image %s with %s: %s", image_id, tag, ex)
+        return image_id
+
     async def update_requirement_cache(
         self, runtime_task, result
     ):  # pylint: disable=W0221
@@ -418,10 +446,7 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
         if result in STATUSES_NOT_OK:
             cache.delete_environment(self.environment, environment_id)
             return
-        _, stdout, _ = await self.podman.execute(
-            "commit", "-q", runtime_task.spawner_handle
-        )
-        image_id = stdout.decode().strip()
+        image_id = await self._create_and_tag_image(runtime_task)
         cache.update_environment(self.environment, environment_id, image_id)
         cache.update_requirement_status(
             self.environment,

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -421,27 +421,27 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
         _, stdout, _ = await self.podman.execute(
             "commit", "-q", runtime_task.spawner_handle
         )
-        container_id = stdout.decode().strip()
-        cache.update_environment(self.environment, environment_id, container_id)
+        image_id = stdout.decode().strip()
+        cache.update_environment(self.environment, environment_id, image_id)
         cache.update_requirement_status(
             self.environment,
-            container_id,
+            image_id,
             runtime_task.task.runnable.kind,
             runtime_task.task.runnable.kwargs.get("name"),
             True,
         )
 
     async def save_requirement_in_cache(self, runtime_task):  # pylint: disable=W0221
-        container_id = str(uuid.uuid4())
+        image_id = str(uuid.uuid4())
         _, requirements = self._get_image_from_cache(runtime_task)
         if requirements:
             for requirement_type, requirement in requirements:
                 cache.set_requirement(
-                    self.environment, container_id, requirement_type, requirement
+                    self.environment, image_id, requirement_type, requirement
                 )
         cache.set_requirement(
             self.environment,
-            container_id,
+            image_id,
             runtime_task.task.runnable.kind,
             runtime_task.task.runnable.kwargs.get("name"),
             False,


### PR DESCRIPTION
The podman spawner will create images with requirements so that they can be reused by other tests.  But those images won't have any meaningful tags associated with them.  That is, users doing a "podman images" command will only see "<UNKNOWN>".

With this change, a somewhat meaningful description is attempted to be used as tag.