### PR TITLE
avocado/utils/cpu.py: add getting physical core from lscpu

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -634,8 +634,10 @@ def lscpu():
     output = process.run("lscpu")
     res = {}
     for line in output.stdout.decode("utf-8").split("\n"):
+        if "Physical cores/chip:" in line:
+            res["physical_cores"] = int(line.split(":")[1].strip())
         if "Core(s) per socket:" in line:
-            res["cores"] = int(line.split(":")[1].strip())
+            res["virtual_cores"] = int(line.split(":")[1].strip())
         if "Physical sockets:" in line:
             res["physical_sockets"] = int(line.split(":")[1].strip())
         if "Physical chips:" in line:


### PR DESCRIPTION
This patch adds support for getting number of physical cores present in a lpar from lscpu. 
This is useful for running perf 24x7 events which requires this value with domain parameter.