### PR TITLE
fix: System_output returns a byte string (bytes) not a string (str)

### DIFF
--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -79,7 +79,7 @@ def can_sudo(cmd=None):
     try:
         if cmd:  # Am I able to run the cmd or plain sudo id?
             return not system(cmd, ignore_status=True, sudo=True)
-        if system_output("id -u", ignore_status=True, sudo=True).strip() == "0":
+        if getoutput("id -u", sudo=True).strip() == "0":
             return True
         return False
     except OSError:  # Broken sudo binary


### PR DESCRIPTION
sudo id -u :  'b'0''
<img width="525" height="338" alt="image" src="https://github.com/user-attachments/assets/f106b348-9d41-448f-b23a-997cb6c07017" />


System_output returns a byte string (bytes), not a string (str).
Will cause "can_sudo" to consistently return False
We need to use. decode ('utf-8 ') to convert the byte string into a string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system privilege detection to prevent incorrect checks caused by data type mismatches, ensuring more reliable root/sudo detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->