### PR TITLE
linux_modules: add kernel conf path in image mode

### DIFF
--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -21,6 +21,7 @@
 Linux kernel modules APIs
 """
 
+import os
 import re
 import logging
 import platform
@@ -223,6 +224,8 @@ def check_kernel_config(config_name):
     kernel_version = platform.uname()[2]
 
     config_file = '/boot/config-' + kernel_version
+    if not os.path.exists(config_file):
+        config_file = "/lib/modules/%s/config" % kernel_version
     with open(config_file, 'r') as kernel_config:
         for line in kernel_config:
             line = line.split('=')


### PR DESCRIPTION
The kernel configuration file with package mode is stored under /boot, but isn't with image mode.
With image mode, we can find it in /lib/modules/ like below. So this fix is to add this support.

#ll /lib/modules/5.14.0-570.el9.aarch64/config
-rw-r--r--. 1 root root 212983 Dec 31  1969 /lib/modules/5.14.0-570.el9.aarch64/config 
#cat /lib/modules/5.14.0-570.el9.aarch64/config |more
CONFIG_CC_VERSION_TEXT="gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-5)" 
CONFIG_CC_IS_GCC=y
CONFIG_GCC_VERSION=110500

Signed-off-by: Dan Zheng <dzheng@redhat.com>
