### PR TITLE
Hardcoded nrunner removal in TestSuite

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -339,15 +339,9 @@ class TestSuite:
         if job_config:
             config.update(job_config)
         config.update(suite_config)
-        runner = config.get("run.suite_runner")
-        if runner == "nrunner":
-            suite = cls._from_config_with_resolver(config, name)
-            if suite.test_parameters or suite.variants:
-                suite.tests = suite._get_test_variants()
-        else:
-            raise TestSuiteError(
-                f'Suite creation for runner "{runner}" ' f"is not supported"
-            )
+        suite = cls._from_config_with_resolver(config, name)
+        if suite.test_parameters or suite.variants:
+            suite.tests = suite._get_test_variants()
 
         if not config.get("run.ignore_missing_references"):
             if not suite.tests:


### PR DESCRIPTION
This is a removal of left over of legacy code. When avocado supported `legacy` and `nrunner` runners we also distinguished between resolver resolution and test load. When the `legacy` runner has been removed, we don't have this issue anymore, because resolvers are only supported implementation of test resolution. Unfortunately, we kept validation of supported runners during the test reference resolution with hardcoded `nrunner`. This is wrong because `nrunner` is a `SuiteRunner` plugin, and it can be replaced by any installed `SuiteRunner`.

Reference: #5954