### PR TITLE
Settings: look for configuration in /usr/local/etc if on FreeBSD

### DIFF
--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -41,6 +41,7 @@ import configparser
 import glob
 import json
 import os
+import platform
 import re
 
 from pkg_resources import resource_exists, resource_filename
@@ -407,7 +408,10 @@ class Settings:
             self.all_config_paths.append(self._config_path_local)
 
     def _prepare_base_dirs(self):
-        cfg_dir = "/etc"
+        if platform.system() == "FreeBSD":
+            cfg_dir = "/usr/local/etc"
+        else:
+            cfg_dir = "/etc"
         user_dir = os.path.expanduser("~")
 
         if "VIRTUAL_ENV" in os.environ:


### PR DESCRIPTION
FreeBSD reserves /etc for the base system configuration.  All other software should usr /usr/local/etc instead.

Reference: https://man.freebsd.org/cgi/man.cgi?hier(7)
Reported-by: Roman Bogorodskiy <bogorodskiy@gmail.com>