### PR TITLE
Aurl utility deprecation

### DIFF
--- a/avocado/utils/aurl.py
+++ b/avocado/utils/aurl.py
@@ -17,11 +17,13 @@ URL related functions.
 
 The strange name is to avoid accidental naming collisions in code.
 """
-
+import logging
 import urllib.parse
 
 #: The most common schemes (protocols) used in URLs
 COMMON_SCHEMES = ("http", "https", "ftp", "git")
+
+LOG = logging.getLogger(__name__)
 
 
 def is_url(path):
@@ -32,5 +34,8 @@ def is_url(path):
     :param path: path to check.
     :rtype: Boolean.
     """
+    LOG.warning(
+        "The aurl utility is deprecated and will be removed after the next LTS release."
+    )
     url_parts = urllib.parse.urlparse(path)
     return url_parts[0] in COMMON_SCHEMES

--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -22,11 +22,12 @@ import os
 import shutil
 import socket
 import sys
+import urllib.parse
 from multiprocessing import Process
 from urllib.error import HTTPError
 from urllib.request import urlopen
 
-from avocado.utils import aurl, crypto, output
+from avocado.utils import crypto, output
 
 log = logging.getLogger(__name__)
 
@@ -148,7 +149,7 @@ def _get_file(src, dst, permissions=None):
     if src == dst:
         return None
 
-    if aurl.is_url(src):
+    if urllib.parse.urlparse(src)[0] in ["http", "https"]:
         url_download(src, dst)
     else:
         shutil.copyfile(src, dst)

--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -19,8 +19,7 @@ Avocado path related functions.
 import os
 import stat
 import tempfile
-
-from avocado.utils import aurl
+import urllib
 
 SHEBANG = "#!"
 
@@ -54,7 +53,12 @@ def get_path(base_path, user_path):
     :param base_path: The base path of relative user specified paths.
     :param user_path: The user specified path.
     """
-    if os.path.isabs(user_path) or aurl.is_url(user_path):
+    if os.path.isabs(user_path) or urllib.parse.urlparse(user_path)[0] in [
+        "http",
+        "https",
+        "ftp",
+        "file",
+    ]:
         return user_path
     return os.path.join(base_path, user_path)
 


### PR DESCRIPTION
This commit deprecates the aurl utility and removes its usages from avocado code base. It is being deprecated because it doesn't bring much value, and it is easy to use common python utilities instead of it.