### PR TITLE
Only pin markupsafe on s390x

### DIFF
--- a/optional_plugins/html/setup.py
+++ b/optional_plugins/html/setup.py
@@ -39,7 +39,11 @@ setup(
     url="http://avocado-framework.github.io/",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[f"avocado-framework=={VERSION}", "jinja2", "markupsafe<3.0.0"],
+    install_requires=[
+        f"avocado-framework=={VERSION}",
+        "jinja2",
+        "markupsafe<3.0.0 ; platform_machine == 's390x'",
+    ],
     entry_points={
         "avocado.plugins.cli": [
             "html = avocado_result_html:HTML",

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -104,6 +104,9 @@ these days a framework) to perform automated testing.
 %if 0%{?rhel}
 sed -e 's/"PyYAML>=4.2b2"/"PyYAML>=3.12"/' -i optional_plugins/varianter_yaml_to_mux/setup.py
 %endif
+%if ! 0%{?fedora} >= 42
+sed -e '/"markupsafe<3.0.0"/d' -i optional_plugins/html/setup.py
+%endif
 %py3_build
 pushd optional_plugins/html
 %py3_build


### PR DESCRIPTION
Commit 634bc1a31 pinned the markupsafe because of installations on s390x only.  It makes sense to limit the pinning to s390x then.

That in itself would be simple enough, but, during RPM builds on Fedora 42 (really rawhide at this time), the RPM package dependency system provides MarkupSafe > 3.0.0 (currently 3.0.2).  So, we remove the pinning, or else, the build would fail due to a version requirement conflict.

Reference: https://github.com/avocado-framework/avocado/issues/6038