### PR TITLE
Coverage.py during test load

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 source = avocado/, optional_plugins/
-concurrency = multiprocessing
+concurrency = multiprocessing, thread
 parallel = true


### PR DESCRIPTION
This commit updates the coverage.py support in avocado. Currently, avocado was only covering lines which has been touched during the test runtime, but such solution omits lines which are used during imports. Because of this the coverage can be inaccurate, because it misses lines with method names, class names, imports etc. After this change the coverage reports are more accurate.