### PR TITLE
PyYAML and Python 3.7 compatibility

### DIFF
--- a/optional_plugins/varianter_yaml_to_mux/setup.py
+++ b/optional_plugins/varianter_yaml_to_mux/setup.py
@@ -48,7 +48,7 @@ setup(
     url="http://avocado-framework.github.io/",
     packages=packages,
     include_package_data=True,
-    install_requires=[f"avocado-framework=={VERSION}", "PyYAML>=4.2b2"],
+    install_requires=[f"avocado-framework=={VERSION}", "PyYAML<6.0.0"],
     zip_safe=False,
     test_suite="tests",
     entry_points={


### PR DESCRIPTION
PyYAML versions 6.0.0 and later, are not compatible with Python 3.7.

Let's drop the minimal version requirement, which is not needed on current platforms while setting the maximum version to avoid Python 3.7 incompatibilities.

Reference: https://pypi.org/project/PyYAML/5.4.1/