### PR TITLE
Static checks: use import order and style checks from avocado-static-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          submodules: true
       - name: Allow git to operate on directory checked out by GH Actions
         run: git config --global --add safe.directory `pwd`
       - name: Installing Avocado development dependencies

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "static-checks"]
+	path = static-checks
+	url = https://github.com/avocado-framework/avocado-static-checks

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -600,6 +600,7 @@ def create_suites(args):  # pylint: disable=W0621
         config_check_static["resolver.references"].append(
             "static-checks/check-import-order"
         )
+        config_check_static["resolver.references"].append("static-checks/check-style")
         suites.append(TestSuite.from_config(config_check_static, "static-checks"))
 
     # ========================================================================

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -597,6 +597,9 @@ def create_suites(args):  # pylint: disable=W0621
     if args.dict_tests["static-checks"]:
         config_check_static = copy.copy(config_check)
         config_check_static["resolver.references"] = glob.glob("selftests/*.sh")
+        config_check_static["resolver.references"].append(
+            "static-checks/check-import-order"
+        )
         suites.append(TestSuite.from_config(config_check_static, "static-checks"))
 
     # ========================================================================

--- a/selftests/isort.sh
+++ b/selftests/isort.sh
@@ -1,3 +1,0 @@
-#!/bin/sh -e
-
-isort --check-only --profile black .

--- a/selftests/style.sh
+++ b/selftests/style.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -e
-echo "** Running black..."
-
-python3 -m black --check --diff --color .


### PR DESCRIPTION
This switches two checks from the custom scripts in the Avocado repo to use the ones from avocado-static checks.  The lint check will follow up after some changes to avocado-static-checks itself.

Reference: https://github.com/avocado-framework/avocado/issues/5989