### PR TITLE
fix: Robust resource lookup for editable installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,12 +330,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/version
 
-  version_task_ubuntu_22:
+  version_task_ubuntu_24:
 
-    name: Version task ubuntu:22.04
+    name: Version task ubuntu:24.04
     runs-on: ubuntu-22.04
     container:
-      image: ubuntu:22.04
+      image: ubuntu:24.04
     steps:
       - name: Install Python dependencies
         run: apt update && apt -y install python3 python3-setuptools ca-certificates
@@ -343,12 +343,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/version
 
-  version_task_ubuntu_20:
+  version_task_ubuntu_22:
 
-    name: Version task ubuntu:20.04
+    name: Version task ubuntu:22.04
     runs-on: ubuntu-22.04
     container:
-      image: ubuntu:20.04
+      image: ubuntu:22.04
     steps:
       - name: Install Python dependencies
         run: apt update && apt -y install python3 python3-setuptools ca-certificates
@@ -432,12 +432,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/egg
 
-  egg_task_ubuntu_22:
+  egg_task_ubuntu_24:
 
-    name: Egg task ubuntu:22.04
+    name: Egg task ubuntu:24.04
     runs-on: ubuntu-22.04
     container:
-      image: ubuntu:22.04
+      image: ubuntu:24.04
     steps:
       - name: Install Python dependencies
         run: apt update && apt -y install python3 python3-setuptools
@@ -445,12 +445,12 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/egg
 
-  egg_task_ubuntu_20:
+  egg_task_ubuntu_22:
 
-    name: Egg task ubuntu:20.04
+    name: Egg task ubuntu:22.04
     runs-on: ubuntu-22.04
     container:
-      image: ubuntu:20.04
+      image: ubuntu:22.04
     steps:
       - name: Install Python dependencies
         run: apt update && apt -y install python3 python3-setuptools

--- a/avocado/core/settings.py
+++ b/avocado/core/settings.py
@@ -42,8 +42,7 @@ import glob
 import json
 import os
 import re
-
-from pkg_resources import resource_exists, resource_filename
+from importlib.resources import files
 
 from avocado.core.settings_dispatcher import SettingsDispatcher
 
@@ -415,9 +414,9 @@ class Settings:
             user_dir = os.environ["VIRTUAL_ENV"]
 
         config_file_name = "avocado.conf"
-        config_pkg_base = os.path.join("etc", "avocado", config_file_name)
-        if resource_exists("avocado", config_pkg_base):
-            self._config_path_pkg = resource_filename("avocado", config_pkg_base)
+        conf_file = files("avocado") / "etc" / "avocado" / config_file_name
+        if conf_file.is_file():
+            self._config_path_pkg = str(conf_file)
         else:
             self._config_path_pkg = None
         self._config_dir_system = os.path.join(cfg_dir, "avocado")


### PR DESCRIPTION
This commit resolves a TypeError that occurred when avocado and avocado-vt was installed in editable mode. Previously, pkg_resources would fail to correctly resolve resource paths (like avocado.conf) because the module's __file__ attribute could be None.

To fix this, we've switched to importlib.resources.files for locating package data. This modern API is more reliable and correctly handles resource lookups across various installation methods, including editable installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized packaged-configuration resource handling; no user-facing changes or behavior differences expected.
* **Chores**
  * CI workflow updated to use newer Ubuntu images (tasks moved to newer OS versions); no changes to build steps or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->