### PR TITLE
Data Structure Deprecation

### DIFF
--- a/.github/workflows/autils_migration_announcement.yml
+++ b/.github/workflows/autils_migration_announcement.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '**/ar.py'
       - '**/path.py'
+      - '**/data_structures.py'
 
 jobs:
   commnet-to-pr:

--- a/avocado/utils/data_structures.py
+++ b/avocado/utils/data_structures.py
@@ -571,3 +571,9 @@ class DataSize:
         :rtype: int
         """
         return int(self._value * self.MULTIPLIERS[self._unit] / self.MULTIPLIERS["t"])
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("data_structures")


### PR DESCRIPTION
Announcement of deprecation of data_structures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Importing legacy data-structure utilities now emits a deprecation warning at import time; public APIs and signatures remain unchanged.
* **Chores**
  * CI announcement workflow now triggers on additional utility changes to include those PRs in the announcement process; no runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->