### PR TITLE
Latest available python in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.16, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.16, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:
@@ -117,7 +117,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.11.1]
+        python-version: [3.11]
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
@@ -153,7 +153,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10.0, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
 
     steps:
       - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
@@ -184,7 +184,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.16, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:
@@ -211,7 +211,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.16, 3.11, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        python-version: [3.8.16, 3.9.16, 3.10.9, 3.11.1, 3.12.0, 3.13.0]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.11.0]
+        python-version: [3.11]
       fail-fast: false
     outputs:
       job_status: ${{ job.status }}
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: [3.11.0]
+        python-version: [3.11]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
This is a refactoring of CI configuration which removes python minor version specification. After this change, the CI runner will always choose the latest available minor version in CI runner, and we will be able to catch possible errors in minor version changes.