### PR TITLE
Deployment test: update to Fedora 40 and matching ansible

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -67,7 +67,7 @@ jobs:
     name: Avocado deployment
     runs-on: ubuntu-latest
     container:
-      image: fedora:36
+      image: fedora:40
     env:
       GIT_URL: 'https://github.com/avocado-framework/avocado'
       INVENTORY: 'selftests/deployment/inventory'

--- a/selftests/deployment/roles/common/tasks/main.yml
+++ b/selftests/deployment/roles/common/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
-- include: aexpect.yml
-- include: repos.yml
-- include: dependencies.yml
+- include_tasks: aexpect.yml
+- include_tasks: repos.yml
+- include_tasks: dependencies.yml

--- a/selftests/deployment/roles/common/tasks/repos.yml
+++ b/selftests/deployment/roles/common/tasks/repos.yml
@@ -50,7 +50,7 @@
   yum_repository:
     name: avocado-latest
     description: Copr repo for avocado-latest
-    baseurl: https://copr-be.cloud.fedoraproject.org/results/@avocado/avocado-latest/fedora-$releasever-$basearch/
+    baseurl: https://copr-be.cloud.fedoraproject.org/results/@avocado/avocado-latest-92lts/fedora-$releasever-$basearch/
     gpgcheck: no
   when:
     - method == 'copr'


### PR DESCRIPTION
The COPR repos are building for the active Fedora, so let's bump that to version 40.  While at it, we will be using a version of ansible that has deprecated the "include" tag.  The error one gets is:

   ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use
   include_tasks or import_tasks instead. This feature was removed from
   ansible-core in a release after 2023-05-16. Please update your
   playbooks.

This updates the playbook to work properly under the matching ansible version.

Reference: 44bcb711b1ff2b1de8f6534804dc3c621005f08a