### PR TITLE
Added fix for limited depth traversal to fetch disk names.

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -130,11 +130,11 @@ def get_disks():
     except json.JSONDecodeError as je:
         raise DiskError(f"Error occurred while parsing JSON data: {je}") from je
     disks = []
-    for device in json_data["blockdevices"]:
-        disks.append(device["name"])
+    to_process = json_data.get("blockdevices", [])
+    for device in to_process:
+        disks.append(device.get("name"))
         if "children" in device:
-            for child in device["children"]:
-                disks.append(child["name"])
+            to_process.extend(device["children"])
     return disks
 
 


### PR DESCRIPTION
Addex fix to enable full-depth traversal for disk/v-disk name traversal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and listing of all disk devices, including nested devices, ensuring more reliable and comprehensive results when viewing available disks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->