### PR TITLE
Modify cpu.py - Improve robustness 

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -631,7 +631,7 @@ def lscpu():
     :physical chips:
     :chips: physical sockets * physical chips
     """
-    output = process.run("lscpu")
+    output = process.run("LANG=en_US.UTF-8;lscpu", shell=True)
     res = {}
     for line in output.stdout.decode("utf-8").split("\n"):
         if "Physical cores/chip:" in line:


### PR DESCRIPTION
When I use the cpu.lscpu() function, I find that I get an empty dict result, which is not as expected. When I checked, I found that the reason is that the default language of my system is not English, so I made this change.
I have tested that this language setting only works in the current pipeline and have found no other effects.
Hope to adopt.