### PR TITLE
vmimage fedora provider update

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -212,7 +212,7 @@ class FedoraImageProviderBase(ImageProviderBase):
         else:
             cloud = "CloudImages"
 
-        if self.url_old_images and int(self.version) <= 36:
+        if self.url_old_images and int(self.version) <= 38:
             self.url_versions = self.url_old_images
 
         self.url_images = self.url_versions + "{version}/" + cloud + "/{arch}/images/"


### PR DESCRIPTION
Fedora has moved versions 37 and 38 to archive, we need to update our scripts to reflect this change.

Reference:
https://github.com/avocado-framework/avocado/actions/runs/9442784424/job/26005494505