### PR TITLE
MacOS update from 12 to 14 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   check-macos:
 
     name: macOS with Python ${{ matrix.python-version }}
-    runs-on: macos-12
+    runs-on: macos-14
 
     strategy:
       matrix:


### PR DESCRIPTION
Github is depracating the MacOS 12 runner and it will be removed December 3rd. Let's do the update now to avoid any future trubles.

Reference: https://github.com/actions/runner-images/issues/10721