### PR TITLE
Cloudinit coverage

### DIFF
--- a/avocado/utils/cloudinit.py
+++ b/avocado/utils/cloudinit.py
@@ -96,18 +96,24 @@ def iso(
 
     :param output_path: the location of the resulting (to be created) ISO
                         image containing the cloudinit configuration
+    :type output_path: str
     :param instance_id: the ID of the cloud instance, a form of identification
                         for the dynamically created executing instances
+    :type instance_id: str
     :param username: the username to be used when logging interactively on the
                      instance
+    :type username: str
     :param password: the password to be used along with username when
                      authenticating with the login services on the instance
+    :type password: str
     :param phone_home_host: the address of the host the instance
                             should contact once it has finished
                             booting
+    :type phone_home_host: str
     :param phone_home_port: the port acting as an HTTP phone home
                             server that the instance should contact
                             once it has finished booting
+    :type phone_home_port: str
     :param authorized_key: a SSH public key to be added as an authorized key
                            for the default user, similar to "ssh-rsa ..."
     :type authorized_key: str

--- a/avocado/utils/cloudinit.py
+++ b/avocado/utils/cloudinit.py
@@ -161,6 +161,7 @@ class PhoneHomeServerHandler(BaseHTTPRequestHandler):
         if path == self.server.instance_id:
             self.server.instance_phoned_back = True
         self.send_response(200)
+        self.end_headers()
 
     def log_message(self, format_, *args):  # pylint: disable=W0221
         """Logs an arbitrary message.

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 80,
     "nrunner-requirement": 28,
-    "unit": 682,
+    "unit": 683,
     "jobs": 11,
     "functional-parallel": 318,
     "functional-serial": 7,

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 80,
     "nrunner-requirement": 28,
-    "unit": 683,
+    "unit": 685,
     "jobs": 11,
     "functional-parallel": 318,
     "functional-serial": 7,

--- a/selftests/unit/utils/cloudinit.py
+++ b/selftests/unit/utils/cloudinit.py
@@ -20,25 +20,37 @@ class CloudInit(unittest.TestCase):
             self.assertRaises(RuntimeError, cloudinit.iso, os.devnull, "INSTANCE_ID")
 
 
+@unittest.skipUnless(
+    has_iso_create_write(), "system lacks support for creating ISO images"
+)
 class CloudInitISO(unittest.TestCase):
+    def iso_no_phone_home_check(self, instance_id, username, password):
+        path = os.path.join(self.tmpdir.name, "cloudinit.iso")
+        cloudinit.iso(path, instance_id, username, password)
+        iso = iso9660.iso9660(path)
+        self.assertIn(instance_id, iso.read("/meta-data").decode("utf-8"))
+        user_data = iso.read("/user-data")
+        iso.close()
+        return user_data.decode("utf-8")
+
     def setUp(self):
         prefix = temp_dir_prefix(self)
         self.tmpdir = tempfile.TemporaryDirectory(prefix=prefix)
 
-    @unittest.skipUnless(
-        has_iso_create_write(), "system lacks support for creating ISO images"
-    )
     def test_iso_no_phone_home(self):
-        path = os.path.join(self.tmpdir.name, "cloudinit.iso")
-        instance_id = b"INSTANCE_ID"
-        username = b"AVOCADO_USER"
-        password = b"AVOCADO_PASSWORD"
-        cloudinit.iso(path, instance_id, username, password)
-        iso = iso9660.iso9660(path)
-        self.assertIn(instance_id, iso.read("/meta-data"))
-        user_data = iso.read("/user-data")
+        instance_id = "INSTANCE_ID"
+        username = "AVOCADO_USER"
+        password = "AVOCADO_PASSWORD"
+        user_data = self.iso_no_phone_home_check(instance_id, username, password)
         self.assertIn(username, user_data)
         self.assertIn(password, user_data)
+
+    def test_iso_no_phone_home_root(self):
+        instance_id = "INSTANCE_ID"
+        username = "root"
+        password = "AVOCADO_PASSWORD"
+        user_data = self.iso_no_phone_home_check(instance_id, username, password)
+        self.assertIn("disable_root: False", user_data)
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/selftests/unit/utils/cloudinit.py
+++ b/selftests/unit/utils/cloudinit.py
@@ -93,16 +93,14 @@ class PhoneHome(unittest.TestCase):
 
     ADDRESS = "127.0.0.1"
 
-    def post_ignore_response(self, url):
-        port = self.server.socket.getsockname()[1]
+    def post_response(self, url, port=None):
+        if not port:
+            port = self.server.socket.getsockname()[1]
         conn = http.client.HTTPConnection(self.ADDRESS, port)
         conn.request("POST", url)
-        try:
-            conn.getresponse()
-        except Exception:
-            pass
-        finally:
-            conn.close()
+        response = conn.getresponse()
+        self.assertIs(response.status, 200)
+        conn.close()
 
     def setUp(self):
         self.instance_id = data_factory.generate_random_string(12)
@@ -112,14 +110,14 @@ class PhoneHome(unittest.TestCase):
         self.assertFalse(self.server.instance_phoned_back)
         server_thread = threading.Thread(target=self.server.handle_request)
         server_thread.start()
-        self.post_ignore_response("/BAD_INSTANCE_ID")
+        self.post_response("/BAD_INSTANCE_ID")
         self.assertFalse(self.server.instance_phoned_back)
 
     def test_phone_home_good(self):
         self.assertFalse(self.server.instance_phoned_back)
         server_thread = threading.Thread(target=self.server.handle_request)
         server_thread.start()
-        self.post_ignore_response("/" + self.instance_id)
+        self.post_response("/" + self.instance_id)
         self.assertTrue(self.server.instance_phoned_back)
 
     def test_phone_home_bad_good(self):


### PR DESCRIPTION
This is a set of tests for `avocado.utils.cloudinit` utility, with fixes found on the way, to prepare it for migration to Autils and increase its coverage. 