### PR TITLE
optional_plugins/ansible/setup.py: pin cryptography requirement

### DIFF
--- a/optional_plugins/ansible/setup.py
+++ b/optional_plugins/ansible/setup.py
@@ -40,6 +40,7 @@ setup(
         f"avocado-framework=={VERSION}",
         "cffi==1.17.1; python_version<'3.10'",
         "cffi; python_version>='3.10'",
+        "cryptography<46.0.0; python_version<'3.10'",
         "pycparser",
         "ansible-core",
         "markupsafe<3.0.0",


### PR DESCRIPTION
On Python 3.9 and earlier, we're pinning the cffi dep.  With the most recent cryptography release (46.0.0), a more recent cffi version is required.  This causes the dependency resolution to be impossible.

Let's also pin the version of cryptography on Python 3.9, along with cffi.