### PR TITLE
Set release-specific URLs in PyPI publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/avocado-framework
+      url: https://pypi.org/project/avocado-framework/${{ github.event.inputs.version }}
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:


### PR DESCRIPTION
This patch will make the links on the UI of the [Deployments](https://github.com/avocado-framework/avocado/deployments/pypi) and workflow pages more accurate.