### PR TITLE
Runnable: only set configuration used by runners

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -222,7 +222,7 @@ class Runner(SuiteRunner):
         :type config: dict
         """
         for runnable in runnables:
-            runnable.config = Runnable.add_configuration_used(runnable.kind, config)
+            runnable.config = Runnable.filter_runnable_config(runnable.kind, config)
 
     def _determine_status_server(self, test_suite, config_key):
         if test_suite.config.get("run.status_server_auto"):

--- a/selftests/unit/nrunner.py
+++ b/selftests/unit/nrunner.py
@@ -102,14 +102,30 @@ class RunnableTest(unittest.TestCase):
     def test_runnable_command_args(self):
         runnable = Runnable("noop", "uri", "arg1", "arg2")
         actual_args = runnable.get_command_args()
-        exp_args = ["-k", "noop", "-u", "uri", "-a", "arg1", "-a", "arg2"]
+        exp_args = [
+            "-k",
+            "noop",
+            "-u",
+            "uri",
+            "-c",
+            '{"runner.identifier_format": "{uri}"}',
+            "-a",
+            "arg1",
+            "-a",
+            "arg2",
+        ]
         self.assertEqual(actual_args, exp_args)
 
     def test_get_dict(self):
         runnable = Runnable("noop", "_uri_", "arg1", "arg2")
         self.assertEqual(
             runnable.get_dict(),
-            {"kind": "noop", "uri": "_uri_", "args": ("arg1", "arg2"), "config": {}},
+            {
+                "kind": "noop",
+                "uri": "_uri_",
+                "args": ("arg1", "arg2"),
+                "config": {"runner.identifier_format": "{uri}"},
+            },
         )
 
     def test_get_json(self):
@@ -117,7 +133,7 @@ class RunnableTest(unittest.TestCase):
         expected = (
             '{"kind": "noop", '
             '"uri": "_uri_", '
-            '"config": {}, '
+            '"config": {"runner.identifier_format": "{uri}"}, '
             '"args": ["arg1", "arg2"]}'
         )
         self.assertEqual(runnable.get_json(), expected)


### PR DESCRIPTION
This reverts commit 94584fc60 ("Runnable: do not ignore the configuration passed from recipes").

That change, because of the fact that every runnable uses "runner.identifier_format", erroneously assumed that every configuration should be passed to the runnables.  In fact, it was decided long ago, and implemented after that, that only the configuration that is used by runnables should be set on them.

Now, because "runner.indentifier_format" is used by all, this needs to be taken into account.  In the near future, we may revisit the idea of "runner.indentifier_format" being handled by the runnable as a configuration item, and be transformed into a primary parameter of the runnables.

Reference: https://github.com/avocado-framework/avocado/issues/5964