### PR TITLE
Fix for upload binaries to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,13 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        with:
+          app_id: ${{ secrets.MR_AVOCADO_ID }}
+          installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
+          private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           persist-credentials: false


### PR DESCRIPTION
The build and upload eggs release workflow is using Mr.Avocado token, but this token has never been generated for this workflow, therefore it is not working. This commit adds the step with token generation, which will fix the issue.

I have tested it in my fork, and you can see the results [here](https://github.com/richtja/avocado/actions/runs/9889257014).