### PR TITLE
utils/cpu: Add support for Power11 processor

### DIFF
--- a/avocado/utils/cpu.py
+++ b/avocado/utils/cpu.py
@@ -36,6 +36,7 @@ VENDORS_MAP = {
     "ibm": (
         rb"POWER\d",
         rb"IBM/S390",
+        rb"Power\d",
     ),
 }
 
@@ -198,6 +199,7 @@ def get_arch():
     cpu_table = [
         (b"^cpu.*(RS64|Broadband Engine)", "powerpc"),
         (rb"^cpu.*POWER\d+", "powerpc"),
+        (rb"^cpu.*Power\d+", "powerpc"),
         (b"^cpu.*PPC970", "powerpc"),
         (
             b"(ARM|^CPU implementer|^CPU part|^CPU variant"
@@ -261,7 +263,7 @@ def get_family():
         res = []
         try:
             for line in _get_info():
-                res = re.findall(rb"cpu\s+:\s+(POWER\d+)", line)
+                res = re.findall(rb"cpu\s+:\s+(POWER\d+|Power\d+)", line, re.IGNORECASE)
                 if res:
                     break
             family = res[0].decode("utf-8").lower()


### PR DESCRIPTION
This commit enhances the CPU utility to support the Power11 processor by making pattern matching case-insensitive.