### PR TITLE
Remove IPv4 Addresses of network interface.

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -554,6 +554,25 @@ class NetworkInterface:
             msg = f"Failed to flush ipaddr. {ex}"
             raise NWException(msg)
 
+    def nm_flush_ipaddr(self):
+        """Remove all the IPv4 address for this interface by using IP tool.
+
+        This method will explicitly identifies all available IP addresses with
+        netmask of interfaces and deletes them.
+
+        You must have sudo permissions to run this method on a host.
+        """
+        cmd = f"nmcli -g ip4.ADDRESS device show {self.name}"
+        ipaddresses = run_command(cmd, self.host, sudo=True).strip().split(" | ")
+        if ipaddresses:
+            try:
+                for ipaddr in ipaddresses:
+                    cmd = f"ip addr delete {ipaddr} dev {self.name}"
+                    run_command(cmd, self.host, sudo=True)
+            except Exception as ex:
+                msg = f"Failed to flush ipaddr. {ex}"
+                raise NWException(msg)
+
     def remove_link(self):
         """Deletes virtual interface link.
 


### PR DESCRIPTION
when IP addresses are confiugred from a config file, the generic "ip flush" command does not removes the IP address and IP's will be remain intact.

when user wanted to remove all IP addresses of interface which user doesnot aware of it, this code will helps to find all the assigned IP addresses and removes it.