### PR TITLE
cannot import name 'packaging' from 'pkg_resources' fix

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -23,7 +23,7 @@ import os
 import shutil
 import tempfile
 
-from pkg_resources import packaging
+from packaging.version import parse
 
 from avocado.utils import archive, asset, build, distro, process
 
@@ -207,6 +207,6 @@ def check_version(version):
     :type version: string
     :param version: version to be compared with current kernel version
     """
-    os_version = packaging.version.parse(os.uname()[2])
-    version = packaging.version.parse(version)
+    os_version = parse(os.uname()[2])
+    version = parse(version)
     assert os_version > version, "Old kernel"


### PR DESCRIPTION
In the setuptools>=70 the `pkg_resources` is deprecated and some of its features might cause troubles. These changes have impact on avocado CI with python3.12. This commit uses directly the `packaging` package instead of `pkg_resources` which solves the CI issues.

Reference:
https://setuptools.pypa.io/en/stable/pkg_resources.html#package-discovery-and-resource-access-using-pkg-resources

The CI failures can be seen [here](https://github.com/avocado-framework/avocado/actions/runs/9279694152/job/25532776722?pr=5941#step:10:2529).