### PR TITLE
Freeze the network.ports utility development

### DIFF
--- a/.github/workflows/autils_migration_announcement.yml
+++ b/.github/workflows/autils_migration_announcement.yml
@@ -8,6 +8,7 @@ on:
       - '**/ar.py'
       - '**/path.py'
       - '**/data_structures.py'
+      - '**/network/ports.py'
 
 jobs:
   commnet-to-pr:

--- a/avocado/utils/network/ports.py
+++ b/avocado/utils/network/ports.py
@@ -219,3 +219,9 @@ class PortTracker(Borg):
         """
         if port in self.retained_ports:
             self.retained_ports.remove(port)
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("network.ports")


### PR DESCRIPTION
Since the network.ports development has been migrated to AAutils we need to inform users and developers about this change.

Reference: https://github.com/avocado-framework/aautils/pull/88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Deprecations
  * Added an import-time deprecation warning for legacy network ports utilities; users may see a notice when importing these modules. This is a non-breaking notice; no public APIs were changed.
* Chores
  * CI workflow updated to also trigger when pull requests modify network ports utilities, ensuring announcements include such changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->