### PR TITLE
CI: Bump GH Actions Windows image to 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
   smokecheck-windows:
 
     name: Windows with Python ${{ matrix.python-version }}
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     strategy:
       matrix:


### PR DESCRIPTION
Windows 2019 image will be removed on 2025-06-30.  Let's bump to windows-2025 instead.

Reference: https://github.com/actions/runner-images/issues/12045