### PR TITLE
Avocado instrumented timeout in setUp and tearDown fix

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -585,7 +585,7 @@ class Test(unittest.TestCase, TestData):
             self.__skip_test = True
             stacktrace.log_exc_info(sys.exc_info(), logger=self.log)
             raise exceptions.TestSkipError(details)
-        except exceptions.TestCancel:
+        except (exceptions.TestCancel, exceptions.TestInterrupt):
             stacktrace.log_exc_info(sys.exc_info(), logger=self.log)
             raise
         except:  # Old-style exceptions are not inherited from Exception()
@@ -633,7 +633,7 @@ class Test(unittest.TestCase, TestData):
                 f"test. Original skip exception: {details}"
             )
             raise exceptions.TestError(skip_illegal_msg)
-        except exceptions.TestCancel:
+        except (exceptions.TestCancel, exceptions.TestInterrupt):
             stacktrace.log_exc_info(sys.exc_info(), logger=self.log)
             raise
         except:  # avoid old-style exception failures pylint: disable=W0702

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -29,7 +29,7 @@ TEST_SIZE = {
     "nrunner-requirement": 28,
     "unit": 678,
     "jobs": 11,
-    "functional-parallel": 307,
+    "functional-parallel": 309,
     "functional-serial": 7,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,


### PR DESCRIPTION
This commit is a fix for avocado-instrumented timeouts. When the tests are interrupted due to timeout during `setUp` or `tearDown` method, those tests would result in `ERROR` instead of `INTERRUPTED`. This commit updates the exception handling of this method to fix this issue.

Reference: #6013