### PR TITLE
Release workflow updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build eggs
-        run: make -f Makefile.gh build-egg
+        run: |
+          if python -c 'import sys; exit(0) if sys.version_info.minor > 11 else exit(1)' ; then
+            pip install setuptools
+          fi
+          make -f Makefile.gh build-egg
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
       URL: "https://readthedocs.org/api/v3/projects/${{ github.event.inputs.rtd_project }}"
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        with:
+          app_id: ${{ secrets.MR_AVOCADO_ID }}
+          installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
+          private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}
       - name: install required packages
         run:  dnf -y install rpmdevtools git python3-pip make
       - uses: actions/checkout@v3
@@ -59,7 +66,7 @@ jobs:
       - name: Push changes to github
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.RELEASE_TOKEN }}
+          github_token: ${{ steps.generate_token.outputs.token }}
           branch: ${{ github.ref }}
       - name: Build wheel
         run: make -f Makefile.gh build-wheel check-wheel
@@ -104,7 +111,7 @@ jobs:
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.RELEASE_TOKEN }}
+          repo_token: ${{ steps.generate_token.outputs.token }}
           file: ${{ github.workspace }}/EGG_UPLOAD/avocado_framework*egg
           tag: ${{ github.event.inputs.version }}
           overwrite: true


### PR DESCRIPTION
This PR fixes some issues which were found during the 104 release.

1.  Adds Avocado bot token, to reduce the dependency of the release on @clebergnu's private tokens.
2.  Fixes the issues with setuptools on python 3.12.