### PR TITLE
Ansible plugin: pin cffi to 1.17.1 on Python ≤ 3.9

### DIFF
--- a/optional_plugins/ansible/setup.py
+++ b/optional_plugins/ansible/setup.py
@@ -38,7 +38,8 @@ setup(
     include_package_data=True,
     install_requires=[
         f"avocado-framework=={VERSION}",
-        "cffi",
+        "cffi==1.17.1; python_version<'3.10'",
+        "cffi; python_version>='3.10'",
         "pycparser",
         "ansible-core",
         "markupsafe<3.0.0",


### PR DESCRIPTION
The most recent cffi releases require toolchain features not always available on older platforms and have dropped support for some pre-3.10 interpreter builds. To keep the ansible runner installable on Python3.9 we now use:

	Pin cffi==1.17.1 when python_version < 3.10
	Keep an unpinned cffi requirement for python_version >= 3.10

This conditional dependency prevents build failures on Python 3.9 while still allowing newer interpreters to use the latest cffi release.

Reference:
https://github.com/avocado-framework/avocado/actions/runs/16724207016/job/47335509923?pr=6195#step:6:612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "cffi" dependency to use a specific version for Python versions earlier than 3.10, improving compatibility across Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->