### PR TITLE
Selftests: remove shebangs and main() calls

### DIFF
--- a/selftests/.data/unittests.py
+++ b/selftests/.data/unittests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import unittest
 
 
@@ -17,7 +16,3 @@ class Second(unittest.TestCase):
     @unittest.skip("This is suppose to be skipped")
     def test_skip(self):
         pass
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/selftests/.data/whiteboard.py
+++ b/selftests/.data/whiteboard.py
@@ -1,8 +1,6 @@
-#!/usr/bin/env python3
-
 import base64
 
-from avocado import Test, main
+from avocado import Test
 
 
 class WhiteBoard(Test):
@@ -35,7 +33,3 @@ class WhiteBoard(Test):
         for _ in range(0, iterations):
             result += data
         self.whiteboard = base64.encodebytes(result.encode()).decode("ascii")
-
-
-if __name__ == "__main__":
-    main()

--- a/selftests/functional/serial/requirements.py
+++ b/selftests/functional/serial/requirements.py
@@ -1,15 +1,12 @@
 import glob
 import os
-import unittest
 
 from avocado import Test, skipUnless
 from avocado.core import exit_codes
 from avocado.utils import process, script
 from selftests.utils import AVOCADO, TestCaseTmpDir
 
-SINGLE_SUCCESS_CHECK = '''#!/usr/bin/env python3
-
-from avocado import Test
+SINGLE_SUCCESS_CHECK = '''from avocado import Test
 
 
 class SuccessTest(Test):
@@ -20,9 +17,7 @@ class SuccessTest(Test):
         """
 '''
 
-SINGLE_FAIL_CHECK = '''#!/usr/bin/env python3
-
-from avocado import Test
+SINGLE_FAIL_CHECK = '''from avocado import Test
 
 
 class FailTest(Test):
@@ -33,9 +28,7 @@ class FailTest(Test):
         """
 '''
 
-MULTIPLE_SUCCESS = '''#!/usr/bin/env python3
-
-from avocado import Test
+MULTIPLE_SUCCESS = '''from avocado import Test
 from avocado.utils import process
 
 
@@ -65,9 +58,7 @@ class SuccessTest(Test):
         self.check_hello()
 '''
 
-MULTIPLE_FAIL = '''#!/usr/bin/env python3
-
-from avocado import Test
+MULTIPLE_FAIL = '''from avocado import Test
 from avocado.utils import process
 
 
@@ -221,7 +212,3 @@ class BasicTest(TestCaseTmpDir, Test):
                 "-foo-bar-",
                 result.stdout_text,
             )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/selftests/unit/utils/diff_validator.py
+++ b/selftests/unit/utils/diff_validator.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import tempfile
 import unittest
@@ -136,7 +134,3 @@ class ChangeValidationTest(unittest.TestCase):
             change_success,
             f"The change must not be valid:\n{diff_validator.create_diff_report(change_dict)}",
         )
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
The tests modified here are not supposed to be executables, and thus, should not shebangs and/or main() calls.