### PR TITLE
Backport: Added exception handling for OSError that may be thrown by os.read

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -485,7 +485,10 @@ class FDDrainer:
                 if not has_io:
                     # Don't read unless there are new data available
                     continue
-            tmp = os.read(self.fd, 8192)
+            try:
+                tmp = os.read(self.fd, 8192)
+            except OSError:
+                break
             if not tmp:
                 break
             self.data.write(tmp)


### PR DESCRIPTION
Backport this patch to 92lts, as avocado-vt is currently still using this.