### PR TITLE
Allow to override /etc dir location

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -46,6 +46,7 @@ import re
 from pkg_resources import resource_exists, resource_filename
 
 from avocado.core.settings_dispatcher import SettingsDispatcher
+from avocado import paths
 
 
 def sorted_dict(dict_object):
@@ -407,7 +408,7 @@ class Settings:
             self.all_config_paths.append(self._config_path_local)
 
     def _prepare_base_dirs(self):
-        cfg_dir = "/etc"
+        cfg_dir = os.path.join(paths.ETCPREFIX, "/etc")
         user_dir = os.path.expanduser("~")
 
         if "VIRTUAL_ENV" in os.environ:

--- a/avocado/core/utils/path.py
+++ b/avocado/core/utils/path.py
@@ -1,5 +1,7 @@
 import os
 
+from avocado import paths
+
 from pkg_resources import get_distribution
 
 
@@ -32,7 +34,7 @@ def system_wide_or_base_path(file_path):
     if os.path.isabs(file_path):
         abs_path = file_path
     else:
-        abs_path = os.path.join(os.path.sep, file_path)
+        abs_path = os.path.join(paths.ETCPREFIX, file_path)
     if os.path.exists(abs_path):
         return abs_path
     return prepend_base_path(file_path)

--- a/avocado/paths.py
+++ b/avocado/paths.py
@@ -1,0 +1,2 @@
+# To be overriden by setup.py
+ETCPREFIX = "/"

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from subprocess import CalledProcessError, run
 
 import setuptools.command.develop
+import setuptools.command.install
 from setuptools import Command, find_packages, setup
 
 # pylint: disable=E0611
@@ -201,6 +202,27 @@ class Develop(setuptools.command.develop.develop):
                 self.handle_install()
             elif self.uninstall:
                 self.handle_uninstall()
+
+
+class Install(setuptools.command.install.install):
+    """Custom install command."""
+
+    user_options = setuptools.command.install.install.user_options + [
+        ("etcprefix=", None, "The etc directory prefix [default: /]"),
+    ]
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.etcprefix = "/usr/local"  # pylint: disable=W0201
+
+    def run(self):
+        pkg_dir = os.path.join(self.build_lib, 'avocado')
+        os.makedirs(pkg_dir, exist_ok=True)
+
+        with open(os.path.join(pkg_dir, 'paths.py'), 'w') as f:
+            f.write(f'ETCPREFIX = "{self.etcprefix}"')
+
+        super().run()
 
 
 class SimpleCommand(Command):
@@ -504,6 +526,7 @@ if __name__ == "__main__":
         cmdclass={
             "clean": Clean,
             "develop": Develop,
+            "install": Install,
             "lint": Linter,
             "man": Man,
             "plugin": Plugin,


### PR DESCRIPTION
Some systems, e.g. FreeBSD, place third-part software configuration files in /usr/local/etc instead of /etc.

Extend the install command to accept "etcprefix" option used for global configuration paths. By default it's "/", so it keeps the current behaviour unchanged.