### PR TITLE
docs: improve 'all' stream and 'full.log' docs

### DIFF
--- a/docs/source/guides/user/chapters/logging.rst
+++ b/docs/source/guides/user/chapters/logging.rst
@@ -49,6 +49,9 @@ from all tests in one place.
 .. note:: You have to specify separated logging streams. You can't use the
  built-in streams in this function.
 
+.. note:: There's a special stream 'all' that let's you store all streams into the
+          ``full.log`` file in the job result directory.
+
 
 .. _avocado-log-files:
 

--- a/docs/source/guides/writer/chapters/logging.rst
+++ b/docs/source/guides/writer/chapters/logging.rst
@@ -154,7 +154,7 @@ The very same ``avocado.test.progress`` logger, could be used across multiple te
 and across multiple test modules.
 
 By default avocado is creating ``full.log`` file in job_log directory with
-all avocado logs which were created during the job run::
+all avocado logs which were created during the job run, ie. ``--store-logging-stream=all`` is the default if not specified otherwise::
 
      $ avocado run examples/tests/logging_streams.py
 

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -145,6 +145,8 @@ Options for subcommand `run` (`avocado run --help`)::
       --store-logging-stream LOGGING_STREAM
                             Store given logging STREAMs in
                             "$JOB_RESULTS_DIR/$STREAM.$LEVEL".
+                            LOGGING_STREAM=all is the default and will store all logs
+                            into the file "$JOB_RESULTS_DIR/full.log"
       --xunit FILE          Enable xUnit result format and write it to FILE. Use
                             "-" to redirect to the standard output.
       --disable-xunit-job-result


### PR DESCRIPTION
Add a few sentences that hopefully help to understand which file to look into for the 'legacy' behavior of the job.log, e.g. in 93lts.