### PR TITLE
Pre-release: fix check for latest avocado build

### DIFF
--- a/contrib/containers/ci/selftests/check-copr-rpm-version.docker
+++ b/contrib/containers/ci/selftests/check-copr-rpm-version.docker
@@ -1,6 +1,6 @@
 # This container is used in selftests/pre_release/tests/check-copr-rpm-version.sh
-FROM fedora:40
+FROM fedora:42
 LABEL description "Fedora image used on COPR RPM version check"
 RUN dnf -y install 'dnf-command(copr)'
-RUN dnf -y copr enable @avocado/avocado-latest-release
+RUN dnf -y copr enable @avocado/avocado-latest
 RUN dnf -y clean all

--- a/selftests/pre_release/tests/check-copr-rpm-version.sh
+++ b/selftests/pre_release/tests/check-copr-rpm-version.sh
@@ -15,7 +15,7 @@ VERSION=$(python setup.py --version 2>/dev/null)
 COMMIT_DATE=$(git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1 $ORIGIN/master)
 SHORT_COMMIT=$(git rev-parse --short=9 $ORIGIN/master)
 RPM_RELEASE_NUMBER=$(grep -E '^Release:\s([0-9]+)' python-avocado.spec | sed -E 's/Release:\s([0-9]+).*/\1/')
-DISTRO_VERSION=40
+DISTRO_VERSION=42
 
 DEFAULT_RPM_NVR="python3-avocado-${VERSION}-${RPM_RELEASE_NUMBER}.${COMMIT_DATE}git${SHORT_COMMIT}.fc${DISTRO_VERSION}"
 RPM_NVR="${1:-$DEFAULT_RPM_NVR}"


### PR DESCRIPTION
This fixes a number of issues with a pre-release check for the latest avocado build:

 1. The repo with the actual latest build is called "avocado-latest" (while the latest released build is called "avocado-latest-release")

 2. Fedora 40 has been EOL'd and it's been bumped to 42

The new container images with these changes are already deployed on quay.io.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to Fedora 42 for CI environments.
  * Switched to the current COPR repository channel for package installation.

* **Tests**
  * Updated pre-release check to target Fedora 42 by default, aligning RPM version expectations with the newer distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->