### PR TITLE
fix(archive.py): return None when zstd command validation fails

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -168,6 +168,7 @@ def probe_zstd_cmd():
         )
         if proc.returncode or proc.stdout != b"avocado\n":
             LOG.error("zstd command does not seem to be the Zstandard compression tool")
+            return None
         return zstd_cmd
     return None
 


### PR DESCRIPTION
1.Previously, the probe_zstd_cmd() function would return the zstd command path even if the validation test failed. This could lead to using an incompatible or malfunctioning zstd tool. Now it correctly returns None in such cases,making the error handling more robust and consistent with the function's documented behavior.
2.fixed acomment issue, where the comment included parameters that do not exist."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where an invalid command path could be returned after a failed validation, ensuring that only valid paths are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->