### PR TITLE
lint: fix one outstanding raise-missing-from / W0707

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -573,7 +573,7 @@ class NetworkInterface:
                     run_command(cmd, self.host, sudo=True)
             except Exception as ex:
                 msg = f"Failed to flush ipaddr. {ex}"
-                raise NWException(msg)
+                raise NWException(msg) from ex
 
     def remove_link(self):
         """Deletes virtual interface link.


### PR DESCRIPTION
This is follow up of 66c549d9f.

Reference: https://pylint.pycqa.org/en/latest/user_guide/messages/warning/raise-missing-from.html