### PR TITLE
Runnable: fix job/suite config use and runnable identifier

### DIFF
--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -158,9 +158,8 @@ class Runnable:
         """
         fmt = self.config.get("runner.identifier_format", "{uri}")
 
-        # For the cases where there is no config (when calling the Runnable
-        # directly
-        if not fmt:
+        # Optimize for the most common scenario
+        if fmt == "{uri}":
             return self.uri
 
         # For args we can use the entire list of arguments or with a specific

--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -113,7 +113,6 @@ class Runnable:
         #: expressing assets that the test will require in order to run.
         self.assets = kwargs.pop("assets", None)
         self.kwargs = kwargs
-        self._identifier_format = config.get("runner.identifier_format", "{uri}")
 
     def __repr__(self):
         fmt = (
@@ -157,7 +156,7 @@ class Runnable:
         Since this is formatter, combined values can be used. Example:
         "{uri}-{args}".
         """
-        fmt = self._identifier_format
+        fmt = self.config.get("runner.identifier_format", "{uri}")
 
         # For the cases where there is no config (when calling the Runnable
         # directly

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -76,6 +76,7 @@ def resolutions_to_runnables(resolutions, config):
         if resolution.result != ReferenceResolutionResult.SUCCESS:
             continue
         for runnable in resolution.resolutions:
+            runnable.config = runnable.filter_runnable_config(runnable.kind, config)
             result.append(runnable)
     return result
 

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -222,7 +222,7 @@ class Runner(SuiteRunner):
         :type config: dict
         """
         for runnable in runnables:
-            runnable.config = Runnable.add_configuration_used(runnable.kind, config)
+            runnable.config = Runnable.filter_runnable_config(runnable.kind, config)
 
     def _determine_status_server(self, test_suite, config_key):
         if test_suite.config.get("run.status_server_auto"):

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -26,7 +26,6 @@ import tempfile
 from avocado.core.dispatcher import SpawnerDispatcher
 from avocado.core.exceptions import JobError, JobFailFast
 from avocado.core.messages import MessageHandler
-from avocado.core.nrunner.runnable import Runnable
 from avocado.core.nrunner.runner import check_runnables_runner_requirements
 from avocado.core.output import LOG_JOB
 from avocado.core.plugin_interfaces import CLI, Init, SuiteRunner
@@ -212,18 +211,6 @@ class Runner(SuiteRunner):
         super().__init__()
         self.status_server_dir = None
 
-    @staticmethod
-    def _update_avocado_configuration_used_on_runnables(runnables, config):
-        """Updates the config used on runnables with this suite's config values
-
-        :param runnables: the tasks whose runner requirements will be checked
-        :type runnables: list of :class:`Runnable`
-        :param config: A config dict to be used on the desired test suite.
-        :type config: dict
-        """
-        for runnable in runnables:
-            runnable.config = Runnable.filter_runnable_config(runnable.kind, config)
-
     def _determine_status_server(self, test_suite, config_key):
         if test_suite.config.get("run.status_server_auto"):
             # no UNIX domain sockets on Windows
@@ -301,10 +288,6 @@ class Runner(SuiteRunner):
 
         test_suite.tests, missing_requirements = check_runnables_runner_requirements(
             test_suite.tests
-        )
-
-        self._update_avocado_configuration_used_on_runnables(
-            test_suite.tests, test_suite.config
         )
 
         self._abort_if_missing_runners(missing_requirements)

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-7": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
-    "unit": 669,
+    "unit": 670,
     "jobs": 11,
     "functional-parallel": 307,
     "functional-serial": 7,

--- a/selftests/unit/nrunner.py
+++ b/selftests/unit/nrunner.py
@@ -102,14 +102,30 @@ class RunnableTest(unittest.TestCase):
     def test_runnable_command_args(self):
         runnable = Runnable("noop", "uri", "arg1", "arg2")
         actual_args = runnable.get_command_args()
-        exp_args = ["-k", "noop", "-u", "uri", "-a", "arg1", "-a", "arg2"]
+        exp_args = [
+            "-k",
+            "noop",
+            "-u",
+            "uri",
+            "-c",
+            '{"runner.identifier_format": "{uri}"}',
+            "-a",
+            "arg1",
+            "-a",
+            "arg2",
+        ]
         self.assertEqual(actual_args, exp_args)
 
     def test_get_dict(self):
         runnable = Runnable("noop", "_uri_", "arg1", "arg2")
         self.assertEqual(
             runnable.get_dict(),
-            {"kind": "noop", "uri": "_uri_", "args": ("arg1", "arg2"), "config": {}},
+            {
+                "kind": "noop",
+                "uri": "_uri_",
+                "args": ("arg1", "arg2"),
+                "config": {"runner.identifier_format": "{uri}"},
+            },
         )
 
     def test_get_json(self):
@@ -117,7 +133,7 @@ class RunnableTest(unittest.TestCase):
         expected = (
             '{"kind": "noop", '
             '"uri": "_uri_", '
-            '"config": {}, '
+            '"config": {"runner.identifier_format": "{uri}"}, '
             '"args": ["arg1", "arg2"]}'
         )
         self.assertEqual(runnable.get_json(), expected)

--- a/selftests/unit/suite.py
+++ b/selftests/unit/suite.py
@@ -74,6 +74,17 @@ class TestSuiteTest(unittest.TestCase):
         self.suite = TestSuite.from_config(config=suite_config, job_config=job_config)
         self.assertEqual(self.suite.config.get("core.show"), ["none"])
 
+    def test_config_runnable(self):
+        config = {
+            "resolver.references": [
+                "examples/nrunner/recipes/runnable/noop.json",
+            ],
+            "runner.identifier_format": "NOT FOO",
+        }
+        suite = TestSuite.from_config(config)
+        runnable = suite.tests[0]
+        self.assertEqual(runnable.config.get("runner.identifier_format"), "NOT FOO")
+
     def tearDown(self):
         self.tmpdir.cleanup()
 


### PR DESCRIPTION
This addresses a few different issues that in the end, result in the failure to set and apply a Runnable's identifier.

More specifically this:
* fixes a regression that was adding the entire Avocado configuration to every runnable
* makes sure the suite configuration is applied to runnables at suite creation time
* uses the actual configuration of a runnable to set build its identifier