### PR TITLE
avocado/utils/archive.py: make probe function for zstd public

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -116,7 +116,13 @@ def is_zstd_file(path):
         return zstd_file.read(len(ZSTD_MAGIC)) == ZSTD_MAGIC
 
 
-def _probe_zstd_cmd():
+def probe_zstd_cmd():
+    """
+    Attempts to find a suitable zstd tool that behaves as expected
+
+    :rtype: str or None
+    :returns: path to a suitable zstd executable or None if not found
+    """
     zstd_cmd = shutil.which("zstd")
     if zstd_cmd is not None:
         proc = subprocess.run(
@@ -136,7 +142,7 @@ def zstd_uncompress(path, output_path=None, force=False):
     """
     Extracts a zstd compressed file.
     """
-    zstd_cmd = _probe_zstd_cmd()
+    zstd_cmd = probe_zstd_cmd()
     if not zstd_cmd:
         raise ArchiveException("Unable to find a suitable zstd compression tool")
     output_path = _decide_on_path(path, ".zst", output_path)

--- a/selftests/unit/utils/archive.py
+++ b/selftests/unit/utils/archive.py
@@ -7,7 +7,7 @@ import unittest
 from avocado.utils import archive, crypto, data_factory
 from selftests.utils import BASEDIR, temp_dir_prefix
 
-ZSTD_AVAILABLE = archive._probe_zstd_cmd() is not None
+ZSTD_AVAILABLE = archive.probe_zstd_cmd() is not None
 
 
 class ArchiveTest(unittest.TestCase):


### PR DESCRIPTION
There's value in making the zstd probe function public (which was previously not perceived).  This function can be used to skip/cancel tests when a suitable zstd is not found.