### PR TITLE
Fix image pattern for FedoraSecondary provider on s390x

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -235,7 +235,10 @@ class FedoraImageProvider(FedoraImageProviderBase):
         self.url_old_images = (
             "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/"
         )
-        self.image_pattern = "Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
+        if int(self.version) >= 40:
+            self.image_pattern = "Fedora-Cloud-Base-Generic-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
+        else:
+            self.image_pattern = "Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
 
 
 class FedoraSecondaryImageProvider(FedoraImageProviderBase):
@@ -254,7 +257,10 @@ class FedoraSecondaryImageProvider(FedoraImageProviderBase):
         self.url_old_images = (
             "https://archives.fedoraproject.org/pub/archive/fedora-secondary/releases/"
         )
-        self.image_pattern = "Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
+        if int(self.version) >= 40:
+            self.image_pattern = "Fedora-Cloud-Base-Generic-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
+        else:
+            self.image_pattern = "Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
 
 
 class CentOSImageProvider(ImageProviderBase):
@@ -585,6 +591,7 @@ class Image:
             cache_dirs = [self.cache_dir]
         else:
             cache_dirs = self.cache_dir
+        LOG.debug("Attempting to download image from URL: %s", self.url)
         asset_path = asset.Asset(
             name=self.url,
             asset_hash=self.checksum,
@@ -657,6 +664,9 @@ class Image:
         :returns: Image instance that can provide the image
                   according to the parameters.
         """
+        # Use the current system architecture if arch is not provided
+        if arch is None:
+            arch = DEFAULT_ARCH
         provider = get_best_provider(name, version, build, arch)
 
         if cache_dir is None:

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 70,
     "nrunner-requirement": 28,
-    "unit": 681,
+    "unit": 682,
     "jobs": 11,
     "functional-parallel": 314,
     "functional-serial": 7,

--- a/selftests/unit/utils/vmimage.py
+++ b/selftests/unit/utils/vmimage.py
@@ -508,6 +508,7 @@ class FedoraImageProvider(unittest.TestCase):
 <img src="/icons/folder.gif" alt="[DIR]"> <a href="28/">28/</a>                     2019-09-02 20:37    -
 <img src="/icons/folder.gif" alt="[DIR]"> <a href="29/">29/</a>                     2018-10-26 17:27    -
 <img src="/icons/folder.gif" alt="[DIR]"> <a href="30/">30/</a>                     2019-04-26 20:58    -
+<img src="/icons/folder.gif" alt="[DIR]"> <a href="40/">40/</a>                     2023-04-26 20:58    -
 <img src="/icons/folder.gif" alt="[DIR]"> <a href="7/">7/</a>                      2016-05-21 03:28    -
 <img src="/icons/folder.gif" alt="[DIR]"> <a href="8/">8/</a>                      2016-05-21 02:12    -
 <img src="/icons/folder.gif" alt="[DIR]"> <a href="9/">9/</a>                      2013-04-25 08:48    -
@@ -516,16 +517,32 @@ class FedoraImageProvider(unittest.TestCase):
 </body></html>"""
 
     @unittest.mock.patch("avocado.utils.vmimage.urlopen")
-    def test_get_image_parameters_match(self, urlopen_mock):
+    def test_get_image_parameters_match_pre_40(self, urlopen_mock):
         expected_version = "30"
         expected_arch = "x86_64"
         expected_build = "1234"
         urlread_mocked = unittest.mock.Mock(return_value=self.VERSION_LISTING)
         urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
         provider = vmimage.FedoraImageProvider(
-            expected_version, expected_build, expected_arch
+            version=expected_version, build=expected_build, arch=expected_arch
         )
         image = f"Fedora-Cloud-Base-{expected_version}-{expected_build}.{expected_arch}.qcow2"
+        parameters = provider.get_image_parameters(image)
+        self.assertEqual(expected_version, parameters["version"])
+        self.assertEqual(expected_build, parameters["build"])
+        self.assertEqual(expected_arch, parameters["arch"])
+
+    @unittest.mock.patch("avocado.utils.vmimage.urlopen")
+    def test_get_image_parameters_match_post_40(self, urlopen_mock):
+        expected_version = "40"
+        expected_arch = "x86_64"
+        expected_build = "1234"
+        urlread_mocked = unittest.mock.Mock(return_value=self.VERSION_LISTING)
+        urlopen_mock.return_value = unittest.mock.Mock(read=urlread_mocked)
+        provider = vmimage.FedoraImageProvider(
+            version=expected_version, build=expected_build, arch=expected_arch
+        )
+        image = f"Fedora-Cloud-Base-Generic-{expected_version}-{expected_build}.{expected_arch}.qcow2"
         parameters = provider.get_image_parameters(image)
         self.assertEqual(expected_version, parameters["version"])
         self.assertEqual(expected_build, parameters["build"])
@@ -573,6 +590,7 @@ class FedoraImageProvider(unittest.TestCase):
                 28,
                 29,
                 30,
+                40,
                 7,
                 8,
                 9,


### PR DESCRIPTION
Updated the image pattern in FedoraSecondaryImageProvider to match the available Fedora image file names for the s390x architecture. This resolves the issue where the vmimage utility could not download the correct image due to a pattern mismatch.

Reference: https://github.com/avocado-framework/avocado/issues/6071