### PR TITLE
Test coverage with multiprocessing fix

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 source = avocado/, optional_plugins/
 concurrency = multiprocessing
+parallel = true

--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -15,7 +15,9 @@ echo "Using coverage utility: $COVERAGE"
 
 $COVERAGE erase
 rm -f .coverage.*
-$COVERAGE run selftests/check.py --skip=static-checks
+echo -e "import coverage\ncoverage.process_startup()" >> sitecustomize.py
+env COVERAGE_PROCESS_START=.coveragerc $COVERAGE run selftests/check.py --skip=static-checks
+rm -f sitecustomize.py
 $COVERAGE combine
 echo
 $COVERAGE report -m --include "avocado/core/*"


### PR DESCRIPTION
The test coverage of avocado gathered by coverage.py. It was not precise, because some of our functional tests were running in sub-processes where the coverage was not enabled. This change it adds `sitecustomize.py` to ensure that coverage will be enabled for all python processes which will run during coverage testing. After this change, the overall test coverage of avocado will increase from 54% to 68%

Reference: https://coverage.readthedocs.io/en/latest/subprocess.html

---
As an example of not working, coverage testing can be #6072. Where the coverage of new runner is 0 even tho the PR introduce its testing.