### PR TITLE
Backport: Add exception handling for OSError that my be thrown by os.fsync

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -519,7 +519,7 @@ class FDDrainer:
                         try:
                             fileno = stream.fileno()
                             os.fsync(fileno)
-                        except UnsupportedOperation:
+                        except UnsupportedOperation, OSError:
                             pass
                 if hasattr(handler, 'close'):
                     handler.close()


### PR DESCRIPTION
We've seen instances where "Bad file descriptor" OSError was raised. This looks similar to 52d69bed34982ba36b535c70293ea686fedb1898. Handle in the same way by ignoring the error and continuing execution.