### PR TITLE
Add retry for urlopen

### DIFF
--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -44,11 +44,18 @@ def url_open(url, data=None, timeout=5):
     :return: file-like object.
     :raises: `URLError`.
     """
-    try:
-        result = urlopen(url, data=data, timeout=timeout)
-    except (socket.timeout, HTTPError) as ex:
-        msg = f"Failed downloading file: {str(ex)}"
-        log.error(msg)
+    retry_attempt = 0
+    while retry_attempt < 10:
+        try:
+            result = urlopen(url, data=data, timeout=timeout)
+            break
+        except (socket.timeout, HTTPError) as ex:
+            msg = f"Failed downloading file: {str(ex)}"
+            log.error(msg)
+            retry_attempt += 1
+            msg = f"retry attempt: {retry_attempt}"
+            log.debug(msg)
+    if "result" not in locals():
         return None
 
     msg = (


### PR DESCRIPTION
Many a times open url returns 503 errors, handling it by introducing retries.

Before:

```
[stdlog] 2024-12-02 16:42:53,814 avocado.utils.download download         L0096 INFO | Fetching https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/snapshot/master.tar.gz -> /root/avocado/data/cache/by_location/fb1b8783e9b605568767b2ad1c7c4e9a264d1085/kselftest.tar.f5c94290-8910-4763-88d7-8583bf659cd0
[stdlog] 2024-12-02 16:42:59,104 avocado.utils.download download         L0051 ERROR| Failed downloading file: The read operation timed out
[stderr] Failed to get file. Probably timeout was reached when connecting to the server.
[stdlog] 2024-12-02 16:42:59,109 avocado.utils.asset asset            L0165 INFO | Temporary asset file unavailable due to failed download attempt.
```
After:
```
[stdlog] 2024-12-02 02:00:50,228 avocado.utils.asset asset            L0152 DEBUG| Asset not in cache after lock, fetching it.
[stdlog] 2024-12-02 02:00:50,228 avocado.utils.download download         L0101 INFO | Fetching https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/snapshot/master.tar.gz -> /root/avocado/data/cache/by_location/fb1b8783e9b605568767b2ad1c7c4e9a264d1085/kselftest.tar.1a5eab69-aff0-4f99-a111-2f77e9b30f23
[stdlog] 2024-12-02 02:00:55,500 avocado.utils.download download         L0053 ERROR| Failed downloading file: The read operation timed out
[stdlog] 2024-12-02 02:00:55,501 avocado.utils.download download         L0055 DEBUG| retry attempt: 1
[stdlog] 2024-12-02 02:01:00,716 avocado.utils.download download         L0053 ERROR| Failed downloading file: The read operation timed out
[stdlog] 2024-12-02 02:01:00,717 avocado.utils.download download         L0055 DEBUG| retry attempt: 2
[stdlog] 2024-12-02 02:01:05,813 avocado.utils.download download         L0053 ERROR| Failed downloading file: The read operation timed out
[stdlog] 2024-12-02 02:01:05,813 avocado.utils.download download         L0055 DEBUG| retry attempt: 3
[stdlog] 2024-12-02 02:01:05,814 avocado.utils.download download         L0063 DEBUG| Opened URL "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/snapshot/master.tar.gz" and received response with headers including: content-length UNKNOWN, date: "Sun, 01 Dec 2024 20:31:16 GMT", last-modified: "Sun, 01 Dec 2024 20:31:06 GMT"
```