### PR TITLE
Spawner capabilities

### DIFF
--- a/avocado/core/plugin_interfaces.py
+++ b/avocado/core/plugin_interfaces.py
@@ -326,6 +326,10 @@ class Spawner(Plugin):
     originally installed are possible children of this.
     """
 
+    #: The capabilities of a spawner implementation. Possible values
+    #: in :class:`avocado.core.spawners.common.SpawnCapabilities`
+    CAPABILITIES = []
+
     @staticmethod
     @abc.abstractmethod
     def is_task_alive(runtime_task):

--- a/avocado/core/spawners/common.py
+++ b/avocado/core/spawners/common.py
@@ -18,6 +18,20 @@ class SpawnMethod(enum.Enum):
     ANY = object()
 
 
+class SpawnCapabilities(enum.Enum):
+    """The capabilities of a spawner implementation."""
+
+    #: The spawner can automatically provision the environment. There
+    #: is no need to create environment before running the task.
+    AUTOMATIC_ENVIRONMENT_PROVISIONING = "Automatic environment provisioning"
+    #: The avocado will be preinstalled in the environment.
+    AVOCADO_DEPLOYMENT = "Avocado deployment"
+    #: The environment is accessible after the task is finished.
+    ENVIRONMENT_PRESERVATION = "Environment preservation"
+    #: The spawner can share the filesystem with the run task.
+    FILESYSTEM_SHARING = "Filesystem sharing"
+
+
 class SpawnerMixin:
     """Common utilities for Spawner implementations."""
 

--- a/avocado/plugins/plugins.py
+++ b/avocado/plugins/plugins.py
@@ -20,6 +20,7 @@ from avocado.core import dispatcher
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
 from avocado.core.settings import settings
+from avocado.core.spawners.common import SpawnCapabilities
 from avocado.utils import astring
 
 
@@ -46,31 +47,64 @@ class Plugins(CLICmd):
             short_arg="-o",
         )
 
+        help_msg = "Display the spawner plugins capabilities"
+        settings.register_option(
+            section="plugins",
+            key="capabilities",
+            default=False,
+            key_type=bool,
+            action="store_true",
+            help_msg=help_msg,
+            parser=parser,
+            long_arg="--capabilities",
+        )
+
     def run(self, config):
-        for plugin_dispatcher, config_needed, job_needed in itertools.chain(
-            dispatcher.get_dispatchers("avocado.core.dispatcher"),
-            dispatcher.get_dispatchers("avocado.core.resolver"),
-        ):
-            if not config_needed:
-                plugins_active = plugin_dispatcher()
-            elif config_needed and not job_needed:
-                plugins_active = plugin_dispatcher(config)
-            else:
-                plugins_active = plugin_dispatcher(config, None)
-            msg = f"{plugins_active.PLUGIN_DESCRIPTION}:"
 
-            LOG_UI.info(msg)
-            plugin_matrix = []
-            if config.get("plugins.ordered_list"):
-                sorted_plugins = plugins_active.get_extentions_by_priority()
-            else:
-                sorted_plugins = plugins_active.get_extentions_by_name()
-            for plugin in sorted_plugins:
-                plugin_matrix.append((plugin.name, plugin.obj.description))
+        if config.get("plugins.capabilities"):
+            spawners_dispatcher = dispatcher.SpawnerDispatcher(config, None)
 
-            if not plugin_matrix:
-                LOG_UI.debug("(No active plugin)")
+            LOG_UI.info(f"{spawners_dispatcher.PLUGIN_DESCRIPTION}:")
+
+            capabilities_matrix = []
+            for spawner in spawners_dispatcher.get_extentions_by_name():
+                capabilities_matrix.append((spawner.name, spawner.obj.description, ""))
+                for capability in SpawnCapabilities:
+                    if capability in spawner.obj.CAPABILITIES:
+                        capabilities_matrix.append(("", f"{capability.value}:", "yes"))
+                    else:
+                        capabilities_matrix.append(("", f"{capability.value}:", "no"))
+                capabilities_matrix.append(("", "", ""))
+            if not capabilities_matrix:
+                LOG_UI.debug("(No active spawner)")
             else:
-                for line in astring.iter_tabular_output(plugin_matrix):
+                for line in astring.iter_tabular_output(capabilities_matrix):
                     LOG_UI.debug(line)
-            LOG_UI.debug("")
+        else:
+            for plugin_dispatcher, config_needed, job_needed in itertools.chain(
+                dispatcher.get_dispatchers("avocado.core.dispatcher"),
+                dispatcher.get_dispatchers("avocado.core.resolver"),
+            ):
+                if not config_needed:
+                    plugins_active = plugin_dispatcher()
+                elif config_needed and not job_needed:
+                    plugins_active = plugin_dispatcher(config)
+                else:
+                    plugins_active = plugin_dispatcher(config, None)
+                msg = f"{plugins_active.PLUGIN_DESCRIPTION}:"
+
+                LOG_UI.info(msg)
+                plugin_matrix = []
+                if config.get("plugins.ordered_list"):
+                    sorted_plugins = plugins_active.get_extentions_by_priority()
+                else:
+                    sorted_plugins = plugins_active.get_extentions_by_name()
+                for plugin in sorted_plugins:
+                    plugin_matrix.append((plugin.name, plugin.obj.description))
+
+                if not plugin_matrix:
+                    LOG_UI.debug("(No active plugin)")
+                else:
+                    for line in astring.iter_tabular_output(plugin_matrix):
+                        LOG_UI.debug(line)
+                LOG_UI.debug("")

--- a/avocado/plugins/spawners/lxc.py
+++ b/avocado/plugins/spawners/lxc.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from avocado.core.plugin_interfaces import Init, Spawner
 from avocado.core.settings import settings
-from avocado.core.spawners.common import SpawnerMixin, SpawnMethod
+from avocado.core.spawners.common import SpawnCapabilities, SpawnerMixin, SpawnMethod
 
 LOG = logging.getLogger(__name__)
 
@@ -103,6 +103,10 @@ class LXCSpawner(Spawner, SpawnerMixin):
 
     description = "LXC (container) based spawner"
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+    CAPABILITIES = [
+        SpawnCapabilities.AVOCADO_DEPLOYMENT,
+        SpawnCapabilities.ENVIRONMENT_PRESERVATION,
+    ]
     slots_cache = {}
 
     def is_operational(self):

--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -11,7 +11,7 @@ from avocado.core.dependencies.requirements import cache
 from avocado.core.plugin_interfaces import CLI, DeploymentSpawner, Init
 from avocado.core.resolver import ReferenceResolutionAssetType
 from avocado.core.settings import settings
-from avocado.core.spawners.common import SpawnerMixin, SpawnMethod
+from avocado.core.spawners.common import SpawnCapabilities, SpawnerMixin, SpawnMethod
 from avocado.core.teststatus import STATUSES_NOT_OK
 from avocado.core.version import VERSION
 from avocado.utils import distro
@@ -118,6 +118,12 @@ class PodmanSpawner(DeploymentSpawner, SpawnerMixin):
 
     description = "Podman (container) based spawner"
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+    CAPABILITIES = [
+        SpawnCapabilities.AUTOMATIC_ENVIRONMENT_PROVISIONING,
+        SpawnCapabilities.AVOCADO_DEPLOYMENT,
+        SpawnCapabilities.ENVIRONMENT_PRESERVATION,
+        SpawnCapabilities.FILESYSTEM_SHARING,
+    ]
 
     _PYTHON_VERSIONS_CACHE = {}
 

--- a/avocado/plugins/spawners/process.py
+++ b/avocado/plugins/spawners/process.py
@@ -4,7 +4,7 @@ import socket
 
 from avocado.core.dependencies.requirements import cache
 from avocado.core.plugin_interfaces import Spawner
-from avocado.core.spawners.common import SpawnerMixin, SpawnMethod
+from avocado.core.spawners.common import SpawnCapabilities, SpawnerMixin, SpawnMethod
 from avocado.core.teststatus import STATUSES_NOT_OK
 from avocado.core.utils.eggenv import get_python_path_env_if_egg
 
@@ -32,6 +32,11 @@ class ProcessSpawner(Spawner, SpawnerMixin):
 
     description = "Process based spawner"
     METHODS = [SpawnMethod.STANDALONE_EXECUTABLE]
+    CAPABILITIES = [
+        SpawnCapabilities.AUTOMATIC_ENVIRONMENT_PROVISIONING,
+        SpawnCapabilities.AVOCADO_DEPLOYMENT,
+        SpawnCapabilities.FILESYSTEM_SHARING,
+    ]
 
     def is_operational(self):
         return True


### PR DESCRIPTION
This commit adds a new subcommand `avocado plugins --capabilities` for printing info about spawners capabilities to console.

It uses new Enum value `SpawnCapabilities` for listing all possible spawner capabilities and add new static list `CAPABILITIES` to Spawner class to describe supported capabilities by a given spawner.

Reference: #6107