### PR TITLE
avocado.utils.kernel: fix kernel version parsing

### DIFF
--- a/avocado/utils/kernel.py
+++ b/avocado/utils/kernel.py
@@ -20,13 +20,9 @@ Provides utilities for the Linux kernel.
 import logging
 import multiprocessing
 import os
+import re
 import shutil
 import tempfile
-
-try:
-    import packaging
-except ImportError:
-    from pkg_resources import packaging
 
 from avocado.utils import archive, asset, build, distro, process
 
@@ -201,6 +197,14 @@ class KernelBuild:
         shutil.rmtree(self.work_dir)
 
 
+def _parse_kernel_version(version):
+    match = re.match(r"(\d+)\.(\d+)\.(\d+)-(\d+).*", version)
+    if match:
+        return tuple(map(int, match.groups()))
+    else:
+        raise AssertionError(f'Malformed kernel version "{version}"')
+
+
 def check_version(version):
     """
     This utility function compares the current kernel version with
@@ -210,6 +214,6 @@ def check_version(version):
     :type version: string
     :param version: version to be compared with current kernel version
     """
-    os_version = packaging.version.parse(os.uname()[2])
-    version = packaging.version.parse(version)
+    os_version = _parse_kernel_version(os.uname()[2])
+    version = _parse_kernel_version(version)
     assert os_version > version, "Old kernel"

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-7": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
-    "unit": 678,
+    "unit": 681,
     "jobs": 11,
     "functional-parallel": 314,
     "functional-serial": 7,

--- a/selftests/unit/utils/kernel.py
+++ b/selftests/unit/utils/kernel.py
@@ -1,6 +1,6 @@
 import unittest
 
-from avocado.utils.kernel import KernelBuild
+from avocado.utils.kernel import KernelBuild, _parse_kernel_version
 from selftests.utils import setup_avocado_loggers
 
 setup_avocado_loggers()
@@ -25,3 +25,15 @@ class TestKernelBuild(unittest.TestCase):
     def tearDown(self):
         # To make sure that the temporary workdir is cleaned up
         del self.kernel
+
+
+class Version(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(_parse_kernel_version("1.2.3-100"), (1, 2, 3, 100))
+
+    def test_uname(self):
+        self.assertEqual(_parse_kernel_version("9.0.1-100.fc50.x86_64"), (9, 0, 1, 100))
+
+    def test_malformed_incomplete(self):
+        with self.assertRaises(AssertionError):
+            _parse_kernel_version("1.2")


### PR DESCRIPTION
This fixes two problems with the current version parse mechanism:

 1. Recent setuptools' version parse function, which has dropped "LegacyVersion" support, raises an InvalidVersion exception for common kernel version info as presented by the system and returned by os.uname()

 2. The import of the packaging module is broken on systems with no setuptools and only the "packaging" module.

This introduces a simple but custom version parse that solves both and simplifies dependencies.

Fixes: https://github.com/avocado-framework/avocado/issues/6058