### PR TITLE
VMimage get --debug option

### DIFF
--- a/selftests/check.py
+++ b/selftests/check.py
@@ -29,7 +29,7 @@ TEST_SIZE = {
     "nrunner-requirement": 28,
     "unit": 678,
     "jobs": 11,
-    "functional-parallel": 313,
+    "functional-parallel": 314,
     "functional-serial": 7,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,

--- a/selftests/functional/plugin/vmimage.py
+++ b/selftests/functional/plugin/vmimage.py
@@ -81,6 +81,17 @@ class VMImagePlugin(unittest.TestCase):
         result = process.run(cmd_line)
         self.assertIn(expected_output, result.stdout_text)
 
+    def test_get_debug(self):
+        cmd_line = (
+            f"{AVOCADO} --config {self.config_file.name} vmimage "
+            f"get --debug --distro=SHOULD_NEVER_EXIST --arch zzz_64"
+        )
+        result = process.run(cmd_line, ignore_status=True)
+        self.assertEqual(result.exit_status, exit_codes.AVOCADO_FAIL)
+        self.assertIn(
+            "Provider for should_never_exist not available", result.stdout_text
+        )
+
     def tearDown(self):
         self.base_dir.cleanup()
 


### PR DESCRIPTION
This commit adds a new option to `vmimage get` feature called `debug`. It brings possibility to run vmimage command in debug mode to get more detailed information about possible failures. In debug mode, all exceptions caused by vmimage utility will be raised to console. That should provide enough information for further debugging of possible issues.

Reference: #6051

---
`vmimage get` without debug:
```
$ avocado vmimage get --distro Fedora --distro-version 2 
The requested image could not be downloaded

```
`vmimage get` with debug:
```
$ avocado vmimage get --distro Fedora --distro-version 2 --debug
avocado.utils.vmimage: Version not available at https://dl.fedoraproject.org/pub/fedora/linux/releases/
The requested image could not be downloaded
```