### PR TITLE
Align pylint between avocado.utils and AAutils 

### DIFF
--- a/.pylintrc_utils
+++ b/.pylintrc_utils
@@ -1,0 +1,507 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=netifaces
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,archive.py,asset.py,astring.py,aurl.py,build.py,cloudinit.py,cpu.py,crypto.py,data_factory.py,data_structures.py,datadrainer.py,debug.py,diff_validator.py,disk.py,distro.py,dmesg.py,download.py,exit_codes.py,file_utils.py,filelock.py,gdb.py,genio.py,git.py,iso9660.py,kernel.py,linux.py,linux_modules.py,lv_utils.py,memory.py,multipath.py,nvme.py,output.py,partition.py,pci.py,pmem.py,podman.py,process.py,script.py,service.py,softwareraid.py,ssh.py,stacktrace.py,sysinfo.py,vmimage.py,wait.py,gdbmi_parser.py,spark.py,common.py,exceptions.py,hosts.py,interfaces.py,ports.py,distro_packages.py,inspector.py,main.py,manager.py,apt.py,base.py,dnf.py,dpkg.py,rpm.py,yum.py,zypper.py
+# regex matches against base names, not paths.
+ignore-patterns=.git
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=pylint.extensions.no_self_use,pylint.extensions.docparams,pylint.extensions.docstyle
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=all
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=line-too-long,
+  locally-disabled,
+  suppressed-message,
+  useless-suppression,
+  use-symbolic-message-instead,
+  too-few-public-methods,
+  fixme
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: en_ZM (myspell), en_ZW
+# (myspell), en_US (myspell), en_PH (myspell), en_IN (myspell), en_BW
+# (myspell), en_TT (myspell), en_GB (myspell), en_SG (myspell), en_AG
+# (myspell), en_NG (myspell), en_CA (myspell), en_BS (myspell), en_AU
+# (myspell), en_JM (myspell), en_ZA (myspell), en_HK (myspell), en_BZ
+# (myspell), en_IE (myspell), en_NZ (myspell), en_DK (myspell), en_MW
+# (myspell), en_NA (myspell), en_GH (myspell)..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
+
+[tool.pylint.parameter_documentation]
+accept-no-param-doc = false
+
+accept-no-raise-doc = false
+
+accept-no-return-doc = false
+
+accept-no-yields-doc = false
+
+# Possible choices: ['sphinx', 'epytext', 'google', 'numpy', 'default']
+default-docstring-type = sphinx
+

--- a/avocado-static-checks.conf
+++ b/avocado-static-checks.conf
@@ -1,3 +1,4 @@
 [lint]
 avocado/utils:static-checks/default_configs/pylintrc
+avocado/utils:.pylintrc_utils
 .:.pylintrc

--- a/avocado/utils/ar.py
+++ b/avocado/utils/ar.py
@@ -11,7 +11,7 @@
 #
 # Copyright: Red Hat Inc. 2021
 # Author: Cleber Rosa <crosa@redhat.com>
-"""
+__doc__ = """
 Module to read UNIX ar files
 """
 
@@ -41,7 +41,10 @@ class ArMember:
 
 
 class Ar:
-    """An UNIX ar archive."""
+    """An UNIX ar archive iterator.
+
+    It reads ar archive file and iterates over the members in form of :class:`autils.archive.ar.ArMember`
+    """
 
     def __init__(self, path):
         self._path = path
@@ -59,8 +62,8 @@ class Ar:
     def is_valid(self):
         """Checks if a file looks like an AR archive.
 
-        :param path: path to a file
-        :returns: bool
+        :return: If file looks like an AR archive
+        :rtype: bool
         """
         with self as open_file:
             return open_file.read(8) == MAGIC
@@ -95,11 +98,21 @@ class Ar:
             return ArMember(identifier, size, data_position)
 
     def list(self):
-        """Return the name of the members in the archive."""
+        """List the members in the archive.
+
+        :return: List the names of the members in the archive
+        :rtype: list
+        """
         return [member.identifier for member in self]
 
     def read_member(self, identifier):
-        """Returns the data for the given member identifier."""
+        """Reads the data for the given member identifier.
+
+        :param identifier: Archive member name.
+        :type identifier: str
+        :return: data for the given member
+        :rtype: bytes or None
+        """
         for member in self:
             if identifier == member.identifier:
                 with self as open_file:

--- a/avocado/utils/path.py
+++ b/avocado/utils/path.py
@@ -28,22 +28,19 @@ SHEBANG = "#!"
 
 
 class CmdNotFoundError(Exception):
-    """
-    Indicates that the command was not found in the system after a search.
+    """Indicates that the command was not found in the system after a search.
+
+    :param cmd: String with the command.
+    :param paths: List of paths where we looked after.
     """
 
     def __init__(self, cmd, paths):  # pylint: disable=W0231
-        """
-        :param cmd: String with the command.
-        :param paths: List of paths where we looked after.
-        """
         super()
         self.cmd = cmd
         self.paths = paths
 
     def __str__(self):
-        """
-        String representation of the exception.
+        """String representation of the exception.
 
         :return: A string describing the missing command and the paths searched.
         :rtype: str
@@ -55,13 +52,15 @@ class CmdNotFoundError(Exception):
 
 
 def get_path(base_path, user_path):
-    """
-    Translate a user specified path to a real path.
+    """Translate a user specified path to a real path.
+
     If user_path is relative, append it to base_path.
     If user_path is absolute, return it as is.
 
     :param base_path: The base path of relative user specified paths.
+    :param type base_path: str
     :param user_path: The user specified path.
+    :type user_path: str
     :return: The resolved path.
     :rtype: str
     """
@@ -76,11 +75,9 @@ def get_path(base_path, user_path):
 
 
 def init_dir(*args):
-    """
-    Wrapper around os.path.join that creates dirs based on the final path.
+    """Wrapper around os.path.join that creates dirs based on the final path.
 
     :param args: List of dir arguments that will be os.path.joined.
-    :type directory: list
     :return: directory.
     :rtype: str
     """
@@ -91,16 +88,17 @@ def init_dir(*args):
 
 
 def find_command(cmd, default=None, check_exec=True):
-    """
-    Try to find a command in the PATH, paranoid version.
+    """Try to find a command in the PATH, paranoid version.
 
     :param cmd: Command to be found.
+    :type cmd: str
     :param default: Command path to use as a fallback if not found
                     in the standard directories.
+    :type default: str or None
     :param check_exec: if a check for permissions that render the command
                        executable by the current user should be performed.
     :type check_exec: bool
-    :raise: :class:`avocado.utils.path.CmdNotFoundError` in case the
+    :raise avocado.utils.path.CmdNotFoundError: in case the
             command was not found and no default was given.
     :return: Returns an absolute path to the command or the default
             value if the command is not found
@@ -136,20 +134,17 @@ def find_command(cmd, default=None, check_exec=True):
 
 
 class PathInspector:
-    """
-    Inspects paths to provide information about them.
+    """Inspects paths to provide information about them.
+
+    :param path: The path to inspect.
+    :type path: str
     """
 
     def __init__(self, path):
-        """
-        :param path: The path to inspect.
-        :type path: str
-        """
         self.path = path
 
     def get_first_line(self):
-        """
-        Reads and returns the first line of the file from path.
+        """Reads and returns the first line of the file from path.
 
         :return: The first line of the file or an empty string if the file
                  does not exist or is empty.
@@ -162,8 +157,7 @@ class PathInspector:
         return first_line
 
     def has_exec_permission(self):
-        """
-        Checks if the file from path has execute permissions for the user.
+        """Checks if the file from path has execute permissions for the user.
 
         :return: True if the file has execute permissions, False otherwise.
         :rtype: bool
@@ -174,8 +168,7 @@ class PathInspector:
         return False
 
     def is_empty(self):
-        """
-        Checks if the file in path is empty.
+        """Checks if the file in path is empty.
 
         :return: True if the file is empty, False otherwise.
         :rtype: bool
@@ -186,8 +179,7 @@ class PathInspector:
         return False
 
     def is_script(self, language=None):
-        """
-        Checks if the file in the path is a script, optionally checking for a specific language.
+        """Checks if the file in the path is a script, optionally checking for a specific language.
 
         :param language: The scripting language to check for (e.g., "python").
                          If None, checks for any shebang.
@@ -206,8 +198,7 @@ class PathInspector:
         return False
 
     def is_python(self):
-        """
-        Checks if the file in path is a Python script.
+        """Checks if the file in path is a Python script.
 
         :return: True if the file is a Python script, False otherwise.
         :rtype: bool
@@ -218,8 +209,7 @@ class PathInspector:
 
 
 def usable_rw_dir(directory, create=True):
-    """
-    Verify whether we can use this dir (read/write).
+    """Verify whether we can use this dir (read/write).
 
     Checks for appropriate permissions, and creates missing dirs as needed.
 
@@ -249,8 +239,7 @@ def usable_rw_dir(directory, create=True):
 
 
 def usable_ro_dir(directory):
-    """
-    Verify whether dir exists and we can access its contents.
+    """Verify whether dir exists and we can access its contents.
 
     Check if a usable RO directory is there.
 
@@ -276,8 +265,7 @@ def usable_ro_dir(directory):
 
 
 def check_readable(path):
-    """
-    Verify that the given path exists and is readable.
+    """Verify that the given path exists and is readable.
 
     This should be used where an assertion makes sense, and is useful
     because it can provide a better message in the exception it
@@ -286,7 +274,6 @@ def check_readable(path):
     :param path: the path to test
     :type path: str
     :raise OSError: path does not exist or path could not be read
-    :rtype: None
     """
     if not os.path.exists(path):
         raise OSError(f'File "{path}" does not exist')
@@ -295,8 +282,7 @@ def check_readable(path):
 
 
 def get_path_mount_point(path):
-    """
-    Returns the mount point for a given file path.
+    """Returns the mount point for a given file path.
 
     :param path: the complete filename path. if a non-absolute path is
                  given, it's transformed into an absolute path first.
@@ -311,8 +297,7 @@ def get_path_mount_point(path):
 
 
 def get_max_file_name_length(path):
-    """
-    Returns the maximum length of a file name in the underlying file system.
+    """Returns the maximum length of a file name in the underlying file system.
 
     :param path: the complete filename path. if a non-absolute path is
                  given, it's transformed into an absolute path first.


### PR DESCRIPTION
Align pylint between avocado.utils and AAutils
This will enable the same pylint checks from AAutils for avocado.utils
which has already been migrated. The rest will be disabeld.

Signed-off-by: Jan Richter <jarichte@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved and standardized docstrings throughout the path and archive utilities, adding clear parameter and return type annotations for better readability and consistency.
* **Chores**
  * Introduced a new, comprehensive Pylint configuration for stricter code style and linting in the utilities module.
  * Updated static analysis configuration to apply the new linting rules specifically to the utilities directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->