### PR TITLE
feat: Add configurable sudo commands and UOS/Deepin support

### DIFF
--- a/avocado/etc/avocado/sysinfo.conf
+++ b/avocado/etc/avocado/sysinfo.conf
@@ -1,0 +1,6 @@
+[sysinfo]
+sudo_commands = dmidecode,fdisk
+# Add any other commands that require sudo here, separated by commas.
+sudo_distros = uos,deepin
+# Add any other operating system that require sudo here, separated by commas.
+# Values of sudo_distros must match the ID= field from /etc/os-release (e.g. uos, deepin).

--- a/avocado/plugins/sysinfo.py
+++ b/avocado/plugins/sysinfo.py
@@ -169,6 +169,28 @@ class SysinfoInit(Init):
             help_msg=help_msg,
         )
 
+        help_msg = "File with list of commands that require sudo"
+        default = system_wide_or_base_path("etc/avocado/sysinfo.conf")
+        settings.register_option(
+            section="sysinfo",
+            key="sudo_commands",
+            key_type=prepend_base_path,
+            default=default,
+            help_msg=help_msg,
+        )
+
+        help_msg = (
+            "File with list of distributions (values matching ID= in /etc/os-release) "
+            "that require sudo"
+        )
+        settings.register_option(
+            section="sysinfo",
+            key="sudo_distros",
+            key_type=prepend_base_path,
+            default=default,
+            help_msg=help_msg,
+        )
+
 
 class SysInfoJob(JobPreTests, JobPostTests):
 

--- a/python-avocado.spec
+++ b/python-avocado.spec
@@ -290,6 +290,7 @@ Common files (such as configuration) for the Avocado Testing Framework.
 %dir %{_datarootdir}/avocado/schemas
 %{_datarootdir}/avocado/schemas/*
 %config(noreplace)%{_sysconfdir}/avocado/sysinfo/commands
+%config(noreplace)%{_sysconfdir}/avocado/sysinfo.conf
 %config(noreplace)%{_sysconfdir}/avocado/sysinfo/files
 %config(noreplace)%{_sysconfdir}/avocado/sysinfo/profilers
 %config(noreplace)%{_sysconfdir}/avocado/scripts/job/pre.d/README


### PR DESCRIPTION
1.Compatible with UOS/Deepin operating system, the system can also be extended
2.Executing the sudo command is configurable and does not affect other systems, such as "sudo-commands=dmidecode, fdisk"
<img width="728" height="176" alt="image" src="https://github.com/user-attachments/assets/1432baa9-126d-4372-98ec-0f69c5f4f48f" />

<img width="1563" height="533" alt="image" src="https://github.com/user-attachments/assets/b27a1225-cfac-4658-b724-2ef5339a94b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running system information collection commands with elevated privileges based on configuration.
  * New configuration options to specify which commands require elevated privileges and which Linux distributions require them.
  * Added a customizable configuration file to define elevated privilege requirements for sysinfo collection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->