### PR TITLE
pre-release tests with avocado-static-checks submodule

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: true
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
The pre-release checks don't checkout avocado-static-checks submodule, which is mandatory for running static-check after 8639fdb. This is a fix for that.

It fixes failures in https://github.com/avocado-framework/avocado/actions/runs/11099769147/job/30834525300


Reference: 8639fdb