### PR TITLE
Codeclimate removal

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,0 @@
-plugins:
-  bandit:
-    enabled: true
-    config:
-      python_version: 3

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -245,10 +245,6 @@ Build and Quality Status
    :target: https://copr.fedorainfracloud.org/coprs/g/avocado/avocado-latest/package/python-avocado/
    :alt: Copr build
 
-.. image:: https://api.codeclimate.com/v1/badges/03f506164e1d19f95480/maintainability
-   :target: https://codeclimate.com/github/avocado-framework/avocado/maintainability
-   :alt: Code Climate Maintainability
-
 .. image:: https://readthedocs.org/projects/avocado-framework/badge/?version=latest
    :target: https://avocado-framework.readthedocs.io/en/latest/
    :alt: Documentation Status


### PR DESCRIPTION
Since codeclimate check hasn't been accurate and often creates false positive, the positives of having such tool is much lower that the negative impact on PRs. Therefore, this PR removes all occurrences of codeclimate code from Avocado.