### PR TITLE
RPM: provide requirements for running one more test

### DIFF
--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -28,7 +28,7 @@
 Summary: Framework with tools and libraries for Automated Testing
 Name: python-avocado
 Version: 111.0
-Release: 1%{?gitrel}%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2+ and GPLv2 and MIT
 URL: https://avocado-framework.github.io/
 %if 0%{?rel_build}
@@ -72,6 +72,7 @@ BuildRequires: perl-Test-Harness
 BuildRequires: python3-xmlschema
 %endif
 BuildRequires: zstd
+BuildRequires: nmap-ncat
 %endif
 
 %description
@@ -471,6 +472,10 @@ Again Shell code (and possibly other similar shells).
 %{_libexecdir}/avocado*
 
 %changelog
+* Sat Jul 12 2025 Cleber Rosa <crosa@redhat.com> - 111.0-2
+- Provide requirements for running the functional test
+  nrunner.py:TaskRunStatusService.test_task_status_service_lost
+
 * Mon May 19 2025 Jan Richter <jarichte@redhat.com> - 111.0-1
 - New release
 


### PR DESCRIPTION
This enables another test to run during the build of RPM packages.

On a Fedora 42 x86_64 build, without the nmap-ncat dependency:

  RESULTS    : PASS 1170 | ERROR 0 | FAIL 0 | SKIP 115 | WARN 0 | INTERRUPT 0 | CANCEL 10
  JOB TIME   : 233.54 s

And with it:

  RESULTS    : PASS 1171 | ERROR 0 | FAIL 0 | SKIP 114 | WARN 0 | INTERRUPT 0 | CANCEL 10
  JOB TIME   : 230.24 s