### PR TITLE
resultsdb-api support on 3.8 fix

### DIFF
--- a/optional_plugins/resultsdb/setup.py
+++ b/optional_plugins/resultsdb/setup.py
@@ -47,7 +47,11 @@ setup(
     url="http://avocado-framework.github.io/",
     packages=packages,
     include_package_data=True,
-    install_requires=[f"avocado-framework=={VERSION}", "resultsdb-api==2.1.5"],
+    install_requires=[
+        f"avocado-framework=={VERSION}",
+        "resultsdb-api==2.1.5",
+        "urllib3<2.3.0; python_version < '3.9'",
+    ],
     entry_points={
         "avocado.plugins.cli": [
             "resultsdb = avocado_resultsdb.resultsdb:ResultsdbCLI",


### PR DESCRIPTION
The resultsdb-api uses urllib as dependency. The urllib dropped support for the python 3.8 in the version 2.3.0. Let's use older version of urllib to keep python 3.8 support for resultsdb plugin.

Reference:
https://urllib3.readthedocs.io/en/stable/changelog.html#deprecations-and-removals

---
This is a fix for CI failures like [this one](https://github.com/avocado-framework/avocado/actions/runs/12584819073/job/35075262308?pr=6072#step:6:915).