### PR TITLE
GDB/MI parser regression fix

### DIFF
--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -110,8 +110,7 @@ class GdbMiScannerBase(spark.GenericScanner):
         r"[ \t\f\v]+"
 
     def t_symbol(self, s):
-        """"""  # pylint: disable=C0112
-        r",|\{|\}|\[|\]|\="  # pylint: disable=w0105
+        r",|\{|\}|\[|\]|\="
         self.rv.append(Token(s, s))
 
     def t_result_type(self, s):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -104,7 +104,7 @@ API_SECTIONS = {
         "utils",
         genio.read_file("api/headers/utils"),
         "utils",
-        ("core", "plugins"),
+        ("core", "plugins", "utils/external"),
         ("avocado.rst", "modules.rst"),
         "",
     ),

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 90,
     "nrunner-requirement": 28,
-    "unit": 738,
+    "unit": 739,
     "jobs": 11,
     "functional-parallel": 318,
     "functional-serial": 7,

--- a/selftests/unit/utils/gdb.py
+++ b/selftests/unit/utils/gdb.py
@@ -1,5 +1,6 @@
 import unittest
 
+from avocado.utils.external.gdbmi_parser import GdbMiScanner
 from avocado.utils.gdb import GDBRemote, InvalidPacketError
 
 
@@ -28,6 +29,25 @@ class GDBRemoteTest(unittest.TestCase):
             GDBRemote.decode(b"!!#21")
         with self.assertRaises(InvalidPacketError):
             GDBRemote.decode(b"+$!#21")
+
+
+class GDBMiParserTest(unittest.TestCase):
+    def test_tokenize(self):
+        scanner = GdbMiScanner()
+        result = scanner.tokenize('^done,command={exists="true"}')
+        exp = [
+            ("result_type", "^"),
+            ("string", "done"),
+            (",", ","),
+            ("string", "command"),
+            ("=", "="),
+            ("{", "{"),
+            ("string", "exists"),
+            ("=", "="),
+            ("c_string", "true"),
+            ("}", "}"),
+        ]
+        self.assertEqual([(t.type, t.value) for t in result], exp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The first member of "t_{type_of_token}" methods are used as the regex to match while scanning the input.  With the previous change, no symbol would be caught because the effective regex would not be considered.

This reverts 2d741f68909c7ae736830f6a76fd7c88554fa179 and adds a test to avoid future breakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Tests
  * Added a unit test to validate GDB/MI scanner tokenization.
  * Updated the expected unit-test count used by test-size checks.

* Style
  * Cleaned up parser inline documentation and removed a redundant comment; no runtime behavior changed.

* Documentation
  * Adjusted Utilities API docs to exclude external utilities from the generated Utilities section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->