### PR TITLE
 Method modification for obtaining container information

### DIFF
--- a/avocado/utils/podman.py
+++ b/avocado/utils/podman.py
@@ -143,7 +143,7 @@ class Podman(_Podman):
             )
         except PodmanException as ex:
             raise PodmanException(
-                f"Failed getting information about container:" f" {container_id}."
+                f"Failed getting information about container: {container_id}."
             ) from ex
         containers = json.loads(stdout.decode())
         for container in containers:

--- a/avocado/utils/podman.py
+++ b/avocado/utils/podman.py
@@ -147,7 +147,7 @@ class Podman(_Podman):
             ) from ex
         containers = json.loads(stdout.decode())
         for container in containers:
-            if container["Id"] == container_id:
+            if container.get("Id") == container_id:
                 return container
         return {}
 


### PR DESCRIPTION
1.Exception message improvement
Change the f "Failed getting information about container:" f "{container_id}." that concatenates two strings together to a single string to avoid unnecessary string concatenation 
2.Replace container ["Id"] with container. get ("Id") to avoid throwing KeyError when the "Id" key is missing in the dictionary