### PR TITLE
fix: Check if the port is available via socket.connect

### DIFF
--- a/avocado/utils/network/ports.py
+++ b/avocado/utils/network/ports.py
@@ -34,11 +34,11 @@ def is_port_available(
     :type address: str
     :param family: Default is socket.AF_INET. Accepted values are:
                    socket.AF_INET or socket.AF_INET6.
-    :type type: socket.AddressFamily.AF_*
+    :type family: socket.AddressFamily.AF_*
     :param protocol: Protocol type. Default is socket.SOCK_STREAM (TCP).
                      Accepted values are: socket.SOCK_STREAM or
                      socket.SOCK_DGRAM.
-    :type type: socket.AddressFamily.SOCK_*
+    :type protocol: socket.AddressFamily.SOCK_*
     """
     try:
         with socket.socket(family, protocol) as sock:

--- a/avocado/utils/network/ports.py
+++ b/avocado/utils/network/ports.py
@@ -42,14 +42,15 @@ def is_port_available(
     """
     try:
         with socket.socket(family, protocol) as sock:
-            sock.bind((address, port))
-    except PermissionError:
-        # Permission denied, can't be sure
-        return False
-    except OSError:
-        # Address already in use or cannot assign requested address
-        return False
-    return True
+            # Set a timeout for the connection attempt
+            sock.settimeout(1)
+            sock.connect((address, port))
+    except ConnectionRefusedError:
+        # If connection is refused, the port is free
+        return True
+    finally:
+        sock.close()
+    return False
 
 
 def is_port_free(port, address):

--- a/avocado/utils/network/ports.py
+++ b/avocado/utils/network/ports.py
@@ -22,11 +22,6 @@ import warnings
 
 from avocado.utils.data_structures import Borg
 
-#: Families taken into account in this class
-FAMILIES = (socket.AF_INET, socket.AF_INET6)
-#: Protocols taken into account in this class
-PROTOCOLS = (socket.SOCK_STREAM, socket.SOCK_DGRAM)
-
 
 def is_port_available(
     port, address, family=socket.AF_INET, protocol=socket.SOCK_STREAM


### PR DESCRIPTION
The current implementation doesn't accurately determine if the port is
in use. We need to attempt a connection to the port rather than just
attempting to bind to it.

Also, fix some typo in the doc string.

Signed-off-by: Yihuang Yu <yihyu@redhat.com>