### PR TITLE
Add support for decimal values and flexible formatting in DataSize

### DIFF
--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -25,6 +25,7 @@ avocado core code or plugins.
 
 
 import math
+import re
 import sys
 
 
@@ -328,23 +329,20 @@ class DataSize:
 
     def __init__(self, data):
         try:
-            norm_size = data.strip().lower()
-            last = norm_size[-1]
-            if last.isdigit():
-                self._value = int(norm_size)
-                self._unit = "b"
-            elif last in self.MULTIPLIERS:
-                self._value = int(norm_size[:-1])
-                self._unit = last
-            else:
+            norm = str(data).strip().lower()
+            match = re.match(r"^(\d+(\.\d+)?)(?:\s*([bkmgt]))?$", norm)
+            if not match:
                 raise ValueError
 
-            if self._value < 0:
+            self._value = float(match.group(1))
+            self._unit = match.group(3) or "b"
+
+            if self._unit not in self.MULTIPLIERS or self._value < 0:
                 raise ValueError
 
         except ValueError as exc:
             raise InvalidDataSize(
-                'String not in size + unit format (i.e. "10M", "100k", ...)'
+                f"Invalid data size '{data}'. Use formats like '10M', '2.5G', or '100'."
             ) from exc
 
     @property

--- a/selftests/unit/utils/data_structures.py
+++ b/selftests/unit/utils/data_structures.py
@@ -129,9 +129,6 @@ class TestDataSize(unittest.TestCase):
             data_structures.InvalidDataSize, data_structures.DataSize, "-100t"
         )
         self.assertRaises(
-            data_structures.InvalidDataSize, data_structures.DataSize, "0.5g"
-        )
-        self.assertRaises(
             data_structures.InvalidDataSize, data_structures.DataSize, "10Mb"
         )
 
@@ -142,6 +139,7 @@ class TestDataSize(unittest.TestCase):
     def test_values(self):
         self.assertEqual(data_structures.DataSize("10m").b, 10485760)
         self.assertEqual(data_structures.DataSize("10M").b, 10485760)
+        self.assertEqual(data_structures.DataSize("0.5g").b, 536870912)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Test code:**
```
from avocado.utils.data_structures import DataSize


test_data = "1.5G"
ds = DataSize(test_data)
print(f"{test_data} => {ds.b} bytes")
```

**Error before modification:**
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/avocado/utils/data_structures.py", line 334, in __init__
    self._value = int(norm_size[:-1])
ValueError: invalid literal for int() with base 10: '1.5 '

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/test1.py", line 5, in <module>
    ds = DataSize(test_data)
  File "/usr/local/lib/python3.10/site-packages/avocado/utils/data_structures.py", line 343, in __init__
    raise InvalidDataSize(
avocado.utils.data_structures.InvalidDataSize: String not in size + unit format (i.e. "10M", "100k", ...)
```

**Output after modification:**
```
1.5G => 1610612736.0 bytes
```