### PR TITLE
avocado-instrumented/python-unittest resolvers: improve fail message

### DIFF
--- a/avocado/core/resolver.py
+++ b/avocado/core/resolver.py
@@ -187,7 +187,7 @@ def check_file(
             return ReferenceResolution(
                 reference,
                 ReferenceResolutionResult.NOTFOUND,
-                info=f'File "{path}" does not end with "{suffix}"',
+                info=f'File name "{path}" does not end with suffix "{suffix}"',
             )
 
     if not type_check(path):

--- a/docs/source/guides/contributor/chapters/plugins.rst
+++ b/docs/source/guides/contributor/chapters/plugins.rst
@@ -373,18 +373,18 @@ list magic:pass magic:fail magic:foo something-else``::
   magic magic:fail
 
   Resolver             Reference      Info
-  avocado-instrumented magic:pass     File "magic" does not end with ".py"
+  avocado-instrumented magic:pass     File name "magic" does not end with suffix ".py"
   golang               magic:pass     go binary not found
-  avocado-instrumented magic:fail     File "magic" does not end with ".py"
+  avocado-instrumented magic:fail     File name "magic" does not end with suffix ".py"
   golang               magic:fail     go binary not found
-  avocado-instrumented magic:foo    File "magic" does not end with ".py"
+  avocado-instrumented magic:foo    File name "magic" does not end with suffix ".py"
   golang               magic:foo    go binary not found
   magic                magic:foo    Word "magic:foo" is magic type but the foo is not a valid magic word
-  avocado-instrumented something-else File "something-else" does not end with ".py"
+  avocado-instrumented something-else File name "something-else" does not end with suffix ".py"
   golang               something-else go binary not found
   magic                something-else Word "something-else" is not a valid magic word
-  python-unittest      something-else File "something-else" does not end with ".py"
-  robot                something-else File "something-else" does not end with ".robot"
+  python-unittest      something-else File name "something-else" does not end with suffix ".py"
+  robot                something-else File name "something-else" does not end with suffix ".robot"
   rogue                something-else Word "something-else" is not the magic word
   exec-test            something-else File "something-else" does not exist or is not a executable file
   tap                  something-else File "something-else" does not exist or is not a executable file

--- a/docs/source/guides/user/chapters/operations.rst
+++ b/docs/source/guides/user/chapters/operations.rst
@@ -191,16 +191,16 @@ tests::
     Type Test Tag(s)
 
     Resolver             Reference                                Info
-    avocado-instrumented examples/gdb-prerun-scripts/README       File "examples/gdb-prerun-scripts/README" does not end with ".py"
+    avocado-instrumented examples/gdb-prerun-scripts/README       File name "examples/gdb-prerun-scripts/README" does not end with suffix ".py"
     exec-test            examples/gdb-prerun-scripts/README       File "examples/gdb-prerun-scripts/README" does not exist or is not executable
     golang               examples/gdb-prerun-scripts/README
-    python-unittest      examples/gdb-prerun-scripts/README       File "examples/gdb-prerun-scripts/README" does not end with ".py"
+    python-unittest      examples/gdb-prerun-scripts/README       File name "examples/gdb-prerun-scripts/README" does not end with suffix ".py"
     robot                examples/gdb-prerun-scripts/README       File "examples/gdb-prerun-scripts/README" does not end with ".robot"
     tap                  examples/gdb-prerun-scripts/README       File "examples/gdb-prerun-scripts/README" does not exist or is not executable
-    avocado-instrumented examples/gdb-prerun-scripts/pass-sigusr1 File "examples/gdb-prerun-scripts/pass-sigusr1" does not end with ".py"
+    avocado-instrumented examples/gdb-prerun-scripts/pass-sigusr1 File name "examples/gdb-prerun-scripts/pass-sigusr1" does not end with suffix ".py"
     exec-test            examples/gdb-prerun-scripts/pass-sigusr1 File "examples/gdb-prerun-scripts/pass-sigusr1" does not exist or is not executable
     golang               examples/gdb-prerun-scripts/pass-sigusr1
-    python-unittest      examples/gdb-prerun-scripts/pass-sigusr1 File "examples/gdb-prerun-scripts/pass-sigusr1" does not end with ".py"
+    python-unittest      examples/gdb-prerun-scripts/pass-sigusr1 File name "examples/gdb-prerun-scripts/pass-sigusr1" does not end with suffix ".py"
     robot                examples/gdb-prerun-scripts/pass-sigusr1 File "examples/gdb-prerun-scripts/pass-sigusr1" does not end with ".robot"
     tap                  examples/gdb-prerun-scripts/pass-sigusr1 File "examples/gdb-prerun-scripts/pass-sigusr1" does not exist or is not executable
 

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -538,8 +538,8 @@ resolution details::
     $ avocado -V list null
     ...
     Resolver             Reference Info
-    avocado-instrumented null      File "null" does not end with ".py"
-    python-unittest      null      File "null" does not end with ".py"
+    avocado-instrumented null      File name "null" does not end with suffix ".py"
+    python-unittest      null      File name "null" does not end with suffix ".py"
     exec-test            null      File "null" does not exist or is not a executable file
     tap                  null      File "null" does not exist or is not a executable file
     ...

--- a/optional_plugins/golang/README.rst
+++ b/optional_plugins/golang/README.rst
@@ -63,7 +63,7 @@ Then you can ``list`` and ``run`` the countavocados tests provided with the plug
     golang countavocados:ExampleContainers
 
     Resolver             Reference     Info
-    avocado-instrumented countavocados File "countavocados" does not end with ".py"
+    avocado-instrumented countavocados File name "countavocados" does not end with suffix ".py"
     exec-test            countavocados File "countavocados" does not exist or is not a executable file
 
     TEST TYPES SUMMARY


### PR DESCRIPTION
The message given by the avocado-instrumented and python-unittest resolvers, resolvers that share a lot of code and require Python files, can be made clearer.

One of the earliest checks performed is about the file *name* and its *suffix*, and not necessarily about an actual file (that exists). Even though the concepts are pretty close, let's make it clear that these resolvers are rejecting the references given based on the ".py" suffix not existing in the file name, and not necessarily, at that time, rejecting it based on an actual existing file.