### PR TITLE
Fix apt unit tests

### DIFF
--- a/avocado/utils/distro.py
+++ b/avocado/utils/distro.py
@@ -387,7 +387,7 @@ class DebianProbe(Probe):
 
     CHECK_FILE = "/etc/debian_version"
     CHECK_FILE_DISTRO_NAME = "debian"
-    CHECK_VERSION_REGEX = re.compile(r"(\d+)\.(\d+)")
+    CHECK_VERSION_REGEX = re.compile(r"(.+)/(.+)")
 
 
 class UbuntuProbe(Probe):
@@ -399,7 +399,7 @@ class UbuntuProbe(Probe):
     CHECK_FILE_CONTAINS = "ubuntu"
     CHECK_FILE_DISTRO_NAME = "Ubuntu"
     CHECK_VERSION_REGEX = re.compile(
-        r".*VERSION_ID=\"(\d+)\.(\d+)\".*", re.MULTILINE | re.DOTALL
+        r".*VERSION_ID=\"(\d+\.\d+)\".*", re.MULTILINE | re.DOTALL
     )
 
 

--- a/selftests/unit/utils/software_manager.py
+++ b/selftests/unit/utils/software_manager.py
@@ -13,12 +13,26 @@ def apt_supported_distro():
     return distro.detect().name in ["debian", "Ubuntu"]
 
 
+def login_binary_path(distro_name, distro_version):
+    """Retrieve the login binary path based on the distro version""""
+    if distro_name == "Ubuntu":
+        if float(distro_version) >= 24.04:
+            return "/usr/bin/login"
+    if distro_name == "debian":
+        if distro_version == "trixie":
+            return "/usr/bin/login"
+    return "/bin/login"
+
+
 @unittest.skipUnless(os.getuid() == 0, "This test requires root privileges")
 @unittest.skipUnless(apt_supported_distro(), "Unsupported distro")
 class Apt(unittest.TestCase):
     def test_provides(self):
         sm = manager.SoftwareManager()
-        self.assertEqual(sm.provides("/bin/login"), "login")
+        distro_name = distro.detect().name
+        distro_version = distro.detect().version
+        login_path = login_binary_path(distro_name, distro_version)
+        self.assertEqual(sm.provides(login_path), "login")
         self.assertTrue(isinstance(sm.backend, backends.apt.AptBackend))
 
 


### PR DESCRIPTION
This is some of the work in preparation for the debian packaging on https://github.com/avocado-framework/avocado/pull/5912.


I have separated the fixes in two commits, let me know if this is ok.

On a44d5abe4b9776cebc6d782ae86c986bfff58a63 I have fixed the Ubuntu/debian version detection as it was not retrieving the correct versions.

On eff2add503f662353bf3ec3f54c352b536685248 I have fixed the unit test by adding a function to retrieve the binary based on the distro version.

Happy to hear any feedback or improvements.

Resolves: https://github.com/avocado-framework/avocado/issues/6028