### PR TITLE
fix: add kernel build directory config path to check_kernel_config

### DIFF
--- a/avocado/utils/linux_modules.py
+++ b/avocado/utils/linux_modules.py
@@ -244,6 +244,7 @@ def check_kernel_config(config_name):
     config_locations = [
         Path("/proc/config.gz"),
         Path(f"/boot/config-{kernel_version}"),
+        Path(f"/lib/modules/{kernel_version}/build/.config"),
         Path(f"/usr/lib/modules/{kernel_version}/config"),
     ]
     config_file = None


### PR DESCRIPTION
Add /lib/modules/{kernel_version}/build/.config as a configuration location to search for kernel config files. This is a common location where the kernel configuration is stored in the build directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel configuration detection by expanding the search to include additional standard system locations, increasing the likelihood of finding and parsing the active kernel config. This should make kernel-related checks more reliable across more environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->