### PR TITLE
Ensure filename API Returns Absolute Path Using inspect.getabsfile()

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -430,7 +430,7 @@ class Test(unittest.TestCase, TestData):
         Returns the name of the file (path) that holds the current test
         """
         try:
-            possibly_compiled = inspect.getfile(self.__class__)
+            possibly_compiled = inspect.getabsfile(self.__class__)
             if possibly_compiled.endswith(".pyc") or possibly_compiled.endswith(".pyo"):
                 source = possibly_compiled[:-1]
             else:


### PR DESCRIPTION
Previously, the filename API returned a relative path in Python ≤3.9 and an absolute path in Python ≥3.10, leading to inconsistency. This change standardizes the behavior to always return an absolute path, ensuring consistency across Python versions

Link: https://github.com/avocado-framework/avocado/issues/6144#issuecomment-2746929950

Signed-off-by: Ayush Jain <Ayush.jain3@amd.com>