### PR TITLE
Python 13 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0]
+        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install setuptools on Python 3.12
+      - name: Install setuptools on Python >= 3.12
         run: python3 -c 'import setuptools' || python3 -m pip install setuptools
       - name: Avocado smokecheck
         run: make smokecheck
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0]
+        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:
@@ -89,7 +89,7 @@ jobs:
         run: python -V --version
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
-      - name: Install setuptools on Python 3.12
+      - name: Install setuptools on Python >= 3.12
         run: python3 -c 'import setuptools' || python3 -m pip install setuptools
       - name: Installing Avocado in develop mode
         run: python3 setup.py develop --user
@@ -153,7 +153,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10.0, 3.11, 3.12.0]
+        python-version: [3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
@@ -165,7 +165,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -V --version
-      - name: Install setuptools on Python 3.12
+      - name: Install setuptools on Python >= 3.12
         run: python -c 'import setuptools' || python -m pip install setuptools
       - name: Install avocado
         run: python setup.py develop --user
@@ -184,7 +184,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0]
+        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:
@@ -193,7 +193,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install setuptools on Python 3.12
+    - name: Install setuptools on Python >= 3.12
       run: python3 -c 'import setuptools' || python3 -m pip install setuptools
     - name: Build tarballs and wheels
       run: make -f Makefile.gh build-wheel check-wheel
@@ -211,7 +211,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0]
+        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:
@@ -220,7 +220,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install setuptools on Python 3.12
+    - name: Install setuptools on Python >= 3.12
       run: python3 -c 'import setuptools' || python3 -m pip install setuptools
     - name: Build eggs
       run: make -f Makefile.gh build-egg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        python-version: [3.8.16, 3.9.16, 3.10.9, 3.11.1, 3.12.0]
+        python-version: [3.8.16, 3.9.16, 3.10.9, 3.11.1, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:

--- a/contrib/scripts/avocado-fetch-eggs.py
+++ b/contrib/scripts/avocado-fetch-eggs.py
@@ -54,7 +54,7 @@ def get_avocado_egg_url(avocado_version=None, python_version=None):
 
 def main():
     configure_logging_settings()
-    for version in ["3.8", "3.9", "3.10", "3.11", "3.12"]:
+    for version in ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]:
         url = get_avocado_egg_url(python_version=version)
         try:
             asset = Asset(url, cache_dirs=CACHE_DIRS)

--- a/setup.py
+++ b/setup.py
@@ -361,6 +361,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
         ],
         packages=find_packages(exclude=("selftests*",)),
         include_package_data=True,


### PR DESCRIPTION
This adds support for testing the coverage of Avocado under Python 3.13, and advertises it as supporting it.

https://github.com/avocado-framework/avocado/issues/6094

Successful CI Run Python 13: https://github.com/harvey0100/avocado/actions/runs/12882448559

Please let me know if the change inside of python-avocado.spec was required.