### PR TITLE
Fix bug in recursive_compare_dict: Initialize diff_btw_dict if None.

### DIFF
--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -152,6 +152,8 @@ def recursive_compare_dict(dict1, dict2, level="DictKey", diff_btw_dict=None):
 
     :rtype: list or None
     """
+    if diff_btw_dict is None:
+        diff_btw_dict = []
     if isinstance(dict1, dict) and isinstance(dict2, dict):
         if dict1.keys() != dict2.keys():
             set1 = set(dict1.keys())


### PR DESCRIPTION
Added a check to initialize diff_btw_dict as an empty list if it is passed as None. This prevents AttributeError when trying to append differences to a None value.

Original PR link:[#6127 ]( https://github.com/avocado-framework/avocado/pull/6127)