### PR TITLE
Suspend execution of tasks 

### DIFF
--- a/avocado/core/app.py
+++ b/avocado/core/app.py
@@ -25,7 +25,6 @@ from avocado.core.dispatcher import CLICmdDispatcher, CLIDispatcher
 from avocado.core.output import STD_OUTPUT
 from avocado.core.parser import Parser
 from avocado.core.settings import settings
-from avocado.utils import process
 
 
 class AvocadoApp:
@@ -90,13 +89,6 @@ class AvocadoApp:
 
     @staticmethod
     def _setup_signals():
-        def sigterm_handler(signum, frame):  # pylint: disable=W0613
-            children = process.get_children_pids(os.getpid())
-            for child in children:
-                process.kill_process_tree(int(child))
-            raise SystemExit("Terminated")
-
-        signal.signal(signal.SIGTERM, sigterm_handler)
         if hasattr(signal, "SIGTSTP"):
             signal.signal(signal.SIGTSTP, signal.SIG_IGN)  # ignore ctrl+z
 

--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -376,6 +376,28 @@ class Spawner(Plugin):
         :rtype: bool
         """
 
+    async def stop_task(self, runtime_task):
+        """Stop already spawned task.
+
+        :param runtime_task: wrapper for a Task with additional runtime
+                             information.
+        :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
+        :returns: whether the task has been stopped or not.
+        :rtype: bool
+        """
+        raise NotImplementedError()
+
+    async def resume_task(self, runtime_task):
+        """Resume already stopped task.
+
+        :param runtime_task: wrapper for a Task with additional runtime
+                             information.
+        :type runtime_task: :class:`avocado.core.task.runtime.RuntimeTask`
+        :returns: whether the task has been resumed or not.
+        :rtype: bool
+        """
+        raise NotImplementedError()
+
     @staticmethod
     @abc.abstractmethod
     async def check_task_requirements(runtime_task):

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -18,6 +18,7 @@ class RuntimeTaskStatus(Enum):
     FAIL_TRIAGE = "FINISHED WITH FAILURE ON TRIAGE"
     FAIL_START = "FINISHED FAILING TO START"
     STARTED = "STARTED"
+    PAUSED = "PAUSED"
 
     @staticmethod
     def finished_statuses():

--- a/avocado/plugins/runners/dry_run.py
+++ b/avocado/plugins/runners/dry_run.py
@@ -18,11 +18,13 @@ class DryRunRunner(BaseRunner):
     name = "dry-run"
     description = "Runner for --dry-run"
 
-    def run(self, runnable):
-        yield self.prepare_status("started")
+    def _run(self, runnable):
         yield self.prepare_status(
             "finished",
-            {"result": "cancel", "fail_reason": "Test cancelled due to " "--dry-run"},
+            {
+                "result": "cancel",
+                "fail_reason": "Test cancelled due to " "--dry-run",
+            },
         )
 
 

--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -161,39 +161,26 @@ class ExecTestRunner(BaseRunner):
 
         return env
 
-    def _run_proc(self, runnable):
+    def _run(self, runnable):
         if runnable.output_dir is not None:
-            stdout = open(os.path.join(runnable.output_dir, "stdout"), "xb")
-            stderr = open(os.path.join(runnable.output_dir, "stderr"), "xb")
+            stdout_pipe = open(os.path.join(runnable.output_dir, "stdout"), "xb")
+            stderr_pipe = open(os.path.join(runnable.output_dir, "stderr"), "xb")
         else:
-            stdout = subprocess.PIPE
-            stderr = subprocess.PIPE
-
-        return subprocess.Popen(
-            [runnable.uri] + list(runnable.args),
-            stdin=subprocess.DEVNULL,
-            stdout=stdout,
-            stderr=stderr,
-            env=self._get_env(runnable),
-        )
-
-    def run(self, runnable):
-        yield self.prepare_status("started")
+            stdout_pipe = subprocess.PIPE
+            stderr_pipe = subprocess.PIPE
 
         try:
-            process = self._run_proc(runnable)
-        except Exception as e:
-            yield self.prepare_status(
-                "finished", {"result": "error", "fail_reason": str(e)}
+            process = subprocess.Popen(
+                [runnable.uri] + list(runnable.args),
+                stdout=stdout_pipe,
+                stderr=stderr_pipe,
+                env=self._get_env(runnable),
             )
+        except Exception as e:
             self._cleanup(runnable)
-            return
+            raise e
 
-        def poll_proc():
-            return process.poll() is not None
-
-        yield from self.running_loop(poll_proc)
-
+        process.wait()
         if process.stdout is not None:
             stdout = process.stdout.read()
             yield self.prepare_status("running", {"type": "stdout", "log": stdout})

--- a/avocado/plugins/runners/noop.py
+++ b/avocado/plugins/runners/noop.py
@@ -18,8 +18,7 @@ class NoOpRunner(BaseRunner):
         "Sample runner that performs no action before reporting FINISHED status"
     )
 
-    def run(self, runnable):
-        yield self.prepare_status("started")
+    def _run(self, runnable):
         yield self.prepare_status("finished", {"result": "pass"})
 
 

--- a/avocado/plugins/runners/pip.py
+++ b/avocado/plugins/runners/pip.py
@@ -1,11 +1,16 @@
 import sys
-import traceback
 from multiprocessing import set_start_method
 
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.nrunner.runner import BaseRunner
 from avocado.core.utils import messages
 from avocado.utils import process
+
+
+class PipRunnerError(Exception):
+    """
+    Generic error for PipRunner.
+    """
 
 
 class PipRunner(BaseRunner):
@@ -31,40 +36,23 @@ class PipRunner(BaseRunner):
     name = "pip"
     description = "Runner for dependencies of type pip"
 
-    def run(self, runnable):
-        try:
-            yield messages.StartedMessage.get()
-            # check if there is a valid 'action' argument
-            cmd = runnable.kwargs.get("action", "install")
-            # avoid invalid arguments
-            if cmd not in ["install", "uninstall"]:
-                stderr = f"Invalid action {cmd}. Use one of 'install' or 'remove'"
-                yield messages.StderrMessage.get(stderr.encode())
-                yield messages.FinishedMessage.get("error")
-                return
-
-            package = runnable.kwargs.get("name")
-            # if package was passed correctly, run python -m pip
-            if package is not None:
-                try:
-                    cmd = f"python3 -m ensurepip && python3 -m pip {cmd} {package}"
-                    result = process.run(cmd, shell=True)
-                except Exception as e:
-                    yield messages.StderrMessage.get(str(e))
-                    yield messages.FinishedMessage.get("error")
-                    return
-
-            yield messages.StdoutMessage.get(result.stdout)
-            yield messages.StderrMessage.get(result.stderr)
-            yield messages.FinishedMessage.get("pass")
-        except Exception as e:
-            yield messages.StderrMessage.get(traceback.format_exc())
-            yield messages.FinishedMessage.get(
-                "error",
-                fail_reason=str(e),
-                fail_class=e.__class__.__name__,
-                traceback=traceback.format_exc(),
+    def _run(self, runnable):
+        # check if there is a valid 'action' argument
+        cmd = runnable.kwargs.get("action", "install")
+        # avoid invalid arguments
+        if cmd not in ["install", "uninstall"]:
+            raise PipRunnerError(
+                f"Invalid action {cmd}. Use one of 'install' or 'remove'"
             )
+
+        package = runnable.kwargs.get("name")
+        # if package was passed correctly, run python -m pip
+        if package is not None:
+            cmd = f"python3 -m ensurepip && python3 -m pip {cmd} {package}"
+            result = process.run(cmd, shell=True)
+        yield messages.StdoutMessage.get(result.stdout)
+        yield messages.StderrMessage.get(result.stderr)
+        yield messages.FinishedMessage.get("pass")
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/runners/podman_image.py
+++ b/avocado/plugins/runners/podman_image.py
@@ -1,11 +1,10 @@
 import asyncio
 import logging
 import sys
-import time
-from multiprocessing import Process, SimpleQueue, set_start_method
+from multiprocessing import set_start_method
 
 from avocado.core.nrunner.app import BaseRunnerApp
-from avocado.core.nrunner.runner import RUNNER_RUN_STATUS_INTERVAL, BaseRunner
+from avocado.core.nrunner.runner import BaseRunner
 from avocado.core.utils import messages
 from avocado.utils.podman import AsyncPodman, PodmanException
 
@@ -27,39 +26,25 @@ class PodmanImageRunner(BaseRunner):
     name = "podman-image"
     description = f"Runner for dependencies of type {name}"
 
-    def _run_podman_pull(self, uri, queue):
+    def _run(self, runnable):
         # Silence the podman utility from outputting messages into
         # the regular handler, which will go to stdout.  The
         # exceptions caught here still contain all the needed
         # information for debugging in case of errors.
-        logging.getLogger("avocado.utils.podman").addHandler(logging.NullHandler())
-        try:
-            podman = AsyncPodman()
-            loop = asyncio.get_event_loop()
-            loop.run_until_complete(podman.execute("pull", uri))
-            queue.put({"result": "pass"})
-        except PodmanException as ex:
-            queue.put(
-                {"result": "fail", "fail_reason": f"Could not pull podman image: {ex}"}
-            )
-
-    def run(self, runnable):
-        yield messages.StartedMessage.get()
-
         if not runnable.uri:
             reason = "uri identifying the podman image is required"
             yield messages.FinishedMessage.get("error", reason)
         else:
-            queue = SimpleQueue()
-            process = Process(target=self._run_podman_pull, args=(runnable.uri, queue))
-            process.start()
-            while queue.empty():
-                time.sleep(RUNNER_RUN_STATUS_INTERVAL)
-                yield messages.RunningMessage.get()
-
-            output = queue.get()
-            result = output.pop("result")
-            yield messages.FinishedMessage.get(result, **output)
+            logging.getLogger("avocado.utils.podman").addHandler(logging.NullHandler())
+            try:
+                podman = AsyncPodman()
+                loop = asyncio.get_event_loop()
+                loop.run_until_complete(podman.execute("pull", runnable.uri))
+                yield messages.FinishedMessage.get(result="pass")
+            except PodmanException as ex:
+                yield messages.FinishedMessage.get(
+                    result="fail", fail_reason=f"Could not pull podman image: {ex}"
+                )
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/runners/sysinfo.py
+++ b/avocado/plugins/runners/sysinfo.py
@@ -1,15 +1,9 @@
 import multiprocessing
 import os
 import sys
-import time
-import traceback
 
 from avocado.core.nrunner.app import BaseRunnerApp
-from avocado.core.nrunner.runner import (
-    RUNNER_RUN_CHECK_INTERVAL,
-    RUNNER_RUN_STATUS_INTERVAL,
-    BaseRunner,
-)
+from avocado.core.nrunner.runner import BaseRunner
 from avocado.core.utils import messages
 from avocado.utils import sysinfo as sysinfo_collectible
 from avocado.utils.software_manager import manager
@@ -25,7 +19,7 @@ class PreSysInfo:
 
     sysinfo_dir = os.path.join("sysinfo", "pre")
 
-    def __init__(self, config, sysinfo_config, queue):
+    def __init__(self, config, sysinfo_config):
         """
         Set sysinfo collectibles.
 
@@ -38,7 +32,6 @@ class PreSysInfo:
         :type queue: multiprocessing.SimpleQueue
         """
         self.config = config
-        self.queue = queue
         self.log_packages = self.config.get("sysinfo.collect.installed_packages")
         self.timeout = self.config.get("sysinfo.collect.commands_timeout")
         self.locale = self.config.get("sysinfo.collect.locale")
@@ -62,34 +55,29 @@ class PreSysInfo:
         for filename in self.sysinfo_config.get("files", []):
             self.collectibles.add(sysinfo_collectible.Logfile(filename))
 
-    def _save_sysinfo(self, log_hook):
-        try:
-            file_path = os.path.join(self.sysinfo_dir, log_hook.name)
-            for data in log_hook.collect():
-                self.queue.put(messages.FileMessage.get(data, file_path))
-        except sysinfo_collectible.CollectibleException as e:
-            self.queue.put(messages.LogMessage.get(e.args[0]))
-        except Exception as exc:  # pylint: disable=W0703
-            self.queue.put(
-                messages.StderrMessage.get(
-                    f"Collection " f"{type(log_hook)} " f"failed: {exc}"
-                )
-            )
-
     def collect(self):
         """Log all collectibles at the start of the event."""
         self._set_collectibles()
         for log_hook in self.collectibles:
-            self._save_sysinfo(log_hook)
+            try:
+                file_path = os.path.join(self.sysinfo_dir, log_hook.name)
+                for data in log_hook.collect():
+                    yield messages.FileMessage.get(data, file_path)
+            except sysinfo_collectible.CollectibleException as e:
+                yield messages.LogMessage.get(e.args[0])
+            except Exception as exc:  # pylint: disable=W0703
+                yield messages.StderrMessage.get(
+                    f"Collection " f"{type(log_hook)} " f"failed: {exc}"
+                )
 
         if self.log_packages:
-            self._log_packages(self.sysinfo_dir)
-        self.queue.put(messages.FinishedMessage.get("pass"))
+            yield self._log_packages(self.sysinfo_dir)
+        yield messages.FinishedMessage.get("pass")
 
     def _log_packages(self, path):
         installed_path = os.path.join(path, "installed_packages")
         installed_packages = "\n".join(self.installed_pkgs) + "\n"
-        self.queue.put(messages.FileMessage.get(installed_packages, installed_path))
+        return messages.FileMessage.get(installed_packages, installed_path)
 
 
 class PostSysInfo(PreSysInfo):
@@ -102,13 +90,13 @@ class PostSysInfo(PreSysInfo):
 
     sysinfo_dir = os.path.join("sysinfo", "post")
 
-    def __init__(self, config, sysinfo_config, queue, test_fail=False):
+    def __init__(self, config, sysinfo_config, test_fail=False):
         """
         :param test_fail: flag for fail tests. Default False
         :type test_fail: bool
         """
         self.test_fail = test_fail
-        super().__init__(config, sysinfo_config, queue)
+        super().__init__(config, sysinfo_config)
 
     def _set_collectibles(self):
         super()._set_collectibles()
@@ -146,13 +134,11 @@ class SysinfoRunner(BaseRunner):
         "sysinfo.collect.locale",
     ]
 
-    def run(self, runnable):
+    def _run(self, runnable):
         # pylint: disable=W0201
-        self.runnable = runnable
-        yield self.prepare_status("started")
-        sysinfo_config = self.runnable.kwargs.get("sysinfo", {})
-        test_fail = self.runnable.kwargs.get("test_fail", False)
-        if self.runnable.uri not in ["pre", "post"]:
+        sysinfo_config = runnable.kwargs.get("sysinfo", {})
+        test_fail = runnable.kwargs.get("test_fail", False)
+        if runnable.uri not in ["pre", "post"]:
             yield messages.StderrMessage.get(
                 f"Unsupported uri "
                 f"{self.runnable.uri}. "
@@ -160,42 +146,12 @@ class SysinfoRunner(BaseRunner):
             )
             yield messages.FinishedMessage.get("error")
 
-        try:
-            queue = multiprocessing.SimpleQueue()
-            if self.runnable.uri == "pre":
-                sysinfo = PreSysInfo(self.runnable.config, sysinfo_config, queue)
-            else:
-                sysinfo = PostSysInfo(
-                    self.runnable.config, sysinfo_config, queue, test_fail
-                )
-            sysinfo_process = multiprocessing.Process(target=sysinfo.collect)
-
-            sysinfo_process.start()
-
-            most_current_execution_state_time = None
-            while True:
-                time.sleep(RUNNER_RUN_CHECK_INTERVAL)
-                now = time.monotonic()
-                if queue.empty():
-                    if most_current_execution_state_time is not None:
-                        next_execution_state_mark = (
-                            most_current_execution_state_time
-                            + RUNNER_RUN_STATUS_INTERVAL
-                        )
-                    if (
-                        most_current_execution_state_time is None
-                        or now > next_execution_state_mark
-                    ):
-                        most_current_execution_state_time = now
-                        yield messages.RunningMessage.get()
-                else:
-                    message = queue.get()
-                    yield message
-                    if message.get("status") == "finished":
-                        break
-        except Exception:  # pylint: disable=W0703
-            yield messages.StderrMessage.get(traceback.format_exc())
-            yield messages.FinishedMessage.get("error")
+        if self.runnable.uri == "pre":
+            sysinfo = PreSysInfo(self.runnable.config, sysinfo_config)
+        else:
+            sysinfo = PostSysInfo(self.runnable.config, sysinfo_config, test_fail)
+        for message in sysinfo.collect():
+            yield message
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/runners/vmimage.py
+++ b/avocado/plugins/runners/vmimage.py
@@ -1,21 +1,19 @@
 import multiprocessing
-import signal
 import sys
-import time
-import traceback
 from multiprocessing import set_start_method
 
 from avocado.core.exceptions import TestInterrupt
 from avocado.core.nrunner.app import BaseRunnerApp
-from avocado.core.nrunner.runner import (
-    RUNNER_RUN_CHECK_INTERVAL,
-    RUNNER_RUN_STATUS_INTERVAL,
-    BaseRunner,
-)
+from avocado.core.nrunner.runner import BaseRunner
 from avocado.core.utils import messages
-from avocado.core.utils.messages import start_logging
 from avocado.plugins.vmimage import download_image
 from avocado.utils import vmimage
+
+
+class VMImageRunnerError(Exception):
+    """
+    Generic error for VMImageRunner.
+    """
 
 
 class VMImageRunner(BaseRunner):
@@ -31,129 +29,43 @@ class VMImageRunner(BaseRunner):
     name = "vmimage"
     description = "Runner for dependencies of type vmimage"
 
-    @staticmethod
-    def signal_handler(signum, frame):  # pylint: disable=W0613
-        if signum == signal.SIGTERM.value:
-            raise TestInterrupt("VM image operation interrupted: Timeout reached")
-
-    @staticmethod
-    def _run_vmimage_operation(runnable, queue):
+    def _run(self, runnable):
         try:
-            signal.signal(signal.SIGTERM, VMImageRunner.signal_handler)
-            start_logging(runnable.config, queue)
             # Get parameters from runnable.kwargs
             provider = runnable.kwargs.get("provider")
             version = runnable.kwargs.get("version")
             arch = runnable.kwargs.get("arch")
 
             if not provider:
-                stderr = "Missing required parameter: provider"
-                queue.put(messages.StderrMessage.get(stderr.encode()))
-                queue.put(messages.FinishedMessage.get("error"))
-                return
+                raise VMImageRunnerError("Missing required parameter: provider")
 
             message = f"Getting VM image for {provider}"
             if version:
                 message += f" {version}"
             if arch:
                 message += f" {arch}"
-            queue.put(messages.StdoutMessage.get(message.encode()))
+            yield messages.StdoutMessage.get(message.encode())
 
-            queue.put(
-                messages.StdoutMessage.get(
-                    f"Attempting to download image for {provider} (version: {version or 'latest'}, arch: {arch})".encode()
-                )
+            yield messages.StdoutMessage.get(
+                f"Attempting to download image for {provider} (version: {version or 'latest'}, arch: {arch})".encode()
             )
 
             image = download_image(provider, version, arch)
             if not image:
-                raise RuntimeError("Failed to get image")
+                raise VMImageRunnerError("Failed to get image")
 
-            queue.put(
-                messages.StdoutMessage.get(
-                    f"Successfully retrieved VM image from cache or downloaded to: {image['file']}".encode()
-                )
+            yield messages.StdoutMessage.get(
+                f"Successfully retrieved VM image from cache or downloaded to: {image['file']}".encode()
             )
-            queue.put(messages.FinishedMessage.get("pass"))
+            yield messages.FinishedMessage.get("pass")
 
         except (AttributeError, RuntimeError, vmimage.ImageProviderError) as e:
             # AttributeError: provider not found
             # RuntimeError: failed to get image
             # ImageProviderError: provider-specific errors
-            queue.put(
-                messages.StderrMessage.get(
-                    f"Failed to download image: {str(e)}".encode()
-                )
-            )
-            queue.put(
-                messages.FinishedMessage.get(
-                    "error",
-                    fail_reason=str(e),
-                    fail_class=e.__class__.__name__,
-                    traceback=traceback.format_exc(),
-                )
-            )
+            raise VMImageRunnerError(f"Failed to download image: {str(e)}".encode())
         except (TestInterrupt, multiprocessing.TimeoutError) as e:
-            queue.put(
-                messages.StderrMessage.get(f"Operation interrupted: {str(e)}".encode())
-            )
-            queue.put(
-                messages.FinishedMessage.get(
-                    "error",
-                    fail_reason=str(e),
-                    fail_class=e.__class__.__name__,
-                )
-            )
-
-    @staticmethod
-    def _monitor(queue):
-        most_recent_status_time = None
-        while True:
-            time.sleep(RUNNER_RUN_CHECK_INTERVAL)
-
-            if queue.empty():
-                now = time.monotonic()
-                if (
-                    most_recent_status_time is None
-                    or now >= most_recent_status_time + RUNNER_RUN_STATUS_INTERVAL
-                ):
-                    most_recent_status_time = now
-                    yield messages.RunningMessage.get()
-                continue
-
-            message = queue.get()
-            yield message
-            if message.get("status") == "finished":
-                break
-
-    def run(self, runnable):
-        signal.signal(signal.SIGTERM, VMImageRunner.signal_handler)
-        yield messages.StartedMessage.get()
-
-        queue = multiprocessing.SimpleQueue()
-        process = multiprocessing.Process(
-            target=self._run_vmimage_operation, args=(runnable, queue)
-        )
-
-        try:
-            process.start()
-
-            for message in self._monitor(queue):
-                yield message
-
-        except TestInterrupt:
-            process.terminate()
-            for message in self._monitor(queue):
-                yield message
-        except (multiprocessing.ProcessError, OSError) as e:
-            # ProcessError: Issues with process management
-            # OSError: System-level errors (e.g. resource limits)
-            yield messages.StderrMessage.get(f"Process error: {str(e)}".encode())
-            yield messages.FinishedMessage.get(
-                "error",
-                fail_reason=str(e),
-                fail_class=e.__class__.__name__,
-            )
+            raise VMImageRunnerError(f"Operation interrupted: {str(e)}".encode())
 
 
 class RunnerApp(BaseRunnerApp):

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -56,6 +56,7 @@ class ProcessSpawner(Spawner, SpawnerMixin):
             proc = await asyncio.create_subprocess_exec(
                 runner,
                 *args,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
                 env=get_python_path_env_if_egg(),

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import signal
 import socket
 
 from avocado.core.dependencies.requirements import cache
@@ -105,6 +106,16 @@ class ProcessSpawner(Spawner, SpawnerMixin):
             except asyncio.TimeoutError:
                 pass
         return returncode is not None
+
+    async def stop_task(self, runtime_task):
+        try:
+            runtime_task.spawner_handle.process.send_signal(signal.SIGTSTP)
+        except ProcessLookupError:
+            return False
+        return
+
+    async def resume_task(self, runtime_task):
+        await self.stop_task(runtime_task)
 
     @staticmethod
     async def check_task_requirements(runtime_task):

--- a/docs/source/guides/contributor/chapters/tips.rst
+++ b/docs/source/guides/contributor/chapters/tips.rst
@@ -33,6 +33,27 @@ During the execution look for::
 
     avocado --show avocado.utils.debug run examples/tests/assets.py
 
+Interrupting test
+-----------------
+
+In case you want to "pause" the running test, you can use SIGTSTP (ctrl+z)
+signal sent to the main avocado process. This signal is forwarded to test
+and it's children processes. To resume testing you repeat the same signal.
+
+.. note::
+    The job and test timeouts are still enabled on stopped processes. This
+    means that after you restart the test can be killed by the timeout if
+    the timeout was reached. You can use run `-p timeout_factor=$int$` to
+    increase the timeouts for your debugging.
+
+.. note::
+    It is supported by the process spawner only.
+
+.. warning::
+    This feature is meant only for debugging purposes and it can
+    cause unreliable behavior especially if the signal is sent during the
+    test initialization. Therefore use it with caution.
+
 Line-profiler
 -------------
 

--- a/optional_plugins/golang/avocado_golang/runner.py
+++ b/optional_plugins/golang/avocado_golang/runner.py
@@ -29,7 +29,7 @@ class GolangRunner(BaseRunner):
     name = "golang"
     description = "Runner for Golang tests"
 
-    def run(self, runnable):
+    def _run(self, runnable):
         # pylint: disable=W0201
         self.runnable = runnable
         error_msgs = []
@@ -45,7 +45,6 @@ class GolangRunner(BaseRunner):
             )
             return
 
-        yield messages.StartedMessage.get()
         module_test = self.runnable.uri.split(":", 1)
         module = module_test[0]
         try:
@@ -59,15 +58,10 @@ class GolangRunner(BaseRunner):
 
         process = subprocess.Popen(
             cmd,
-            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-
-        def poll_proc():
-            return process.poll() is not None
-
-        yield from self.running_loop(poll_proc)
+        process.wait()
 
         result = "pass" if process.returncode == 0 else "fail"
         yield messages.StdoutMessage.get(process.stdout.read())

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -30,7 +30,7 @@ TEST_SIZE = {
     "unit": 675,
     "jobs": 11,
     "functional-parallel": 315,
-    "functional-serial": 7,
+    "functional-serial": 9,
     "optional-plugins": 0,
     "optional-plugins-golang": 2,
     "optional-plugins-html": 3,

--- a/selftests/functional/runner_package.py
+++ b/selftests/functional/runner_package.py
@@ -27,7 +27,9 @@ class RunnableRun(unittest.TestCase):
         self.assertIn(b"'status': 'started'", res.stdout)
         self.assertIn(b"'status': 'finished'", res.stdout)
         self.assertIn(b"'time': ", res.stdout)
-        self.assertIn(b"'log': b'Package name should be passed as kwargs", res.stdout)
+        self.assertIn(
+            b"PackageRunnerError: Package name should be passed as kwargs", res.stdout
+        )
         self.assertEqual(res.exit_status, 0)
 
     @unittest.skipUnless(

--- a/selftests/functional/serial/basic.py
+++ b/selftests/functional/serial/basic.py
@@ -1,0 +1,97 @@
+import glob
+import os
+import signal
+import sys
+import time
+import unittest
+
+from avocado.utils import process, script
+from selftests.utils import AVOCADO, TestCaseTmpDir
+
+SLEEP_TEST_PYTHON = """import os
+import time
+
+from avocado import Test
+
+
+class SleepTest(Test):
+
+    def test(self):
+        with open(os.path.join(self.logdir, "sleep.txt"), "w") as f:
+            for _ in range(10):
+                f.write("Sleeping \\n")
+                time.sleep(1)
+"""
+
+SLEEP_TEST_EXEC = """#!/bin/bash
+output_file="$AVOCADO_TEST_LOGDIR/sleep.txt"
+for i in {1..10}; do
+    echo "This is line $i" >> "$output_file"
+    sleep 1
+done
+"""
+
+
+@unittest.skipIf(
+    sys.platform.startswith("darwin"),
+    "The test pause feature is not supported on macOS",
+)
+class RunnerOperationTest(TestCaseTmpDir):
+    def _count_lines(self, file_path):
+        with open(os.path.join(file_path, "sleep.txt"), encoding="utf-8") as file:
+            return sum(1 for _ in file)
+
+    def _check_pause(self, tst):
+        cmd_line = f"{AVOCADO} run --disable-sysinfo --job-results-dir {self.tmpdir.name} -- {tst}"
+        proc = process.SubProcess(cmd_line)
+        proc.start()
+        init = True
+        while init:
+            output = proc.get_stdout()
+            if b"STARTED" in output:
+                init = False
+        time.sleep(2)
+        proc.send_signal(signal.SIGTSTP)
+        time.sleep(1)
+        test_log_dir = glob.glob(
+            os.path.join(self.tmpdir.name, "job-*", "test-results", "*")
+        )[0]
+        lines = self._count_lines(test_log_dir)
+        self.assertNotEqual(
+            lines,
+            10,
+            "The test finished before it was paused",
+        )
+        time.sleep(5)
+        self.assertEqual(
+            lines,
+            self._count_lines(test_log_dir),
+            "The test was not paused",
+        )
+        proc.send_signal(signal.SIGTSTP)
+        proc.wait()
+        full_log_path = os.path.join(self.tmpdir.name, "latest", "full.log")
+        with open(full_log_path, encoding="utf-8") as full_log_file:
+            full_log = full_log_file.read()
+        self.assertIn("PAUSED", full_log)
+        self.assertIn("STARTED", full_log)
+        self.assertEqual(
+            self._count_lines(test_log_dir),
+            10,
+            "The test was not resumed",
+        )
+
+    def test_pause_exec(self):
+        with script.TemporaryScript(
+            "sleep.sh",
+            SLEEP_TEST_EXEC,
+        ) as tst_exec:
+            self._check_pause(tst_exec)
+
+    def test_pause_instrumented(self):
+
+        with script.TemporaryScript(
+            "sleep.py",
+            SLEEP_TEST_PYTHON,
+        ) as tst_python:
+            self._check_pause(tst_python)


### PR DESCRIPTION
This PR introduces the suspend execution feature to the nrunner. The
suspend execution was available on the legacy runner, but we didn't move
it to the nrunner. With this feature, it is possible to pause execution
of python based task on process spawner by sending SIGTSTP signal
(ctrl+z). It is helpful for debugging test execution.

Reference: https://github.com/avocado-framework/avocado/issues/6059
Signed-off-by: Jan Richter <jarichte@redhat.com>