### PR TITLE
Set setuptools version to < 80

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install setuptools on Python >= 3.12
-        run: python3 -c 'import setuptools' || python3 -m pip install setuptools
+        run: python3 -c 'import setuptools' || python3 -m pip install "setuptools<80"
       - name: Avocado smokecheck
         run: make smokecheck
 
@@ -87,10 +87,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -V --version
+      - name: Install setuptools on Python >= 3.12
+        run: python3 -c 'import setuptools' || python3 -m pip install "setuptools<80"
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
-      - name: Install setuptools on Python >= 3.12
-        run: python3 -c 'import setuptools' || python3 -m pip install setuptools
       - name: Installing Avocado in develop mode
         run: python3 setup.py develop --user
       - name: Avocado version
@@ -166,7 +166,7 @@ jobs:
       - name: Display Python version
         run: python -V --version
       - name: Install setuptools on Python >= 3.12
-        run: python -c 'import setuptools' || python -m pip install setuptools
+        run: python -c 'import setuptools' || python -m pip install "setuptools<80"
       - name: Install avocado
         run: python setup.py develop --user
       - name: Show avocado help
@@ -194,7 +194,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install setuptools on Python >= 3.12
-      run: python3 -c 'import setuptools' || python3 -m pip install setuptools
+      run: python3 -c 'import setuptools' || python3 -m pip install "setuptools<80"
     - name: Build tarballs and wheels
       run: make -f Makefile.gh build-wheel check-wheel
     - name: Save tarballs and wheels as artifacts
@@ -221,7 +221,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install setuptools on Python >= 3.12
-      run: python3 -c 'import setuptools' || python3 -m pip install setuptools
+      run: python3 -c 'import setuptools' || python3 -m pip install "setuptools<80"
     - name: Build eggs
       run: make -f Makefile.gh build-egg
     - name: Save eggs as artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Build eggs
         run: |
           if python -c 'import sys; exit(0) if sys.version_info.minor > 11 else exit(1)' ; then
-            pip install setuptools
+            pip install "setuptools<80"
           fi
           make -f Makefile.gh build-egg
       - name: Upload binaries to release


### PR DESCRIPTION
This is an CI fix for failures like [this](https://github.com/avocado-framework/avocado/actions/runs/14863146289/job/41733051223?pr=6156).

In setuptools version 80 was removed support for the easy_install command including the sandbox module. Because of this avocado's command `setup.py develop` stopped working. This change fixes our CI to avoid installing setuptools version 80 and higher, but if future we will need to remove the setup.py solution completely.

Reference: https://setuptools.pypa.io/en/stable/history.html#v80-0-0