### PR TITLE
Improve reliability of flaky test test_task_status_service_lost

### DIFF
--- a/selftests/functional/nrunner.py
+++ b/selftests/functional/nrunner.py
@@ -273,13 +273,15 @@ class TaskRunStatusService(TestCaseTmpDir):
         nc_path = os.path.join(self.tmpdir.name, "socket")
         nc_proc = process.SubProcess(f"nc -lU {nc_path}")
         nc_proc.start()
+        time.sleep(3)
         task_proc = process.SubProcess(
-            f"avocado-runner-exec-test task-run -i 1 -u /bin/sleep -a 3 -s {nc_path}"
+            f"avocado-runner-exec-test task-run -i 1 -u /bin/sleep -a 100 -s {nc_path}"
         )
         task_proc.start()
-        time.sleep(1)
+        time.sleep(3)
         nc_proc.kill()
-        time.sleep(1)
+        nc_proc.wait()
+        time.sleep(3)
         self.assertIn(
             f"Connection with {nc_path} has been lost.".encode(), task_proc.get_stderr()
         )


### PR DESCRIPTION
The TaskRunStatusService.test_task_status_service_lost, from selftests/functional/nrunner.py, fails every now and then.  There are a number of expectations with regards to the timing of both the netcat process and listening socket, and the avocado-runner process.

The following changes are added here in an effort to mitigate or eliminate those failures:

 * A wait was added after the netcat process starts, and before the avocado-runner process is created and started, improving the odds that the netcat socket will be available.

 * A longer execution time for the underlying executable (/bin/sleep) mitigates the possibility of it ending before netcat is killed.

 * A longer sleep after the avocado-runner process is started improves the odds of it having properly started and connected to the socket.

 * Waiting for the end of the netcat process makes sure the assertion is not tried without the connection having being broken on the netcat side.