### PR TITLE
CI runner update from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   static-checks:
 
     name: Static checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/avocado-framework/avocado-ci-fedora-38
 
@@ -42,11 +42,11 @@ jobs:
   smokecheck-linux:
 
     name: Smokecheck on Linux with Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, 3.10.16, 3.11, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:
@@ -67,12 +67,12 @@ jobs:
   check-linux:
 
     name: Linux with Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: smokecheck-linux
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, 3.10.16, 3.11, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:
@@ -180,11 +180,11 @@ jobs:
 
   package-build:
     name: Build Package (wheel/tarball) for Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, 3.10.16, 3.11, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:
@@ -207,11 +207,11 @@ jobs:
 
   egg-build:
     name: Build Egg for Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, 3.10.16, 3.11, 3.12.0, 3.13.0]
       fail-fast: false
 
     steps:
@@ -234,7 +234,7 @@ jobs:
 
   experimental-checks:
     name: Experimental checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
       - name: Check out repository code
@@ -257,7 +257,7 @@ jobs:
   version_task_fedora_37:
 
     name: Version task fedora:37
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: fedora:37
     steps:
@@ -270,7 +270,7 @@ jobs:
   version_task_fedora_38:
 
     name: Version task fedora:38
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: fedora:38
     steps:
@@ -283,7 +283,7 @@ jobs:
   version_task_ubi_8:
 
     name: Version task ubi:8.8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: registry.access.redhat.com/ubi8/ubi:8.8
     steps:
@@ -296,7 +296,7 @@ jobs:
   version_task_ubi_9:
 
     name: Version task ubi:9.2
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: registry.access.redhat.com/ubi9/ubi:9.2
     steps:
@@ -307,7 +307,7 @@ jobs:
   version_task_debian_12:
 
     name: Version task debian:12.4
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: debian:12.4
     steps:
@@ -320,7 +320,7 @@ jobs:
   version_task_debian_11:
 
     name: Version task debian:11.0
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: debian:11.0
     steps:
@@ -333,7 +333,7 @@ jobs:
   version_task_ubuntu_22:
 
     name: Version task ubuntu:22.04
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ubuntu:22.04
     steps:
@@ -346,7 +346,7 @@ jobs:
   version_task_ubuntu_20:
 
     name: Version task ubuntu:20.04
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ubuntu:20.04
     steps:
@@ -359,7 +359,7 @@ jobs:
   egg_task_fedora_37:
 
     name: Egg task fedora:37
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: fedora:37
     steps:
@@ -372,7 +372,7 @@ jobs:
   egg_task_fedora_38:
 
     name: Egg task fedora:38
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: fedora:38
     steps:
@@ -385,7 +385,7 @@ jobs:
   egg_task_ubi_8:
 
     name: Egg task ubi:8.8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: registry.access.redhat.com/ubi8/ubi:8.8
     steps:
@@ -398,7 +398,7 @@ jobs:
   egg_task_ubi_9:
 
     name: Egg task ubi:9.2
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: registry.access.redhat.com/ubi9/ubi:9.2
     steps:
@@ -409,7 +409,7 @@ jobs:
   egg_task_debian_12:
 
     name: Egg task debian:12.4
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: debian:12.4
     steps:
@@ -422,7 +422,7 @@ jobs:
   egg_task_debian_11:
 
     name: Egg task debian:11.0
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: debian:11.0
     steps:
@@ -435,7 +435,7 @@ jobs:
   egg_task_ubuntu_22:
 
     name: Egg task ubuntu:22.04
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ubuntu:22.04
     steps:
@@ -448,7 +448,7 @@ jobs:
   egg_task_ubuntu_20:
 
     name: Egg task ubuntu:20.04
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ubuntu:20.04
     steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,7 +10,7 @@ jobs:
 
   make-check:
     name: Run 'make check'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -73,7 +73,7 @@ jobs:
   code-coverage:
 
     name: Code Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
 
   build-and-publish-eggs:
     name: Build eggs and publish them
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: release
     strategy:
       matrix:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -12,7 +12,7 @@ jobs:
 
   user-installation:
     name: User installation commands
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -52,7 +52,7 @@ jobs:
 
   system-wide-installation:
     name: System wide installation commands
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -92,7 +92,7 @@ jobs:
 
   devel-user-installation:
     name: Developer user commands
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -128,7 +128,7 @@ jobs:
 
   devel-wide-system-installation:
     name: Developer system wide commands
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -164,7 +164,7 @@ jobs:
 
   virtualenv-installation:
     name: Virtualenv installation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
@@ -196,7 +196,7 @@ jobs:
 
   devel-virtualenv-installation:
     name: Developer Virtualenv installation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,7 +12,7 @@ jobs:
 
   latest-python:
     name: Linux with Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
@@ -56,7 +56,7 @@ jobs:
 
   without-plugins-latest-python:
     name: Test with Python without plugins ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: latest-python
     if: "always()&&(needs.latest-python.outputs.job_status=='failure')"
     strategy:


### PR DESCRIPTION
This support of ubuntu-20.04 runner image will be removed in April 1,
2025. Let's update the runner to avoid any possible complications.

Reference: https://github.com/actions/runner-images/issues/11101