### PR TITLE
rfe: pkg_resources module replacement

### DIFF
--- a/.github/actions/egg/action.yml
+++ b/.github/actions/egg/action.yml
@@ -6,9 +6,9 @@ runs:
     - name: Test running avocado from eggs
       shell: sh
       run: |
-       python3 setup.py bdist_egg
-       mv dist/avocado_framework-*egg /tmp
-       python3 setup.py clean --all
-       python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
-       cd /tmp
-       python3 -c 'import sys; from pkg_resources import require; require("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true
+        python3 setup.py bdist_egg
+        mv dist/avocado_framework-*egg /tmp
+        python3 setup.py clean --all
+        python3 -c 'import sys; import glob; sys.path.insert(0, glob.glob("/tmp/avocado_framework-*.egg")[0]); from avocado.core.main import main; sys.exit(main())' run /bin/true
+        cd /tmp
+        python3 -c 'import sys; from importlib.metadata import distribution; distribution("avocado-framework"); from avocado.core.main import main; sys.exit(main())' run /bin/true

--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -13,9 +13,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 
-import os
-
-import pkg_resources
+from importlib import metadata
 
 from avocado.core.dispatcher import InitDispatcher
 from avocado.core.settings import settings as stgs
@@ -229,7 +227,9 @@ def initialize_plugin_infrastructure():
         section="plugins", key="disable", key_type=list, default=[], help_msg=help_msg
     )
 
-    kinds = list(pkg_resources.get_entry_map("avocado-framework").keys())
+    kinds = set(
+        ep.group for ep in metadata.distribution("avocado-framework").entry_points
+    )
     plugin_types = [kind[8:] for kind in kinds if kind.startswith("avocado.plugins.")]
     for plugin_type in plugin_types:
         help_msg = f'Execution order for "{plugin_type}" plugins'

--- a/avocado/core/extension_manager.py
+++ b/avocado/core/extension_manager.py
@@ -23,8 +23,7 @@ import copy
 import enum
 import logging
 import sys
-
-import pkg_resources
+from importlib import metadata
 
 from avocado.core.exceptions import JobBaseException
 from avocado.utils import stacktrace
@@ -90,7 +89,12 @@ class ExtensionManager:
             invoke_kwds = {}
 
         # load plugins
-        for ep in pkg_resources.iter_entry_points(self.namespace):
+        all_eps = metadata.entry_points()
+        if isinstance(all_eps, dict):
+            # Older stdlib importlib.metadata.entry_points returns {key: tuple}
+            all_eps = [ep for group in all_eps.values() for ep in group]
+        eps = {ep for ep in all_eps if ep.group == self.namespace}
+        for ep in eps:
             try:
                 plugin = ep.load()
                 obj = plugin(**invoke_kwds)

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -41,9 +41,9 @@ import configparser
 import glob
 import json
 import os
+import pathlib
 import re
-
-from pkg_resources import resource_exists, resource_filename
+from importlib import resources, util
 
 from avocado.core.settings_dispatcher import SettingsDispatcher
 
@@ -413,8 +413,15 @@ class Settings:
 
         config_file_name = "avocado.conf"
         config_pkg_base = os.path.join("etc", "avocado", config_file_name)
-        if resource_exists("avocado", config_pkg_base):
-            self._config_path_pkg = resource_filename("avocado", config_pkg_base)
+        if hasattr(resources, "files"):
+            config_file = resources.files("avocado").joinpath(config_pkg_base)
+        # Python <= 3.8 does not have importlib.resources.files
+        else:
+            config_file = (
+                pathlib.Path(util.find_spec("avocado").origin).parent / config_pkg_base
+            )
+        if config_file.exists():
+            self._config_path_pkg = str(config_file)
         else:
             self._config_path_pkg = None
         self._config_dir_system = os.path.join(cfg_dir, "avocado")

--- a/avocado/core/utils/eggenv.py
+++ b/avocado/core/utils/eggenv.py
@@ -1,6 +1,5 @@
 import os
-
-import pkg_resources
+from importlib import metadata
 
 
 def get_python_path_env_if_egg():
@@ -16,15 +15,15 @@ def get_python_path_env_if_egg():
     :returns: environment mapping with an extra PYTHONPATH for the egg or None
     :rtype: os.environ mapping or None
     """
-    dist = pkg_resources.get_distribution("avocado-framework")
-    if not (dist.location.endswith(".egg") and os.path.isfile(dist.location)):
+    dist_location = metadata.distribution("avocado-framework").locate_file("")
+    if not (str(dist_location).endswith(".egg") and dist_location.is_file()):
         return None
 
     python_path = os.environ.get("PYTHONPATH", "")
     python_path_entries = python_path.split(":")
-    if dist.location in python_path_entries:
+    if dist_location in python_path_entries:
         return None
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = f"{dist.location}:{python_path}"
+    env["PYTHONPATH"] = f"{dist_location}:{python_path}"
     return env

--- a/avocado/core/utils/path.py
+++ b/avocado/core/utils/path.py
@@ -1,13 +1,12 @@
 import os
-
-from pkg_resources import get_distribution
+from importlib.metadata import distribution
 
 
 def prepend_base_path(value):
     expanded = os.path.expanduser(value)
     if not expanded.startswith(("/", "~", ".")):
-        dist = get_distribution("avocado-framework")
-        return os.path.join(dist.location, "avocado", expanded)
+        dist = distribution("avocado-framework")
+        return os.path.join(str(dist.locate_file("")), "avocado", expanded)
     return expanded
 
 

--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -14,11 +14,11 @@
 
 __all__ = ["MAJOR", "MINOR", "VERSION"]
 
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    VERSION = pkg_resources.get_distribution("avocado-framework").version
-except pkg_resources.DistributionNotFound:
+    VERSION = version("avocado-framework")
+except PackageNotFoundError:
     VERSION = "unknown.unknown"
 
 MAJOR, MINOR = VERSION.split(".")

--- a/avocado/plugins/exec_path.py
+++ b/avocado/plugins/exec_path.py
@@ -15,8 +15,8 @@ Libexec PATHs modifier
 """
 
 import os
-
-from pkg_resources import resource_filename
+import pathlib
+from importlib import resources, util
 
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
@@ -40,4 +40,10 @@ class ExecPath(CLICmd):
         if os.path.isdir(system_wide):
             LOG_UI.debug(system_wide)
         else:
-            LOG_UI.debug(resource_filename("avocado", "libexec"))
+            if hasattr(resources, "files"):
+                LOG_UI.debug(resources.files("avocado").joinpath("libexec"))
+            # Python <= 3.8 does not have importlib.resources.files
+            else:
+                LOG_UI.debug(
+                    pathlib.Path(util.find_spec("avocado").origin).parent / "libexec"
+                )

--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -4,8 +4,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-
-import pkg_resources
+from importlib import metadata
 
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.nrunner.runner import BaseRunner
@@ -85,8 +84,8 @@ class ExecTestRunner(BaseRunner):
         """Return the Avocado package version, if installed"""
         version = "unknown.unknown"
         try:
-            version = pkg_resources.get_distribution("avocado-framework").version
-        except pkg_resources.DistributionNotFound:
+            version = metadata.version("avocado-framework")
+        except metadata.PackageNotFoundError:
             pass
         return version
 

--- a/optional_plugins/robot/tests/resolver.py
+++ b/optional_plugins/robot/tests/resolver.py
@@ -1,8 +1,8 @@
 import os
 import unittest
+from importlib import metadata
 
 import avocado_robot.robot
-import pkg_resources
 
 from avocado.core.resolver import ReferenceResolutionResult
 
@@ -17,9 +17,9 @@ def python_module_available(module_name):
     :rtype: bool
     """
     try:
-        pkg_resources.require(module_name)
+        metadata.distribution(module_name)
         return True
-    except pkg_resources.DistributionNotFound:
+    except metadata.PackageNotFoundError:
         return False
 
 

--- a/selftests/utils.py
+++ b/selftests/utils.py
@@ -3,8 +3,7 @@ import os
 import sys
 import tempfile
 import unittest
-
-import pkg_resources
+from importlib import metadata
 
 #: The base directory for the avocado source tree
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
@@ -24,9 +23,9 @@ def python_module_available(module_name):
     :rtype: bool
     """
     try:
-        pkg_resources.require(module_name)
+        metadata.distribution(module_name)
         return True
-    except pkg_resources.DistributionNotFound:
+    except metadata.PackageNotFoundError:
         return False
 
 


### PR DESCRIPTION
The use of pkg_resources is deprecated in favor of importlib_metadata, importlib_resources, so remove it from project.