### PR TITLE
Coverage CI after push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,39 +105,6 @@ jobs:
           retention-days: 1
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
-  code-coverage:
-
-    name: Code Coverage
-    runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        python-version: [3.11]
-    env:
-      CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
-
-    steps:
-      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
-      - name: Check out repository code
-        uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install
-        run: |
-         pip install -r requirements-dev.txt
-         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-         chmod +x ./cc-test-reporter
-      - name: Run pre script
-        run: ./cc-test-reporter before-build
-      - name: Run script
-        run: |
-         python setup.py develop --user
-         ./selftests/run_coverage
-      - name: Run post script
-        run: ./cc-test-reporter after-build --debug
-      - run: echo "🥑 This job's status is ${{ job.status }}."
 
 
 # macOS check on latest Python

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: "PR and Push checks"
 
 on:
   push:
@@ -69,3 +69,37 @@ jobs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
+
+  code-coverage:
+
+    name: Code Coverage
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: [3.11]
+    env:
+      CC_TEST_REPORTER_ID: "387887b88a76f31c2c376219fc749689ea5975c8fe7fcd9609f1dcc139e053a6"
+
+    steps:
+      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: |
+         pip install -r requirements-dev.txt
+         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+         chmod +x ./cc-test-reporter
+      - name: Run pre script
+        run: ./cc-test-reporter before-build
+      - name: Run script
+        run: |
+         python setup.py develop --user
+         ./selftests/run_coverage
+      - name: Run post script
+        run: ./cc-test-reporter after-build --debug
+      - run: echo "🥑 This job's status is ${{ job.status }}."


### PR DESCRIPTION
This commit adds the coverage CI job to a workflow which will be triggered on PR and after the push to the main branches `LTS` and `master`. This is needed because codeclimate needs coverage date from master to show the proper results.