### PR TITLE
nvme subsystem iopolicy value read and update definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:
@@ -184,7 +184,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:
@@ -211,7 +211,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:
@@ -390,7 +390,7 @@ jobs:
       image: registry.access.redhat.com/ubi8/ubi:8.8
     steps:
       - name: Install Python dependencies
-        run: dnf -y install python38 python38-setuptools
+        run: dnf -y install python39 python39-setuptools
       - name: Check out repository code
         uses: actions/checkout@v4
       - uses: ./.github/actions/egg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
       fail-fast: false
 
     steps:

--- a/contrib/scripts/avocado-fetch-eggs.py
+++ b/contrib/scripts/avocado-fetch-eggs.py
@@ -54,7 +54,7 @@ def get_avocado_egg_url(avocado_version=None, python_version=None):
 
 def main():
     configure_logging_settings()
-    for version in ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]:
+    for version in ["3.9", "3.10", "3.11", "3.12", "3.13"]:
         url = get_avocado_egg_url(python_version=version)
         try:
             asset = Asset(url, cache_dirs=CACHE_DIRS)

--- a/docs/source/guides/user/chapters/installing.rst
+++ b/docs/source/guides/user/chapters/installing.rst
@@ -19,7 +19,7 @@ Installing from PyPI
 --------------------
 
 The simplest installation method is through ``pip``.  On most POSIX systems
-with Python 3.8 (or later) and ``pip`` available, installation can be performed
+with Python 3.9 (or later) and ``pip`` available, installation can be performed
 with a single command::
 
   $ pip3 install --user avocado-framework

--- a/optional_plugins/robot/setup.py
+++ b/optional_plugins/robot/setup.py
@@ -49,8 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         f"avocado-framework=={VERSION}",
-        "robotframework>=4.1, <=6.1.1; python_version < '3.8'",
-        "robotframework>=4.1, <7.0; python_version >= '3.8'",
+        "robotframework>=4.1, <7.0; python_version >= '3.9'",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -356,7 +356,6 @@ if __name__ == "__main__":
             "Topic :: Software Development :: Quality Assurance",
             "Topic :: Software Development :: Testing",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
@@ -501,7 +500,7 @@ if __name__ == "__main__":
             ],
         },
         zip_safe=False,
-        python_requires=">=3.8",
+        python_requires=">=3.9",
         cmdclass={
             "clean": Clean,
             "develop": Develop,


### PR DESCRIPTION
Managing NVMe subsystem I/O policies in Linux:

1. get_nvme_subsystem_io_policy(subsystem): This function reads the current I/O policy
   for a specified NVMe subsystem from the /sys/class/nvme-subsystem/<subsystem>/iopolicy
   file and returns it as a string. It uses the process.run() function
   to execute the cat command with sudo privileges and ignores the command's status.
2. change_nvme_subsystem_io_policy(subsystem, io_policy): This function changes the
   I/O policy of an NVMe subsystem to the specified policy. It first checks if the
   current policy matches the desired policy and returns True if they are the same.
   If not, it executes the echo command to set the new policy.
   The function raises a NvmeException if the command fails and returns True
   if the policy was changed successfully.

Both functions use the process.run() function from the process module to execute shell
commands with sudo privileges and ignore their status.
The get_nvme_subsystem_io_policy() function does not take any action if the
current policy matches the desired policy, while the change_nvme_subsystem_io_policy()
function raises an exception or returns True based on the outcome of the policy change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added utilities to read and change NVMe subsystem IO policy.
- Documentation
  - Updated installation guide to require Python 3.9+.
- Chores
  - Dropped Python 3.8 support across CI, release workflows, and egg-fetching scripts; testing now targets Python 3.9–3.13.
  - Updated packaging metadata to require Python 3.9+.
  - Adjusted Robot Framework plugin dependencies to support Python 3.9+ only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->