### PR TITLE
Tap14 update

### DIFF
--- a/avocado/core/tapparser.py
+++ b/avocado/core/tapparser.py
@@ -30,11 +30,11 @@ class TapParser:
 
     _RE_BAILOUT = re.compile(r"Bail out!\s*(.*)")
     _RE_DIRECTIVE = re.compile(
-        r"(?:\s*\#\s*([Ss][Kk][Ii][Pp]\S*|[Tt][Oo][Dd][Oo])\b\s*(.*))?"
+        r"(?:\s*(?:#|\\{2}#)\s*([Ss][Kk][Ii][Pp]\S*|[Tt][Oo][Dd][Oo])\b\s*(.*))?"
     )
     _RE_PLAN = re.compile(r"1\.\.([0-9]+)" + _RE_DIRECTIVE.pattern)
     _RE_TEST = re.compile(
-        r"((?:not )?ok)\s*(?:([0-9]+)\s*)?([^#]*)" + _RE_DIRECTIVE.pattern
+        r"((?:not )?ok)\s*(?:([0-9]+)\s*)?\s*(.*?(?=(?<!\\)#|(?<!\\)\\{2}#|$))" + _RE_DIRECTIVE.pattern
     )
     _RE_VERSION = re.compile(r"TAP version ([0-9]+)")
     _RE_YAML_START = re.compile(r"(\s+)---.*")

--- a/avocado/core/tapparser.py
+++ b/avocado/core/tapparser.py
@@ -32,16 +32,21 @@ class TapParser:
     _RE_DIRECTIVE = re.compile(
         r"(?:\s*(?:#|\\{2}#)\s*([Ss][Kk][Ii][Pp]\S*|[Tt][Oo][Dd][Oo])\b\s*(.*))?"
     )
-    _RE_PLAN = re.compile(r"1\.\.([0-9]+)" + _RE_DIRECTIVE.pattern)
+    _RE_PLAN = re.compile(r"(?: {4})*1\.\.([0-9]+)" + _RE_DIRECTIVE.pattern)
     _RE_TEST = re.compile(
-        r"((?:not )?ok)\s*(?:([0-9]+)\s*)?\s*(.*?(?=(?<!\\)#|(?<!\\)\\{2}#|$))" + _RE_DIRECTIVE.pattern
+        r"(?: {4})*((?:not )?ok)\s*(?:([0-9]+)\s*)?\s*(.*?(?=(?<!\\)#|(?<!\\)\\{2}#|$))"
+        + _RE_DIRECTIVE.pattern
     )
     _RE_VERSION = re.compile(r"TAP version ([0-9]+)")
-    _RE_YAML_START = re.compile(r"(\s+)---.*")
-    _RE_YAML_END = re.compile(r"\s+\.\.\.\s*")
+    _RE_YAML_START = re.compile(r"(?: {4})*(\s+)---.*")
+    _RE_YAML_END = re.compile(r"(?: {4})*\s+\.\.\.\s*")
+
+    _RE_CHILD = re.compile(r"( {4})*")
 
     def __init__(self, tap_io):
         self.tap_io = tap_io
+        self.last_line = ""
+        self.lineno = 0
 
     def parse_test(self, ok, num, name, directive, explanation):
         name = name.strip()
@@ -62,30 +67,40 @@ class TapParser:
         result = TestResult.PASS if ok else TestResult.FAIL
         yield self.Test(num, name, result, explanation)
 
-    def parse(self):
+    def _parse(self, indent_size=0, version=12):
         found_late_test = False
         bailed_out = False
         plan = None
-        lineno = 0
         num_tests = 0
         yaml_lineno = 0
         yaml_indent = ""
         state = self._MAIN
-        version = 12
         while True:
-            lineno += 1
-            try:
-                line = next(self.tap_io).rstrip()
-            except StopIteration:
+            if self.last_line:
+                line = self.last_line
+                self.last_line = ""
+            else:
+                try:
+                    line = next(self.tap_io).rstrip()
+                except StopIteration:
+                    break
+            line_indent_size = len(self._RE_CHILD.match(line).group()) / 4
+            if indent_size < line_indent_size:
+                self.last_line = line
+                yield from self._parse(line_indent_size, version)
+                line = self.last_line
+                self.last_line = ""
+            elif indent_size > line_indent_size:
+                self.last_line = line
                 break
-
+            self.lineno += 1
             # YAML blocks are only accepted after a test
             if state == self._AFTER_TEST:
                 if version >= 13:
                     m = self._RE_YAML_START.match(line)
                     if m:
                         state = self._YAML
-                        yaml_lineno = lineno
+                        yaml_lineno = self.lineno
                         yaml_indent = m.group(1)
                         continue
                 state = self._MAIN
@@ -152,7 +167,7 @@ class TapParser:
             m = self._RE_VERSION.match(line)
             if m:
                 # The TAP version is only accepted as the first line
-                if lineno != 1:
+                if self.lineno != 1:
                     yield self.Error("version number must be on the first line")
                     continue
                 version = int(m.group(1))
@@ -181,3 +196,7 @@ class TapParser:
                     f"Too many tests run (expected "
                     f"{int(plan.count)}, got {int(num_tests)})"
                 )
+
+    def parse(self):
+        self.lineno = 0
+        yield from self._parse()

--- a/avocado/plugins/runners/tap.py
+++ b/avocado/plugins/runners/tap.py
@@ -39,12 +39,14 @@ class TAPRunner(ExecTestRunner):
     def _get_tap_result(stdout):
         parser = TapParser(io.StringIO(stdout.decode()))
         result = "error"
+        fail_reason = None
         for event in parser.parse():
             if isinstance(event, TapParser.Bailout):
                 result = "error"
                 break
             elif isinstance(event, TapParser.Error):
                 result = "error"
+                fail_reason = f"Tap format error: {event.message}"
                 break
             elif isinstance(event, TapParser.Plan):
                 if event.skipped:
@@ -53,23 +55,28 @@ class TAPRunner(ExecTestRunner):
             elif isinstance(event, TapParser.Test):
                 if event.result == TestResult.FAIL:
                     result = "fail"
+                    fail_reason = event.explanation
                     break
                 elif event.result == TestResult.SKIP:
                     result = "skip"
                     break
                 elif event.result == TestResult.XPASS:
                     result = "warn"
+                    if event.name:
+                        tap_test_id = f"{event.number} ({event.name})"
+                    else:
+                        tap_test_id = f"{event.number}"
+                    fail_reason = f"TODO test {tap_test_id} unexpectedly passed."
                     break
                 else:
                     result = "pass"
-        return result
+        return result, fail_reason
 
     def _process_final_status(
         self, process, runnable, stdout=None, stderr=None
     ):  # pylint: disable=W0613
-        return FinishedMessage.get(
-            self._get_tap_result(stdout), returncode=process.returncode
-        )
+        result, fail_reason = self._get_tap_result(stdout)
+        return FinishedMessage.get(result, fail_reason, returncode=process.returncode)
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/runners/tap.py
+++ b/avocado/plugins/runners/tap.py
@@ -51,11 +51,14 @@ class TAPRunner(ExecTestRunner):
                     result = "skip"
                     break
             elif isinstance(event, TapParser.Test):
-                if event.result in (TestResult.XPASS, TestResult.FAIL):
+                if event.result == TestResult.FAIL:
                     result = "fail"
                     break
                 elif event.result == TestResult.SKIP:
                     result = "skip"
+                    break
+                elif event.result == TestResult.XPASS:
+                    result = "warn"
                     break
                 else:
                     result = "pass"

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-7": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
-    "unit": 671,
+    "unit": 672,
     "jobs": 11,
     "functional-parallel": 307,
     "functional-serial": 7,

--- a/selftests/unit/tap.py
+++ b/selftests/unit/tap.py
@@ -118,6 +118,10 @@ class TapParserTests(unittest.TestCase):
         self.assert_test(events, number=1, name="abc", result=TestResult.XPASS)
         self.assert_last(events)
 
+        events = self.parse_tap("not ok 1 abc \\# TODO")
+        self.assert_test(events, number=1, name="abc \\# TODO", result=TestResult.FAIL)
+        self.assert_last(events)
+
     def test_one_test_skip(self):
         events = self.parse_tap("ok 1 abc # SKIP")
         self.assert_test(events, number=1, name="abc", result=TestResult.SKIP)

--- a/selftests/unit/tap.py
+++ b/selftests/unit/tap.py
@@ -150,6 +150,20 @@ class TapParserTests(unittest.TestCase):
         self.assert_plan(events, count=4, late=True)
         self.assert_last(events)
 
+    def test_child_test(self):
+        events = self.parse_tap(
+            "1..4\nok 1\n    1..2\n    ok 1\n    not ok 2\nnot ok 2\nok 3\nnot ok 4"
+        )
+        self.assert_plan(events, count=4, late=False)
+        self.assert_test(events, number=1, name="", result=TestResult.PASS)
+        self.assert_plan(events, count=2, late=False)
+        self.assert_test(events, number=1, name="", result=TestResult.PASS)
+        self.assert_test(events, number=2, name="", result=TestResult.FAIL)
+        self.assert_test(events, number=2, name="", result=TestResult.FAIL)
+        self.assert_test(events, number=3, name="", result=TestResult.PASS)
+        self.assert_test(events, number=4, name="", result=TestResult.FAIL)
+        self.assert_last(events)
+
     def test_directive_case(self):
         events = self.parse_tap("ok 1 abc # skip")
         self.assert_test(events, number=1, name="abc", result=TestResult.SKIP)


### PR DESCRIPTION
This PR introduces support for TAP14 format. And few small fixes to tap runner. 

The main differences between TAP13 and TAP14 important for tap runner:

- Add child tests as 4-space indented TAP streams, with a trailing test point and leading comment line.
- Escaping of \ and # characters.

More info can be found in [TAP14 specification](https://testanything.org/tap-version-14-specification.html)

Reference: #5913