### PR TITLE
Exception handling should be added when invoking external commands to handle possible command execution failures or exceptions.

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -121,8 +121,14 @@ def get_disks():
     :returns: a list of paths to the physical disks on the system
     :rtype: list of str
     """
-    json_result = process.run("lsblk --json --paths --inverse")
-    json_data = json.loads(json_result.stdout_text)
+    try:
+        json_result = process.run("lsblk --json --paths --inverse")
+    except process.CmdError as ce:
+        raise DiskError(f"Error occurred while executing lsblk command: {ce}")
+    try:
+        json_data = json.loads(json_result.stdout_text)
+    except json.JSONDecodeError as je:
+        raise DiskError(f"Error occurred while parsing JSON data: {je}")
     disks = []
     for device in json_data["blockdevices"]:
         disks.append(device["name"])


### PR DESCRIPTION
Modify avocado/utils/disk.py:change get_disks(),Exception handling should be added when invoking external commands to handle possible command execution failures or exceptions.