### PR TITLE
Update check_test docstring to clarify state parameter

### DIFF
--- a/avocado/core/result.py
+++ b/avocado/core/result.py
@@ -100,7 +100,8 @@ class Result:
         """
         Called once for a test to check status and report.
 
-        :param test: A dict with test internal state
+        :param state: result of :class:`avocado.core.test.Test.get_state`.
+        :type state: dict
         """
         status = state.get("status")
         if status == "PASS":

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -521,7 +521,6 @@ class Settings:
                 "argument or be a positional argument"
             )
 
-        option = None
         try:
             option = self._namespaces[namespace]
         except KeyError:


### PR DESCRIPTION
In https://github.com/avocado-framework/avocado/blob/3b1f5cbbb07ea850498b55aa020d74cc0f7fa15f/avocado/core/result.py#L103

The parameter description of 'test' does not match the parameter 'state'

and

Refactor: Remove unused 'option = None' initialization

Signed-off-by: mikigo <huangmingqiang@uniontech.com>