### PR TITLE
logging.warn() refactoring for 92lts

### DIFF
--- a/avocado/plugins/legacy/replay.py
+++ b/avocado/plugins/legacy/replay.py
@@ -226,9 +226,9 @@ class Replay(CLI):
                         'ignore_missing_references',
                         'execution_order']
         if replay_config is None:
-            LOG_UI.warn('Source job config data not found. These options will '
-                        'not be loaded in this replay job: %s',
-                        ', '.join(overridables))
+            LOG_UI.warning('Source job config data not found. These options will '
+                           'not be loaded in this replay job: %s',
+                           ', '.join(overridables))
         else:
             for option in overridables:
                 optvalue = config.get(option, None)
@@ -242,16 +242,16 @@ class Replay(CLI):
                               'external_runner_testdir']:
                     optvalue = config.get('run.{}'.format(option))
                 if optvalue is not None:
-                    LOG_UI.warn("Overriding the replay %s with the --%s value "
-                                "given on the command line.",
-                                option.replace('_', '-'),
-                                option.replace('_', '-'))
+                    LOG_UI.warning("Overriding the replay %s with the --%s value "
+                                   "given on the command line.",
+                                   option.replace('_', '-'),
+                                   option.replace('_', '-'))
                 elif option in replay_config:
                     config[option] = replay_config[option]
 
         if config.get('run.references'):
-            LOG_UI.warn('Overriding the replay test references with test '
-                        'references given in the command line.')
+            LOG_UI.warning('Overriding the replay test references with test '
+                           'references given in the command line.')
         else:
             references = jobdata.retrieve_references(resultsdir)
             if references is None:
@@ -262,14 +262,14 @@ class Replay(CLI):
                 config['run.references'] = references
 
         if 'config' in replay_ignore:
-            LOG_UI.warn("Ignoring configuration from source job with "
-                        "--replay-ignore.")
+            LOG_UI.warning("Ignoring configuration from source job with "
+                           "--replay-ignore.")
         else:
             self.load_config(resultsdir)
 
         if 'variants' in replay_ignore:
-            LOG_UI.warn("Ignoring variants from source job with "
-                        "--replay-ignore.")
+            LOG_UI.warning("Ignoring variants from source job with "
+                           "--replay-ignore.")
         else:
             variants = jobdata.get_variants_path(resultsdir)
             if variants is None:
@@ -299,5 +299,5 @@ class Replay(CLI):
             if os.path.exists(pwd):
                 os.chdir(pwd)
             else:
-                LOG_UI.warn("Directory used in the replay source job '%s' does"
-                            " not exist, using '.' instead", pwd)
+                LOG_UI.warning("Directory used in the replay source job '%s' does"
+                               " not exist, using '.' instead", pwd)

--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -25,7 +25,7 @@ setup(name='avocado-framework-plugin-varianter-yaml-to-mux',
       url='http://avocado-framework.github.io/',
       packages=find_packages(exclude=('tests*',)),
       include_package_data=True,
-      install_requires=['avocado-framework==%s' % VERSION, 'PyYAML>=4.2b2'],
+      install_requires=['avocado-framework==%s' % VERSION, 'PyYAML>=4.2b2,<6.0.2'],
       test_suite='tests',
       entry_points={
           "avocado.plugins.init": [


### PR DESCRIPTION
The `logging.warn()` has been deprecated in python3.3, and it will be removed in python3.13. Let's use `logging.warning()` instead in avocado code.

Reference: https://docs.python.org/3.13/whatsnew/3.13.html
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=2250847 and https://bugzilla.redhat.com/show_bug.cgi?id=2304322