### PR TITLE
Selftests / Functional / Runners: simplify test class inheritance

### DIFF
--- a/selftests/functional/plugin/runners/avocado_instrumented.py
+++ b/selftests/functional/plugin/runners/avocado_instrumented.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-from avocado import Test
 from avocado.core.exit_codes import AVOCADO_JOB_INTERRUPTED
 from avocado.utils import process, script
 from selftests.utils import AVOCADO, TestCaseTmpDir
@@ -26,7 +25,7 @@ class TimeoutTest(Test):
 """
 
 
-class AvocadoInstrumentedRunnerTest(TestCaseTmpDir, Test):
+class AvocadoInstrumentedRunnerTest(TestCaseTmpDir):
     def test_timeout(self):
         cmd_line = (
             f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "

--- a/selftests/functional/plugin/runners/exec_test.py
+++ b/selftests/functional/plugin/runners/exec_test.py
@@ -4,15 +4,14 @@ from avocado import Test
 from avocado.core import exit_codes
 from avocado.core.job import Job
 from avocado.utils import script
-from selftests.utils import TestCaseTmpDir
 
 
-class ExecTestRunnerTest(TestCaseTmpDir, Test):
+class ExecTestRunnerTest(Test):
     def test_env_variables(self):
-        commands_path = os.path.join(self.tmpdir.name, "commands")
+        commands_path = os.path.join(self.workdir, "commands")
         script.make_script(commands_path, "uname -a")
         base_config = {
-            "run.results_dir": self.tmpdir.name,
+            "run.results_dir": self.workdir,
             "sysinfo.collect.per_test": True,
             "sysinfo.collectibles.commands": commands_path,
             "resolver.references": ["examples/tests/env_variables.sh"],
@@ -20,7 +19,7 @@ class ExecTestRunnerTest(TestCaseTmpDir, Test):
         with Job.from_config(base_config) as j:
             result = j.run()
         logfile_path = os.path.join(
-            self.tmpdir.name,
+            self.workdir,
             "latest",
             "test-results",
             "1-1-examples_tests_env_variables.sh",


### PR DESCRIPTION
There's no need to use multiple inheritance in these test classes.

The choices made here was to use the simplest necessary class, which resulted in one being TestCaseTmpDir (basically a unittest.TestCase with a few extra methods for temporary dirs), and the other an Avocado.Test class because of the use of self.log().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test class inheritance for improved consistency.
  * Adjusted temporary directory handling in tests to use a different working directory reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->