### PR TITLE
Avocado instrumented timeout handling in thread

### DIFF
--- a/examples/tests/external_logging_stream.py
+++ b/examples/tests/external_logging_stream.py
@@ -1,3 +1,4 @@
+import matplotlib
 import matplotlib.pyplot as plt
 
 from avocado import Test
@@ -5,6 +6,7 @@ from avocado import Test
 
 class MatplotlibTest(Test):
     def test(self):
+        matplotlib.use("agg")
         _, ax = plt.subplots()
 
         fruits = ["apple", "blueberry", "cherry", "orange"]

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -29,7 +29,7 @@ TEST_SIZE = {
     "nrunner-requirement": 28,
     "unit": 682,
     "jobs": 11,
-    "functional-parallel": 317,
+    "functional-parallel": 318,
     "functional-serial": 7,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,

--- a/selftests/functional/plugin/runners/avocado_instrumented.py
+++ b/selftests/functional/plugin/runners/avocado_instrumented.py
@@ -1,7 +1,29 @@
+import json
+import os
+
 from avocado import Test
 from avocado.core.exit_codes import AVOCADO_JOB_INTERRUPTED
-from avocado.utils import process
+from avocado.utils import process, script
 from selftests.utils import AVOCADO, TestCaseTmpDir
+
+TIMEOU_TEST_WITH_EXCEPTION = """
+import time
+
+from avocado import Test
+
+class TimeoutTest(Test):
+
+    timeout = 3
+
+    def test(self):
+        try:
+            time.sleep(5)
+        except Exception:
+            pass
+
+    def tearDown(self):
+        self.log.info("TearDown")
+"""
 
 
 class AvocadoInstrumentedRunnerTest(TestCaseTmpDir, Test):
@@ -16,3 +38,30 @@ class AvocadoInstrumentedRunnerTest(TestCaseTmpDir, Test):
             "examples/tests/timeouttest.py:TimeoutTest.test:  INTERRUPTED: Test interrupted: Timeout reached",
             result.stdout_text,
         )
+
+    def test_timeout_with_exception(self):
+        with script.TemporaryScript(
+            "test_timeout.py",
+            TIMEOU_TEST_WITH_EXCEPTION,
+            "avocado_timeout_test",
+        ) as tst:
+            res = process.run(
+                (
+                    f"{AVOCADO} run --disable-sysinfo "
+                    f"--job-results-dir {self.tmpdir.name} {tst} "
+                    f"--json -"
+                ),
+                ignore_status=True,
+            )
+            results = json.loads(res.stdout_text)
+            self.assertIn(
+                "Test interrupted: Timeout reached",
+                results["tests"][0]["fail_reason"],
+            )
+            debug_log_path = results["tests"][0]["logfile"]
+            self.assertTrue(os.path.exists(debug_log_path))
+            with open(debug_log_path, encoding="utf-8") as file:
+                self.assertIn(
+                    "INFO | TearDown",
+                    file.read(),
+                )


### PR DESCRIPTION
This commit changes the way how avocado instrumented runner handles test timeouts.  For timeout handling, we used to use signals and raising TestInterrupt error. Such solution has an issue that we can't control where in the code the Error will be raised, and it can be handled before it reaches the runner layer. More info about this issue in #6046.

This change removes the signal handling and uses threading instead. Now each test method will be run in a separated thread and this thread will be terminated if timeout is reached. This solution selves the raising error issue and keeps the current test lifecycle untouched.

Reference: #6046