### PR TITLE
MarkupSafe fix

### DIFF
--- a/docs/source/releases/108_0.rst
+++ b/docs/source/releases/108_0.rst
@@ -15,10 +15,10 @@ Users/Test Writers
   `exec-runnables-recipe`. It allows a user to point to a file that
   will be executed, and that is expected to generate (on its ``STDOUT``)
   content compatible with the Runnable recipe format. More info
-  abotu this new featrue can be found in `documentaion 
+  about this new featrue can be found in `documentaion
   <https://avocado-framework.readthedocs.io/en/latest/guides/writer/chapters/recipes.html#using-dynamically-generated-recipes>`_
 
-* Documentaion about avocado-instrumented test lifecycle has been `improved
+* Documentation about avocado-instrumented test lifecycle has been `improved
   <https://avocado-framework.readthedocs.io/en/latest/guides/reference/chapters/avocado_instrumented.html>`_
 
 Utility Modules

--- a/optional_plugins/ansible/setup.py
+++ b/optional_plugins/ansible/setup.py
@@ -41,6 +41,7 @@ setup(
         "cffi",
         "pycparser",
         "ansible-core",
+        "markupsafe<3.0.0",
     ],
     test_suite="tests",
     entry_points={

--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -39,7 +39,7 @@ setup(
     url="http://avocado-framework.github.io/",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[f"avocado-framework=={VERSION}", "jinja2"],
+    install_requires=[f"avocado-framework=={VERSION}", "jinja2", "markupsafe<3.0.0"],
     entry_points={
         "avocado.plugins.cli": [
             "html = avocado_result_html:HTML",


### PR DESCRIPTION
This adds markupsafe<3.0.0 requirements to html plugin, because
markupsafe-3.0.0 can't be installed with older versions of setuptools on
RHEL9 and other systems because of `CCompilerError`.

Reference: https://github.com/avocado-framework/avocado/issues/6038
Signed-off-by: Jan Richter <jarichte@redhat.com>

---
We have the same issue in our [CI](https://github.com/avocado-framework/avocado/actions/runs/11257807732/job/31302934938?pr=6039#step:6:431) and this PR should fix it.