### PR TITLE
Runnable and Suite configuration support

### DIFF
--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -201,7 +201,7 @@ class Runnable:
             LOG.warning(
                 "The runnable config should have only values "
                 "essential for its runner. In the next version of "
-                "avocado, this will raise a Value Error. Please "
+                "avocado, this will raise a ValueError. Please "
                 "use avocado.core.nrunner.runnable.Runnable.filter_runnable_config "
                 "or avocado.core.nrunner.runnable.Runnable.from_avocado_config"
             )

--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -5,6 +5,7 @@ import logging
 import os
 import subprocess
 import sys
+import warnings
 
 import pkg_resources
 
@@ -192,8 +193,7 @@ class Runnable:
                 "The runnable config should have only values "
                 "essential for its runner. In the next version of "
                 "avocado, this will raise a ValueError. Please "
-                "use avocado.core.nrunner.runnable.Runnable.filter_runnable_config "
-                "or avocado.core.nrunner.runnable.Runnable.from_avocado_config"
+                "use avocado.core.nrunner.runnable.Runnable.filter_runnable_config"
             )
 
     @config.setter
@@ -214,7 +214,7 @@ class Runnable:
     def from_args(cls, args):
         """Returns a runnable from arguments"""
         decoded_args = [_arg_decode_base64(arg) for arg in args.get("arg", ())]
-        return cls.from_avocado_config(
+        return cls(
             args.get("kind"),
             args.get("uri"),
             *decoded_args,
@@ -280,7 +280,7 @@ class Runnable:
         """
         cls._validate_recipe(recipe_dict)
         config = ConfigDecoder.decode_set(recipe_dict.get("config", {}))
-        return cls.from_avocado_config(
+        return cls(
             recipe_dict.get("kind"),
             recipe_dict.get("uri"),
             *recipe_dict.get("args", ()),
@@ -307,6 +307,11 @@ class Runnable:
         cls, kind, uri, *args, config=None, identifier=None, **kwargs
     ):
         """Creates runnable with only essential config for runner of specific kind."""
+        warnings.warn(
+            "from_avocado_config() is deprecated, please use the regular "
+            "class initialization as it has the same behavior.",
+            DeprecationWarning,
+        )
         return cls(kind, uri, *args, config=config, identifier=identifier, **kwargs)
 
     @classmethod

--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -327,7 +327,7 @@ class Runnable:
             if command is not None:
                 command = " ".join(command)
                 configuration_used = STANDALONE_EXECUTABLE_CONFIG_USED.get(command)
-        return configuration_used
+        return configuration_used + CONFIGURATION_USED
 
     @classmethod
     def filter_runnable_config(cls, kind, config):
@@ -349,7 +349,7 @@ class Runnable:
         """
         whole_config = settings.as_dict()
         filtered_config = {}
-        config_items = cls.get_configuration_used_by_kind(kind) + CONFIGURATION_USED
+        config_items = cls.get_configuration_used_by_kind(kind)
         for config_item in config_items:
             filtered_config[config_item] = config.get(
                 config_item, whole_config.get(config_item)

--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -185,6 +185,17 @@ class Runnable:
     def config(self):
         return self._config
 
+    def _config_setter_warning(self, config):
+        configuration_used = Runnable.get_configuration_used_by_kind(self.kind)
+        if not set(configuration_used).issubset(set(config.keys())):
+            LOG.warning(
+                "The runnable config should have only values "
+                "essential for its runner. In the next version of "
+                "avocado, this will raise a ValueError. Please "
+                "use avocado.core.nrunner.runnable.Runnable.filter_runnable_config "
+                "or avocado.core.nrunner.runnable.Runnable.from_avocado_config"
+            )
+
     @config.setter
     def config(self, config):
         """Sets the config values based on the runnable kind.
@@ -196,15 +207,7 @@ class Runnable:
         :param config: A config dict with new values for Runnable.
         :type config: dict
         """
-        configuration_used = Runnable.get_configuration_used_by_kind(self.kind)
-        if not set(configuration_used).issubset(set(config.keys())):
-            LOG.warning(
-                "The runnable config should have only values "
-                "essential for its runner. In the next version of "
-                "avocado, this will raise a ValueError. Please "
-                "use avocado.core.nrunner.runnable.Runnable.filter_runnable_config "
-                "or avocado.core.nrunner.runnable.Runnable.from_avocado_config"
-            )
+        self._config_setter_warning(config)
         self._config = config
 
     @classmethod

--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -97,6 +97,10 @@ class Runnable:
         #: test or being the test, or an actual URI with multiple
         #: parts
         self.uri = uri
+        #: This attributes holds default configuration values that the
+        #: runner has determined that has interest in by setting it in
+        #: attr:`avocado.core.nrunner.runner.BaseRunner.CONFIGURATION_USED`
+        self._default_config = self.filter_runnable_config(kind, {})
         #: This attributes holds configuration from Avocado proper
         #: that is passed to runners, as long as a runner declares
         #: its interest in using them with
@@ -186,6 +190,10 @@ class Runnable:
     def config(self):
         return self._config
 
+    @property
+    def default_config(self):
+        return self._default_config
+
     def _config_setter_warning(self, config):
         configuration_used = Runnable.get_configuration_used_by_kind(self.kind)
         if not set(configuration_used).issubset(set(config.keys())):
@@ -209,6 +217,23 @@ class Runnable:
         """
         self._config_setter_warning(config)
         self._config = config
+
+    @default_config.setter
+    def default_config(self, config):
+        """Sets the default config values based on the runnable kind.
+
+        This is not avocado config, it is a runnable config which is a subset
+        of avocado config based on `STANDALONE_EXECUTABLE_CONFIG_USED` which
+        describes essential configuration values for each runner kind.
+
+        These values are used as convenience if other values are not set
+        in the actual :attr:`config` itself.
+
+        :param config: A config dict with default values for this Runnable.
+        :type config: dict
+        """
+        self._config_setter_warning(config)
+        self._default_config = config
 
     @classmethod
     def from_args(cls, args):

--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -102,8 +102,8 @@ class Runnable:
         #: attr:`avocado.core.nrunner.runner.BaseRunner.CONFIGURATION_USED`
         self._config = {}
         if config is None:
-            config = self.filter_runnable_config(kind, {})
-        self.config = config or {}
+            config = {}
+        self.config = self.filter_runnable_config(kind, config)
         self.args = args
         self.tags = kwargs.pop("tags", None)
         self.dependencies = self.read_dependencies(kwargs.pop("dependencies", None))
@@ -307,9 +307,6 @@ class Runnable:
         cls, kind, uri, *args, config=None, identifier=None, **kwargs
     ):
         """Creates runnable with only essential config for runner of specific kind."""
-        if not config:
-            config = {}
-        config = cls.filter_runnable_config(kind, config)
         return cls(kind, uri, *args, config=config, identifier=identifier, **kwargs)
 
     @classmethod

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -76,7 +76,9 @@ def resolutions_to_runnables(resolutions, config):
         if resolution.result != ReferenceResolutionResult.SUCCESS:
             continue
         for runnable in resolution.resolutions:
-            runnable.config = runnable.filter_runnable_config(runnable.kind, config)
+            runnable.default_config = runnable.filter_runnable_config(
+                runnable.kind, config
+            )
             result.append(runnable)
     return result
 

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -220,7 +220,7 @@ class SysInfoTest(PreTest, PostTest):
             return []
         sysinfo_config = sysinfo.gather_collectibles_config(suite_config)
         return [
-            Runnable.from_avocado_config(
+            Runnable(
                 "sysinfo",
                 "pre",
                 config=suite_config,
@@ -237,7 +237,7 @@ class SysInfoTest(PreTest, PostTest):
         sysinfo_config = sysinfo.gather_collectibles_config(suite_config)
         return [
             (
-                Runnable.from_avocado_config(
+                Runnable(
                     "sysinfo",
                     "post",
                     config=suite_config,
@@ -249,7 +249,7 @@ class SysInfoTest(PreTest, PostTest):
                 ["pass"],
             ),
             (
-                Runnable.from_avocado_config(
+                Runnable(
                     "sysinfo",
                     "post",
                     config=suite_config,

--- a/examples/nrunner/recipes/runnable/noop_config.json
+++ b/examples/nrunner/recipes/runnable/noop_config.json
@@ -1,0 +1,1 @@
+{"kind": "noop", "uri": "noop", "config": {"runner.identifier_format": "nothing-op"}}

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-7": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
-    "unit": 673,
+    "unit": 675,
     "jobs": 11,
     "functional-parallel": 307,
     "functional-serial": 7,

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-7": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
-    "unit": 675,
+    "unit": 677,
     "jobs": 11,
     "functional-parallel": 307,
     "functional-serial": 7,

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-7": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
-    "unit": 672,
+    "unit": 673,
     "jobs": 11,
     "functional-parallel": 307,
     "functional-serial": 7,

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-7": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
-    "unit": 677,
+    "unit": 678,
     "jobs": 11,
     "functional-parallel": 307,
     "functional-serial": 7,

--- a/selftests/functional/resolver.py
+++ b/selftests/functional/resolver.py
@@ -183,7 +183,7 @@ class ResolverFunctionalTmp(TestCaseTmpDir):
 ==================
 asset: 1
 exec-test: 3
-noop: 2
+noop: 3
 package: 1
 python-unittest: 1
 sysinfo: 1"""

--- a/selftests/unit/runnable.py
+++ b/selftests/unit/runnable.py
@@ -1,5 +1,6 @@
 import unittest.mock
 
+import avocado.core.nrunner.runnable as runnable_mod
 from avocado.core.nrunner.runnable import Runnable
 
 
@@ -159,6 +160,17 @@ class RunnableFromRecipe(unittest.TestCase):
                 ]
             ),
         )
+
+    def test_config_warn_if_not_used(self):
+        runnable = Runnable("exec-test", "/bin/sh")
+        with unittest.mock.patch.object(runnable_mod.LOG, "warning") as log_mock:
+            runnable.config = {"some-unused-config": "foo"}
+        log_mock.assert_called_once()
+
+    def test_config_dont_warn_if_used(self):
+        with unittest.mock.patch.object(runnable_mod.LOG, "warning") as log_mock:
+            Runnable("noop", "noop", config={"runner.identifier_format": "noop"})
+        log_mock.assert_not_called()
 
     def test_identifier(self):
         open_mocked = unittest.mock.mock_open(

--- a/selftests/unit/runnable.py
+++ b/selftests/unit/runnable.py
@@ -172,6 +172,19 @@ class RunnableFromRecipe(unittest.TestCase):
             Runnable("noop", "noop", config={"runner.identifier_format": "noop"})
         log_mock.assert_not_called()
 
+    def test_default_config(self):
+        runnable = Runnable("noop", "noop")
+        self.assertEqual(
+            runnable.default_config.get("runner.identifier_format"), "{uri}"
+        )
+
+    def test_default_and_actual_config(self):
+        runnable = Runnable("noop", "noop", config={"runner.identifier_format": "noop"})
+        self.assertEqual(runnable.config.get("runner.identifier_format"), "noop")
+        self.assertEqual(
+            runnable.default_config.get("runner.identifier_format"), "{uri}"
+        )
+
     def test_identifier(self):
         open_mocked = unittest.mock.mock_open(
             read_data=(

--- a/selftests/unit/runnable.py
+++ b/selftests/unit/runnable.py
@@ -146,6 +146,20 @@ class RunnableFromRecipe(unittest.TestCase):
             runnable.config.get("runner.identifier_format"), "{uri}-{args[0]}"
         )
 
+    def test_config_at_init(self):
+        runnable = Runnable("exec-test", "/bin/sh")
+        self.assertEqual(
+            set(runnable.config.keys()),
+            set(
+                [
+                    "run.keep_tmp",
+                    "runner.exectest.exitcodes.skip",
+                    "runner.exectest.clear_env",
+                    "runner.identifier_format",
+                ]
+            ),
+        )
+
     def test_identifier(self):
         open_mocked = unittest.mock.mock_open(
             read_data=(

--- a/selftests/unit/suite.py
+++ b/selftests/unit/suite.py
@@ -85,6 +85,17 @@ class TestSuiteTest(unittest.TestCase):
         runnable = suite.tests[0]
         self.assertEqual(runnable.config.get("runner.identifier_format"), "NOT FOO")
 
+    def test_config_runnable_and_suite(self):
+        config = {
+            "resolver.references": [
+                "examples/nrunner/recipes/runnable/noop_config.json",
+            ],
+            "runner.identifier_format": "NOT FOO",
+        }
+        suite = TestSuite.from_config(config)
+        runnable = suite.tests[0]
+        self.assertEqual(runnable.config.get("runner.identifier_format"), "nothing-op")
+
     def tearDown(self):
         self.tmpdir.cleanup()
 


### PR DESCRIPTION
This change allows for the a runnable configuration and the suite and default configuration to coexist with the correct behavior.
    
In short, if the suite has a configuration, it will become the new default configuration for a runnable, while its own configuration will not be touched.
    
Fixes: https://github.com/avocado-framework/avocado/issues/5998