### PR TITLE
get the bonding master from slave interface

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -217,6 +217,27 @@ class NetworkInterface:
                 f"Slave interface not found for " f"the bond {self.name}"
             ) from exc
 
+    def _get_bondingmaster(self):
+        """Get the bonding master interface name from a slave interface.
+        
+        This method returns the bond interface name for the current slave interface.
+        
+        :return: Bond master interface name as string
+        :raises NWException: If bonding master not found or interface is not a slave
+        """
+        master_path = f"/sys/class/net/{self.name}/master"
+        cmd = f"readlink {master_path}"
+        try:
+            output = run_command(cmd, self.host)
+            # Extract the bond interface name from the relative path
+            # Output will be like: ../../bond0 or ../bond0
+            bond_name = os.path.basename(output.strip())
+            return bond_name
+        except Exception as exc:
+            raise NWException(
+                f"Bonding master not found for interface {self.name}"
+            ) from exc
+
     def _move_file_to_backup(self, filename, ignore_missing=True):
         """Moves a file to a backup location.
 

--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -43,6 +43,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 from ipaddress import AddressValueError, IPv4Address, ip_interface
@@ -827,6 +828,32 @@ class NetworkInterface:
             msg = f"{self.name} is not a bond device. {ex}"
             LOG.debug(msg)
             return False
+
+    def get_bond_master(self):
+        """Get the bonding master interface name from a slave interface.
+
+        This method returns the bond interface name for the current slave
+        interface, or ``None`` if the resolved master device is not a bond.
+
+        :return: Bond master interface name if the master is a bonding device,
+                 ``None`` if the master symlink exists but does not point to a
+                 bond interface.
+        :rtype: str or None
+        :raises avocado.utils.network.exceptions.NWException: If the master
+                 symlink cannot be read or the command fails.
+        """
+        master_path = f"/sys/class/net/{self.name}/master"
+        cmd = f"readlink {shlex.quote(master_path)}"
+        try:
+            output = run_command(cmd, self.host)
+            bond_name = os.path.basename(output.strip())
+            if NetworkInterface(bond_name, self.host, if_type="Bond").is_bond():
+                return bond_name
+            return None
+        except Exception as exc:
+            raise NWException(
+                f"Bonding master not found for interface {self.name}"
+            ) from exc
 
     def is_veth(self):
         """Check if interface is a Virtual Ethernet.


### PR DESCRIPTION
The patch identifies and returns the bonding master for a slave interface.

Add get_bond_master() method that resolves the bonding master interface
for a given slave by reading the /sys/class/net/<iface>/master symlink.
Returns the master interface name if it is a bond device, None otherwise,
and raises NWException if the symlink cannot be read.

Also import shlex to safely quote the sysfs path in the readlink command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of bonding master interfaces for network devices.
* **Bug Fixes**
  * Network interface and bonding names containing special characters are now handled safely when creating or activating connections.
  * Bonding master lookup failures now report clearer network-specific errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->