### PR TITLE
Seltests / Containers / CI: Bump Fedora to 40

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -12,7 +12,7 @@ jobs:
     name: Ansible (${{matrix.extra}})
     runs-on: ubuntu-latest
     container:
-      image: fedora:38
+      image: fedora:40
     env:
       RUN_BEFORE: 'dnf install -y git ansible'
       GIT_URL: 'https://github.com/${{github.repository}}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Static checks
     runs-on: ubuntu-20.04
     container:
-      image: quay.io/avocado-framework/avocado-ci-fedora-38
+      image: quay.io/avocado-framework/avocado-ci-fedora-40
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
@@ -254,12 +254,12 @@ jobs:
           retention-days: 1
       - run: echo "🥑 This job's status is ${{ job.status }}."
 
-  version_task_fedora_37:
+  version_task_fedora_40:
 
-    name: Version task fedora:37
+    name: Version task fedora:40
     runs-on: ubuntu-20.04
     container:
-      image: fedora:37
+      image: fedora:40
     steps:
       - name: Install Python dependencies
         run: dnf -y install python3 python3-setuptools
@@ -267,12 +267,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/version
 
-  version_task_fedora_38:
+  version_task_fedora_41:
 
-    name: Version task fedora:38
+    name: Version task fedora:41
     runs-on: ubuntu-20.04
     container:
-      image: fedora:38
+      image: fedora:41
     steps:
       - name: Install Python dependencies
         run: dnf -y install python3-setuptools
@@ -356,12 +356,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/version
 
-  egg_task_fedora_37:
+  egg_task_fedora_40:
 
-    name: Egg task fedora:37
+    name: Egg task fedora:40
     runs-on: ubuntu-20.04
     container:
-      image: fedora:37
+      image: fedora:40
     steps:
       - name: Install Python dependencies
         run: dnf -y install python3 python3-setuptools
@@ -369,12 +369,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/egg
 
-  egg_task_fedora_38:
+  egg_task_fedora_41:
 
-    name: Egg task fedora:38
+    name: Egg task fedora:41
     runs-on: ubuntu-20.04
     container:
-      image: fedora:38
+      image: fedora:41
     steps:
       - name: Install Python dependencies
         run: dnf -y install python3-setuptools
@@ -471,7 +471,7 @@ jobs:
          python3 setup.py bdist_egg
          mv dist/avocado_framework-*egg /tmp/avocado_framework.egg
          python3 setup.py clean --all
-         python3 -c 'import sys; sys.path.insert(0, "/tmp/avocado_framework.egg"); from avocado.core.main import main; sys.exit(main())' run --spawner=podman --spawner-podman-image=fedora:38 --spawner-podman-avocado-egg=file:///tmp/avocado_framework.egg -- /bin/true
+         python3 -c 'import sys; sys.path.insert(0, "/tmp/avocado_framework.egg"); from avocado.core.main import main; sys.exit(main())' run --spawner=podman --spawner-podman-image=fedora:40 --spawner-podman-avocado-egg=file:///tmp/avocado_framework.egg -- /bin/true
 
   podman_external_runner_task:
 
@@ -498,7 +498,7 @@ jobs:
     name: Fedora develop install/uninstall task
     runs-on: ubuntu-latest
     container:
-      image: fedora:38
+      image: fedora:40
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -520,7 +520,7 @@ jobs:
     name: Fedora selftests
     runs-on: ubuntu-latest
     container:
-      image: quay.io/avocado-framework/avocado-ci-fedora-36
+      image: quay.io/avocado-framework/avocado-ci-fedora-40
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     name: Release pipeline
     runs-on: ubuntu-latest
     container:
-      image: fedora:34
+      image: fedora:40
     env:
       VERSION: ${{ github.event.inputs.version }}
       DEVEL_NAME: ${{ github.event.inputs.devel_name }}

--- a/.packit.yml
+++ b/.packit.yml
@@ -9,7 +9,7 @@ jobs:
       - fedora-all
       - centos-stream-9
       - epel-9
-      - fedora-38-aarch64
-      - fedora-38-ppc64le
-      - fedora-38-s390x
+      - fedora-41-aarch64
+      - fedora-41-ppc64le
+      - fedora-41-s390x
       enable_net: False

--- a/contrib/containers/ci/selftests/check-copr-rpm-version.docker
+++ b/contrib/containers/ci/selftests/check-copr-rpm-version.docker
@@ -2,5 +2,5 @@
 FROM fedora:40
 LABEL description "Fedora image used on COPR RPM version check"
 RUN dnf -y install 'dnf-command(copr)'
-RUN dnf -y copr enable @avocado/avocado-latest
+RUN dnf -y copr enable @avocado/avocado-latest-release
 RUN dnf -y clean all

--- a/contrib/containers/ci/selftests/fedora-40.docker
+++ b/contrib/containers/ci/selftests/fedora-40.docker
@@ -1,6 +1,7 @@
-FROM fedora:38
+FROM fedora:40
 LABEL description "Fedora image used on integration checks"
-RUN dnf -y module enable avocado:latest
+RUN dnf -y install dnf-plugins-core
+RUN dnf -y copr enable @avocado/avocado-latest-release
 RUN dnf -y install dnf-plugins-core git findutils make which
 RUN dnf -y install diffutils python3-isort python3-enchant python3-pylint python3-autopep8
 RUN dnf -y builddep python-avocado

--- a/contrib/containers/ci/selftests/magic.docker
+++ b/contrib/containers/ci/selftests/magic.docker
@@ -4,7 +4,7 @@
 # is by running:
 # $ cd examples/plugins/tests
 # $ buildah bud -f ../../../contrib/containers/ci/selftests/magic.docker
-FROM fedora:38
+FROM fedora:40
 LABEL description "Image that contains the example magic plugin"
 RUN dnf -y install python3-setuptools
 COPY magic /tmp/magic

--- a/contrib/containers/fedora-40-latest-copr.docker
+++ b/contrib/containers/fedora-40-latest-copr.docker
@@ -1,6 +1,6 @@
-FROM fedora:38
+FROM fedora:40
 LABEL description "Fedora image with the latest Avocado COPR build"
 RUN dnf -y install dnf-plugins-core
-RUN dnf -y copr enable @avocado/avocado-latest
+RUN dnf -y copr enable @avocado/avocado-latest-release
 RUN dnf -y install python3-avocado python3-avocado-bash python3-avocado-common python3-avocado-examples python3-avocado-plugins-golang python3-avocado-plugins-output-html python3-avocado-plugins-result-upload python3-avocado-plugins-varianter-cit python3-avocado-plugins-varianter-pict python3-avocado-plugins-varianter-yaml-to-mux
 RUN dnf -y clean all

--- a/docs/source/guides/contributor/chapters/environment.rst
+++ b/docs/source/guides/contributor/chapters/environment.rst
@@ -15,12 +15,12 @@ pretty good starting point for development too (it's actually intended
 to be used on some CI checks, but don't mind that).  You can pull the
 image from::
 
-    quay.io/avocado-framework/avocado-ci-fedora-38
+    quay.io/avocado-framework/avocado-ci-fedora-40
 
 It's a simple image, with just a number of known needed packages
 installed.  This is the full definition of the image:
 
-.. literalinclude:: ../../../../../contrib/containers/ci/selftests/fedora-38.docker
+.. literalinclude:: ../../../../../contrib/containers/ci/selftests/fedora-40.docker
 
 You can use the information there to apply to your own environment if
 you choose not to use the container image itself.

--- a/selftests/functional/utils/podman.py
+++ b/selftests/functional/utils/podman.py
@@ -6,21 +6,21 @@ class PodmanTest(Test):
     def test_python_version(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
-        :avocado: dependency={"type": "podman-image", "uri": "fedora:38"}
+        :avocado: dependency={"type": "podman-image", "uri": "fedora:40"}
         :avocado: tags=slow
         """
         podman = Podman()
-        result = podman.get_python_version("fedora:38")
-        self.assertEqual(result, (3, 11, "/usr/bin/python3"))
+        result = podman.get_python_version("fedora:40")
+        self.assertEqual(result, (3, 12, "/usr/bin/python3"))
 
     def test_container_info(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
-        :avocado: dependency={"type": "podman-image", "uri": "fedora:38"}
+        :avocado: dependency={"type": "podman-image", "uri": "fedora:40"}
         :avocado: tags=slow
         """
         podman = Podman()
-        _, stdout, _ = podman.execute("create", "fedora:38", "/bin/bash")
+        _, stdout, _ = podman.execute("create", "fedora:40", "/bin/bash")
         container_id = stdout.decode().strip()
         result = podman.get_container_info(container_id)
         self.assertEqual(result["Id"], container_id)
@@ -35,21 +35,21 @@ class AsyncPodmanTest(Test):
     async def test_python_version(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
-        :avocado: dependency={"type": "podman-image", "uri": "fedora:38"}
+        :avocado: dependency={"type": "podman-image", "uri": "fedora:40"}
         :avocado: tags=slow
         """
         podman = AsyncPodman()
-        result = await podman.get_python_version("fedora:38")
-        self.assertEqual(result, (3, 11, "/usr/bin/python3"))
+        result = await podman.get_python_version("fedora:40")
+        self.assertEqual(result, (3, 12, "/usr/bin/python3"))
 
     async def test_container_info(self):
         """
         :avocado: dependency={"type": "package", "name": "podman", "action": "check"}
-        :avocado: dependency={"type": "podman-image", "uri": "fedora:38"}
+        :avocado: dependency={"type": "podman-image", "uri": "fedora:40"}
         :avocado: tags=slow
         """
         podman = AsyncPodman()
-        _, stdout, _ = await podman.execute("create", "fedora:38", "/bin/bash")
+        _, stdout, _ = await podman.execute("create", "fedora:40", "/bin/bash")
         container_id = stdout.decode().strip()
         result = await podman.get_container_info(container_id)
         self.assertEqual(result["Id"], container_id)


### PR DESCRIPTION
Because Fedora 38 is at the end of its life-cycle let's update the used Fedora images to 41 before the public package repositories will be removed.