### PR TITLE
Surface the release RTD link to GHA workflow summary page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,10 @@ jobs:
       - name: Build documentation readthedocs
         run: |
           make -f Makefile.gh build-update-readthedocs
-      - run: echo "In a few minutes the release documentation will be available in https://${{ github.event.inputs.rtd_project }}.readthedocs.io/en/${{ github.event.inputs.version }}/"
+      - run: >-
+          echo In a few minutes the release documentation will be available at
+          https://${{ github.event.inputs.rtd_project }}.readthedocs.io/en/${{ github.event.inputs.version }}/
+          | tee -a "${GITHUB_STEP_SUMMARY}"
 
   publish-to-pypi:
     name: Publish Avocado to PyPI


### PR DESCRIPTION
This will additionally display the updated text on pages like https://github.com/avocado-framework/avocado/actions/runs/11215982471.

Here's an example of how job summaries are displayed: https://github.com/ansible/awx-plugins/actions/runs/10793404435#summary-29935289633.