### PR TITLE
Github workflow for announcement of AAutils migration

### DIFF
--- a/.github/workflows/autils_migration_announcement.yml
+++ b/.github/workflows/autils_migration_announcement.yml
@@ -1,0 +1,45 @@
+name: AAutils migration announcement
+
+on:
+  pull_request_target:
+    types:
+      - opened
+    paths:
+      - '**/ar.py'
+
+jobs:
+  commnet-to-pr:
+    name: Do an announcement to PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        with:
+          app_id: ${{ secrets.MR_AVOCADO_ID }}
+          installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
+          private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}
+      - name: Get PR ID
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          pr_data=$(gh api graphql -f query='query {
+                  repository(owner:"avocado-framework", name:"avocado") {
+                          pullRequest(number:${{ github.event.number }}) {
+                                  id
+                          }
+                  }
+          }')
+          echo 'PR_ID='$(echo $pr_data | jq .data.repository.pullRequest.id) >> $GITHUB_ENV
+      - name: comment on PR
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          gh api graphql -f query='mutation {
+                  addComment(input: {
+                          subjectId: ${{ env.PR_ID }},
+                          body: """${{ vars.AUTILS_MIGRATION_ANNOUNCEMENT }}"""}) {
+
+                                  clientMutationId
+                  }
+          }'


### PR DESCRIPTION
This workflow should notify contributors on their PRs when they are changing an already migrated utility. This should help us to avoid conflicts between avocado.utils and aautils. The announcement looks like this:

```
You are changing one of the avocado utils which has already been
migrated to AAutils project https://github.com/avocado-framework/aautils
and this utility will be removed after the LTS release. Please make sure
that all your proposed changes are already in AAutils and this PR is
only backport.

For more information about AAutlis migration see
https://avocado-framework.readthedocs.io/en/latest/blueprints/BP005.html

For a list of migrated utilities see
https://avocado-framework.github.io/aautils.html
```