### PR TITLE
Added custom timeout to Fedora selftests CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,7 @@ jobs:
   fedora_selftests_task:
     name: Fedora selftests
     runs-on: ubuntu-latest
+    timeout-minutes: 18 # max + 3*std over the last 400 successful runs
     container:
       image: quay.io/avocado-framework/avocado-ci-fedora-40
     steps:


### PR DESCRIPTION
### Change Summary
Added custom timeout for `Fedora selftests` job of the `GH Actions` workflow based on historical data.

### More details
Over the last 400 successful runs, the `Fedora selftests` job has a maximum runtime of 13 minutes (mean=8, std=1).

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/avocado-framework/avocado/actions/runs/14109095538/job/39522783803) job run, that failed after 6 hours. More stuck jobs have been observed over the last six months, the first one on 2025-01-15 and the last one one on 2025-03-27, while more recent occurences are also possible because our dataset has a cutoff date around late May. With the proposed changes, a total of **97 hours would have been saved** over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail with a timeout at 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 16 minutes` where `max` and `std` (standard deviation) are derived from the history of 400 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this.

Feel free to let us know (here or in the email below) if you have any questions.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the timeout for the "fedora_selftests_task" in the automated workflow to improve test run reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->