### PR TITLE
Test results during the code coverage

### DIFF
--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -94,6 +94,7 @@ jobs:
       - name: Run script
         run: ./selftests/run_coverage
       - name: Push results to codecov
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml

--- a/.github/workflows/vmimage.yml
+++ b/.github/workflows/vmimage.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Run script
         run: ./selftests/run_coverage --select=vmimage
       - name: Push results to codecov
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml

--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -29,7 +29,7 @@ rm -f .coverage.*
 echo -e "import coverage\ncoverage.process_startup()" >> sitecustomize.py
 env COVERAGE_PROCESS_START=.coveragerc $COVERAGE run $coverage_source selftests/check.py $test_config
 rm -f sitecustomize.py
-$COVERAGE combine
+$COVERAGE combine -q
 echo
 $COVERAGE report $coverage_include
 $COVERAGE xml $coverage_include

--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -28,8 +28,10 @@ $COVERAGE erase
 rm -f .coverage.*
 echo -e "import coverage\ncoverage.process_startup()" >> sitecustomize.py
 env COVERAGE_PROCESS_START=.coveragerc $COVERAGE run $coverage_source selftests/check.py $test_config
+test_status=$?
 rm -f sitecustomize.py
 $COVERAGE combine -q
 echo
 $COVERAGE report $coverage_include
 $COVERAGE xml $coverage_include
+exit $test_status

--- a/selftests/run_coverage
+++ b/selftests/run_coverage
@@ -14,12 +14,12 @@ fi
 echo "Using coverage utility: $COVERAGE"
 
 test_config="--skip=static-checks"
-if [ -n $1 ]; then
+if [ -n "$1" ]; then
     test_config=$1
 fi
 coverage_source=""
 coverage_include=""
-if [ -n $2 ]; then
+if [ -n "$2" ]; then
     coverage_source="--source=$2"
     coverage_include="--include=$2"
 fi


### PR DESCRIPTION
The code coverage analysis was mostly focused on code coverage and the
actual test result wasn't taken under consideration. But with https://github.com/avocado-framework/avocado/commit/546fa49bfa87110faad697cceda324c8c0ee4847
the coverage testing is being used for testing vmimage related features,
therefore we need to change the code coverage script to return exit code
based on the test results to be consumed by CI.

Signed-off-by: Jan Richter <jarichte@redhat.com>