### PR TITLE
utils/download: replace urllib with requests for streaming downloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -509,5 +509,5 @@ if __name__ == "__main__":
             "plugin": Plugin,
             "test": Test,
         },
-        install_requires=["setuptools"],
+        install_requires=["setuptools", "requests"],
     )


### PR DESCRIPTION
Fix file download failures during bootstrapping of large guest images by switching url_download_interactive() from urllib.request.urlopen to requests.get with streaming enabled.

No functional change in behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated download flow to use streaming HTTP transfers for more reliable downloads and consistent progress updates.

* **Bug Fixes**
  * Added robust timeout handling and improved behavior when response metadata (like content length) is missing; progress now updates correctly from streamed data.

* **Chores**
  * Added an external HTTP client dependency to support the new streaming implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->