### PR TITLE
External Module Warning

### DIFF
--- a/.github/workflows/autils_migration_announcement.yml
+++ b/.github/workflows/autils_migration_announcement.yml
@@ -9,6 +9,8 @@ on:
       - '**/path.py'
       - '**/data_structures.py'
       - '**/network/ports.py'
+      - '**/external/gdbmi_parser.py'
+      - '**/external/spark.py'
 
 jobs:
   commnet-to-pr:

--- a/avocado/utils/external/gdbmi_parser.py
+++ b/avocado/utils/external/gdbmi_parser.py
@@ -417,3 +417,9 @@ class session:  # pylint: disable=C0103
         ast = self.parse(tokens)
         self.the_interpreter(ast)
         return self.the_output(ast.value)
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("external.gdbmi_parser")

--- a/avocado/utils/external/spark.py
+++ b/avocado/utils/external/spark.py
@@ -848,3 +848,9 @@ class GenericASTMatcher(GenericParser):
         #  Resolve ambiguity in favor of the longest RHS.
         #
         return input_list[-1]
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("external.spark")


### PR DESCRIPTION
Warning of development moving over to AAutils for
External Modules.

Reference: https://github.com/avocado-framework/aautils/issues/69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Deprecations
  * Importing the external gdbmi_parser and spark modules now shows a deprecation warning, guiding users to migrate before future removal.

* Chores
  * Expanded CI workflow triggers to run on pull requests that modify the external gdbmi_parser and spark modules, improving coverage for relevant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->