### PR TITLE
PyPI upload update revert

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -90,3 +90,39 @@ jobs:
           name: job-results-deployment
           path: /github/home/avocado/job-results/
           retention-days: 1
+
+  package-build:
+    name: Build Package (wheel/tarball)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build tarballs and wheels
+      run: make -f Makefile.gh build-wheel check-wheel
+    - name: Save tarballs and wheels as artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: tarballs_and_wheels
+        path: ${{github.workspace}}/PYPI_UPLOAD/
+        retention-days: 1
+    - run: echo "🥑 This job's status is ${{ job.status }}."
+
+  publish-to-test-pypi:
+    name: Publish Avocado to TestPyPI
+    needs:
+    - package-build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/avocado-framework
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: tarballs_and_wheels
+        path: dist/
+    - name: Publish avocado to test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
       URL: "https://readthedocs.org/api/v3/projects/${{ github.event.inputs.rtd_project }}"
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        with:
+          app_id: ${{ secrets.MR_AVOCADO_ID }}
+          installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
+          private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}
       - name: install required packages
         run:  dnf -y install rpmdevtools git python3-pip make
       - uses: actions/checkout@v4
@@ -59,7 +66,7 @@ jobs:
       - name: Push changes to github
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.RELEASE_TOKEN }}
+          github_token: ${{ steps.generate_token.outputs.token }}
           branch: ${{ github.ref }}
       - name: Build wheel
         run: make -f Makefile.gh build-wheel check-wheel
@@ -121,7 +128,7 @@ jobs:
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.RELEASE_TOKEN }}
+          repo_token: ${{ steps.generate_token.outputs.token }}
           file: ${{ github.workspace }}/EGG_UPLOAD/avocado_framework*egg
           tag: ${{ github.event.inputs.version }}
           overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,12 +73,25 @@ jobs:
         run: |
           make -f Makefile.gh build-update-readthedocs
       - run: echo "In a few minutes the release documentation will be available in https://${{ github.event.inputs.rtd_project }}.readthedocs.io/en/${{ github.event.inputs.version }}/"
-      - name: Upload to pypi
-        continue-on-error: true
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWD }}
-        run: make -f Makefile.gh update-pypi
+
+  publish-to-pypi:
+    name: Publish Avocado to PyPI
+    needs:
+    - release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/avocado-framework
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: wheel
+        path: dist/
+    - name: Publish avocado to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
 
   build-and-publish-eggs:
     name: Build eggs and publish them


### PR DESCRIPTION
This will re-enable uploads to pypi with usage of Trusted Publisher Management. It adds again commits from #5926 and #5886 which has been reverted in d069e11a782455f40a376020ed8d9946d67f29d3, 74777fa6cb238f79efe68ffb595cb256073fa66d and 94d6a6183c56f47203f9a352cb3995d70f164293. The only issue with this CI changes was in configuration of pypi and MR. Avocado bot and those have been fixed.