### PR TITLE
Fix: Partition unmount for issue 4463

### DIFF
--- a/avocado/utils/partition.py
+++ b/avocado/utils/partition.py
@@ -290,7 +290,7 @@ class Partition:
                     self, "Force unmount failed", umount_details
                 ) from umount_details
 
-    def unmount(self, force=True):
+    def unmount(self, force=True, mountpoint=None):
         """
         Umount this partition.
 
@@ -301,11 +301,14 @@ class Partition:
         When the unmount fails and force==True we unmount the partition
         ungracefully.
 
+        :param force: Whether to force unmount if the standard unmount fails.
+        :param mountpoint: Optional mountpoint to unmount. If not provided, the current mountpoint of the partition object will be used.
         :return: 1 on success, 2 on force umount success
         :raise PartitionError: On failure
         """
         with MtabLock():
-            mountpoint = self.get_mountpoint()
+            if not mountpoint:
+                mountpoint = self.get_mountpoint()
             result = 1
             if not mountpoint:
                 LOG.debug("%s not mounted", self.device)


### PR DESCRIPTION
https://github.com/avocado-framework/avocado/issues/4463

I have modified the unmount () method of the Partition class, which now supports specifying a mount point during uninstallation. If no mount point parameter is provided, the mount point of the current object will be used. This allows for specifying mount points during class initialization and uninstallation to maintain consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The unmount operation now accepts an optional mountpoint parameter, allowing users to specify custom mount points during unmount operations for improved flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->