### PR TITLE
Add the .strip() method to remove whitespace characters at both ends …

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -549,16 +549,16 @@ def get_vpd(dom_pci_address):
         if len(line) < 5:
             continue
         if "*YL" in line:
-            vpd_dic["slot"] = line[4:]
+            vpd_dic["slot"] = line[4:].strip()
         elif "*DS" in line:
-            vpd_dic["pci_id"] = line[4:]
+            vpd_dic["pci_id"] = line[4:].strip()
         elif "*FC" in line:
-            vpd_dic["feature_code"] = line[4:]
+            vpd_dic["feature_code"] = line[4:].strip()
         elif "*AX" in line:
             if not (dom_pci_address in line or vpd_dic["pci_id"].split()[0] in line):
-                dev_list.append(line[4:])
+                dev_list.append(line[4:].strip())
         elif "*CD" in line:
-            vpd_dic["pci_id"] = line[4:]
+            vpd_dic["pci_id"] = line[4:].strip()
     vpd_dic["devices"] = dev_list
     return vpd_dic
 

--- a/avocado/utils/podman.py
+++ b/avocado/utils/podman.py
@@ -143,11 +143,11 @@ class Podman(_Podman):
             )
         except PodmanException as ex:
             raise PodmanException(
-                f"Failed getting information about container:" f" {container_id}."
+                f"Failed getting information about container: {container_id}."
             ) from ex
         containers = json.loads(stdout.decode())
         for container in containers:
-            if container["Id"] == container_id:
+            if container.get["Id"] == container_id:
                 return container
         return {}
 


### PR DESCRIPTION

In the for loop, line. trip() was added to ensure that white space characters before and after each line processing are removed