### PR TITLE
store_logging_stream_external test fix

### DIFF
--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -830,7 +830,9 @@ class RunnerOperationTest(TestCaseTmpDir):
             self.assertTrue(os.path.exists(file_path))
             with open(file_path, encoding="utf-8") as file:
                 stream = file.read()
-                self.assertIn("matplotlib __init__         L0337 DEBUG|", stream)
+                self.assertTrue(
+                    re.match(r"matplotlib __init__         L[0-9]* DEBUG|", stream)
+                )
 
         log_dir = os.path.join(self.tmpdir.name, "latest")
         test_log_dir = os.path.join(


### PR DESCRIPTION
The store_logging_stream_external test installs external package matplotlib and checks with the package properly logs to the avocado directories. Unfortunately, this test used hardcoded line number of matplotlib. Because of this, the test started failing when the line was changed. This commit fixes this test by using regex instead of hardcoded string. After this change, the test should be protected against external changes in matplotlib package.