### PR TITLE
VMImage Fedora 40 URL

### DIFF
--- a/avocado/utils/vmimage.py
+++ b/avocado/utils/vmimage.py
@@ -235,7 +235,9 @@ class FedoraImageProvider(FedoraImageProviderBase):
         self.url_old_images = (
             "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/"
         )
-        if int(self.version) >= 40:
+        if int(self.version) == 40:
+            self.image_pattern = "Fedora-Cloud-Base-Generic.(?P<arch>{arch})-(?P<version>{version})-(?P<build>{build}).qcow2$"
+        elif int(self.version) >= 41:
             self.image_pattern = "Fedora-Cloud-Base-Generic-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
         else:
             self.image_pattern = "Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
@@ -257,7 +259,9 @@ class FedoraSecondaryImageProvider(FedoraImageProviderBase):
         self.url_old_images = (
             "https://archives.fedoraproject.org/pub/archive/fedora-secondary/releases/"
         )
-        if int(self.version) >= 40:
+        if int(self.version) == 40:
+            self.image_pattern = "Fedora-Cloud-Base-Generic.(?P<arch>{arch})-(?P<version>{version})-(?P<build>{build}).qcow2$"
+        elif int(self.version) >= 41:
             self.image_pattern = "Fedora-Cloud-Base-Generic-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"
         else:
             self.image_pattern = "Fedora-Cloud-Base-(?P<version>{version})-(?P<build>{build}).(?P<arch>{arch}).qcow2$"

--- a/selftests/unit/utils/vmimage.py
+++ b/selftests/unit/utils/vmimage.py
@@ -542,7 +542,7 @@ class FedoraImageProvider(unittest.TestCase):
         provider = vmimage.FedoraImageProvider(
             version=expected_version, build=expected_build, arch=expected_arch
         )
-        image = f"Fedora-Cloud-Base-Generic-{expected_version}-{expected_build}.{expected_arch}.qcow2"
+        image = f"Fedora-Cloud-Base-Generic-{expected_arch}-{expected_version}-{expected_build}.qcow2"
         parameters = provider.get_image_parameters(image)
         self.assertEqual(expected_version, parameters["version"])
         self.assertEqual(expected_build, parameters["build"])


### PR DESCRIPTION
The URL pattern for downloading Fedora 40 VM images has been updated to match the format provided by the distribution. This ensures that the vmimage download functionality works correctly for Fedora 40 images.