### PR TITLE
avocado-pre-release pip install

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
       - name: Install avocado
         run: |
-          sudo python3 -m pip install -r requirements-dev.txt
+          pip install -r requirements-dev.txt
           python3 setup.py develop --user
       - name: Avocado pre-release job
         run: ./selftests/pre_release/jobs/pre_release.py


### PR DESCRIPTION
After the update in github CI runner the avocado install will fail with `Cannot uninstall jsonschema 4.10.3, RECORD file not found. Hint: The package was installed by debian.` This is caused by cached python packages in the runner. Running the pip as standalone app instead of a python module will fix this issue.

Reference:
https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250105.1 https://github.com/avocado-framework/avocado/actions/runs/12706808734/job/35421314652#step:3:93

---
The working CI with the fix can be seen [here](https://github.com/richtja/avocado/actions/runs/12707646975/job/35422989338#step:3:1).