### PR TITLE
Distro: add a functional test for Debian probes

### DIFF
--- a/selftests/check.py
+++ b/selftests/check.py
@@ -29,7 +29,7 @@ TEST_SIZE = {
     "nrunner-requirement": 28,
     "unit": 678,
     "jobs": 11,
-    "functional-parallel": 312,
+    "functional-parallel": 313,
     "functional-serial": 7,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,

--- a/selftests/functional/utils/distro.py
+++ b/selftests/functional/utils/distro.py
@@ -53,3 +53,14 @@ class Distro(Test):
             + os.uname().machine.encode()
             + b") version 9 release 1\n",
         )
+
+    def test_debian_12_7(self):
+        """
+        :avocado: dependency={"type": "podman-image", "uri": "docker.io/library/python@sha256:785fef11f44b7393c03d77032fd72e56af8b05442b051a151229145e5fbbcb29"}
+        """
+        self.run_job(
+            "docker.io/library/python@sha256:785fef11f44b7393c03d77032fd72e56af8b05442b051a151229145e5fbbcb29",
+            b"Detected distribution: debian ("
+            + os.uname().machine.encode()
+            + b") version 12 release 7\n",
+        )


### PR DESCRIPTION
While the standard "debian" container is not so easily suitable for being used in the existing functional tests for distros that run an Avocado job, the very standard "python" container is built on Debian and provides Python (of course).

This should serve to avoid regressions to the distro probes for Debian.