### PR TITLE
check-copr-rpm-version.docker: update OS to Fedora 40

### DIFF
--- a/contrib/containers/ci/selftests/check-copr-rpm-version.docker
+++ b/contrib/containers/ci/selftests/check-copr-rpm-version.docker
@@ -1,7 +1,6 @@
 # This container is used in selftests/pre_release/tests/check-copr-rpm-version.sh
-FROM fedora:38
+FROM fedora:40
 LABEL description "Fedora image used on COPR RPM version check"
-RUN dnf -y module disable avocado:latest
 RUN dnf -y install 'dnf-command(copr)'
 RUN dnf -y copr enable @avocado/avocado-latest
 RUN dnf -y clean all


### PR DESCRIPTION
Fedora 38 has reached EOL, and COPR is not building packages for it by default.  Also, modularity is not something we are carrying forward on Fedora 40, so there's no need to disable the module.