### PR TITLE
Show origin of resolution in verbose list

### DIFF
--- a/avocado/plugins/list.py
+++ b/avocado/plugins/list.py
@@ -52,7 +52,7 @@ class List(CLICmd):
             type_label = TERM_SUPPORT.healthy_str(kind)
             if verbose:
                 colored_matrix.append(
-                    (type_label, item[1], _get_tags_as_string(item[2] or {}))
+                    (type_label, item[1], item[2], _get_tags_as_string(item[3] or {}))
                 )
             else:
                 colored_matrix.append((type_label, item[1]))
@@ -65,6 +65,7 @@ class List(CLICmd):
             header = (
                 TERM_SUPPORT.header_str("Type"),
                 TERM_SUPPORT.header_str("Test"),
+                TERM_SUPPORT.header_str("Resolver"),
                 TERM_SUPPORT.header_str("Tag(s)"),
             )
 
@@ -134,13 +135,15 @@ class List(CLICmd):
         """
         test_matrix = []
         verbose = suite.config.get("core.verbose")
-        for runnable in suite.tests:
-
-            if verbose:
-                tags = runnable.tags or {}
-                test_matrix.append((runnable.kind, runnable.uri, tags))
-            else:
-                test_matrix.append((runnable.kind, runnable.uri))
+        for resolution in suite.resolutions:
+            for runnable in resolution.resolutions:
+                if verbose:
+                    tags = runnable.tags or {}
+                    test_matrix.append(
+                        (runnable.kind, runnable.uri, resolution.origin, tags)
+                    )
+                else:
+                    test_matrix.append((runnable.kind, runnable.uri))
         return test_matrix
 
     @staticmethod

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -29,7 +29,7 @@ TEST_SIZE = {
     "nrunner-requirement": 28,
     "unit": 669,
     "jobs": 11,
-    "functional-parallel": 306,
+    "functional-parallel": 307,
     "functional-serial": 7,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,

--- a/selftests/functional/resolver.py
+++ b/selftests/functional/resolver.py
@@ -141,6 +141,22 @@ class ResolverFunctional(unittest.TestCase):
             result.stdout,
         )
 
+    def test_runnable_recipe_origin(self):
+        test_path = os.path.join(
+            BASEDIR,
+            "examples",
+            "nrunner",
+            "recipes",
+            "runnable",
+            "python_unittest.json",
+        )
+        cmd_line = f"{AVOCADO} -V list {test_path}"
+        result = process.run(cmd_line)
+        self.assertIn(
+            b"python-unittest selftests/unit/test.py:TestClassTestUnit.test_long_name runnable-recipe\n",
+            result.stdout,
+        )
+
 
 class ResolverFunctionalTmp(TestCaseTmpDir):
     def test_runnables_recipe(self):


### PR DESCRIPTION
When using some of the new resolvers such as "runnable-recipe", there's no longer a 1:1 relationship that the resolver and the "kind" match.

Certain types of resolution may look fine from the perspective of the original resolver, while it may be a broken or invalid reference to a more apt (or canonical) resolver for its set "kind".

By listing the original resolver, users may be able to more easily identify what the discrepancy is and where it's coming from.

Reference: https://github.com/avocado-framework/avocado/issues/5924