### PR TITLE
selftests: drop job-api test variant that may exceed sqlite3's own limits

### DIFF
--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -39,7 +39,11 @@ setup(
     url="http://avocado-framework.github.io/",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[f"avocado-framework=={VERSION}", "jinja2", "markupsafe<3.0.0"],
+    install_requires=[
+        f"avocado-framework=={VERSION}",
+        "jinja2",
+        "markupsafe<3.0.0",
+    ],
     entry_points={
         "avocado.plugins.cli": [
             "html = avocado_result_html:HTML",

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -104,6 +104,10 @@ these days a framework) to perform automated testing.
 %if 0%{?rhel}
 sed -e 's/"PyYAML>=4.2b2"/"PyYAML>=3.12"/' -i optional_plugins/varianter_yaml_to_mux/setup.py
 %endif
+%if 0%{?fedora} >= 42
+sed -e '/"markupsafe<3.0.0"/d' -i optional_plugins/html/setup.py
+sed -e '/"markupsafe<3.0.0"/d' -i optional_plugins/ansible/setup.py
+%endif
 %py3_build
 pushd optional_plugins/html
 %py3_build

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -18,13 +18,13 @@ from selftests.utils import python_module_available
 
 TEST_SIZE = {
     "static-checks": 7,
-    "job-api-1": 1,
-    "job-api-2": 1,
-    "job-api-3": 2,
-    "job-api-4": 9,
-    "job-api-5": 12,
-    "job-api-6": 4,
-    "job-api-7": 1,
+    "job-api-check-archive-file-exists": 1,
+    "job-api-check-category-directory-exists": 1,
+    "job-api-check-directory-exists": 2,
+    "job-api-check-file-content": 9,
+    "job-api-check-file-exists": 12,
+    "job-api-check-output-file": 4,
+    "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
     "unit": 681,
@@ -289,7 +289,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
 
     suites.append(
         TestSuite.from_config(
-            config_check_archive_file_exists, f"job-api-{len(suites) + 1}"
+            config_check_archive_file_exists, "job-api-check-archive-file-exists"
         )
     )
 
@@ -306,7 +306,8 @@ def create_suite_job_api(args):  # pylint: disable=W0621
 
     suites.append(
         TestSuite.from_config(
-            config_check_category_directory_exists, f"job-api-{len(suites) + 1}"
+            config_check_category_directory_exists,
+            "job-api-check-category-directory-exists",
         )
     )
 
@@ -334,7 +335,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
 
     suites.append(
         TestSuite.from_config(
-            config_check_directory_exists, f"job-api-{len(suites) + 1}"
+            config_check_directory_exists, "job-api-check-directory-exists"
         )
     )
 
@@ -427,7 +428,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
     }
 
     suites.append(
-        TestSuite.from_config(config_check_file_content, f"job-api-{len(suites) + 1}")
+        TestSuite.from_config(config_check_file_content, "job-api-check-file-content")
     )
 
     # ========================================================================
@@ -525,7 +526,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
         )
 
     suites.append(
-        TestSuite.from_config(config_check_file_exists, f"job-api-{len(suites) + 1}")
+        TestSuite.from_config(config_check_file_exists, "job-api-check-file-exists")
     )
 
     # ========================================================================
@@ -568,7 +569,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
         )
 
     suites.append(
-        TestSuite.from_config(config_check_output_file, f"job-api-{len(suites) + 1}")
+        TestSuite.from_config(config_check_output_file, "job-api-check-output-file")
     )
 
     # ========================================================================
@@ -584,7 +585,7 @@ def create_suite_job_api(args):  # pylint: disable=W0621
 
     suites.append(
         TestSuite.from_config(
-            config_check_tmp_directory_exists, f"job-api-{len(suites) + 1}"
+            config_check_tmp_directory_exists, "job-api-check-tmp-directory-exists"
         )
     )
     return suites

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -22,7 +22,7 @@ TEST_SIZE = {
     "job-api-check-category-directory-exists": 1,
     "job-api-check-directory-exists": 2,
     "job-api-check-file-content": 9,
-    "job-api-check-file-exists": 12,
+    "job-api-check-file-exists": 11,
     "job-api-check-output-file": 4,
     "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 70,
@@ -491,13 +491,6 @@ def create_suite_job_api(args):  # pylint: disable=W0621
                 "value": ["result.xunit"],
                 "file": "result.xml",
                 "assert": False,
-            },
-            # this test needs a huge improvement
-            {
-                "namespace": "run.journal.enabled",
-                "value": True,
-                "file": ".journal.sqlite",
-                "assert": True,
             },
         ],
     }


### PR DESCRIPTION
The sqlite3 module (and actually, even the non-python binary with the same name), have "interesting" limitations when it comes to the database path.
    
When the test that creates the journal file, and checks for it, runs as part of an RPM build, the extra directories (/buildir/...) exceed the path size limit.
    
While it would be possible to check if the "logdir" path, plus the name of the journal database path, would eventually exceed the sqlite3 limits, this logic would be exclusive for one test variant.
    
IMO it does not justify adding such logic to keep a test that has considerably low value.