### PR TITLE
check-copr-rpm-version.docker: update COPR repo and OS to Fedora 40

### DIFF
--- a/contrib/containers/ci/selftests/check-copr-rpm-version.docker
+++ b/contrib/containers/ci/selftests/check-copr-rpm-version.docker
@@ -1,7 +1,6 @@
 # This container is used in selftests/pre_release/tests/check-copr-rpm-version.sh
-FROM fedora:36
+FROM fedora:40
 LABEL description "Fedora image used on COPR RPM version check"
-RUN dnf -y module disable avocado:latest
 RUN dnf -y install 'dnf-command(copr)'
-RUN dnf -y copr enable @avocado/avocado-latest
+RUN dnf -y copr enable @avocado/avocado-latest-92lts
 RUN dnf -y clean all

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -15,12 +15,12 @@ VERSION=$(python setup.py --version 2>/dev/null)
 COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1 $ORIGIN/92lts)
 SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/92lts)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
-DISTRO_VERSION=36
+DISTRO_VERSION=40
 
 DEFAULT_RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
 RPM_NVR="${1:-$DEFAULT_RPM_NVR}"
 
 PODMAN=$(which podman 2>/dev/null || which docker)
-PODMAN_IMAGE=quay.io/avocado-framework/check-copr-rpm-version
+PODMAN_IMAGE=quay.io/avocado-framework/check-copr-rpm-version:92lts
 
 $PODMAN run --rm -ti $PODMAN_IMAGE /bin/bash -c "dnf -y install ${RPM_NVR}"


### PR DESCRIPTION
Fedora 38 has reached EOL, and COPR is not building packages for it by default.  Also, modularity is not something we are carrying forward on Fedora 40, so there's no need to disable the module.

Finally, a tag with the right COPR repo is being used for the container image.