### PR TITLE
Better description of config syntax error

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -222,7 +222,10 @@ class ConfigOption:
             return []
 
         if isinstance(value, str):
-            return ast.literal_eval(value)
+            try:
+                return ast.literal_eval(value)
+            except SyntaxError:
+                pass
 
         if isinstance(value, list):
             return value
@@ -628,7 +631,7 @@ class Settings:
             value = value[0]
             try:
                 self.update_option(namespace, value, convert=True)
-            except SyntaxError:
+            except (SyntaxError, ValueError):
                 raise SyntaxError(
                     f"Syntax error in config file {path}, please check the value {value} "
                 )


### PR DESCRIPTION
When there is an issue with syntax in avocado config file avocado won't provide enough information for the user to understand the problem. This commit will improve the error message by specifying the wrong value and the reason for syntax error.

before this commit:
```
SyntaxError: Syntax error in config file ./pom_config, please check the
value /build/avocado/data/cache
```

after this commit:
```
ValueError: /build/avocado/data/cache could not be converted into a list
During handling of the above exception, another exception occurred:

SyntaxError: Syntax error in config file ./pom_config, please check the
value /build/avocado/data/cache
```

Reference: #5906