### PR TITLE
utils/nvme.py:get_current_ns_ids string value error

### DIFF
--- a/avocado/utils/nvme.py
+++ b/avocado/utils/nvme.py
@@ -109,7 +109,8 @@ def get_current_ns_ids(controller_name):
     namespaces = []
     output = process.run(cmd, shell=True, sudo=True, ignore_status=True).stdout_text
     for line in output.splitlines():
-        namespaces.append(int(line.split()[1].split("]")[0]) + 1)
+        if line.startswith("["):
+            namespaces.append(int(line.split()[1].split("]")[0]) + 1)
     return namespaces
 
 


### PR DESCRIPTION
list-ns command has first line as string and shows below error

ValueError: invalid literal for int() with base 10: 'Namespace'

This code change will make sure the string line is ommited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in listing namespace IDs by filtering out irrelevant lines, reducing the chance of errors or invalid data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->