### PR TITLE
dlpar.py: Enhance regex to support optional R suffix in slot format

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -200,7 +200,7 @@ def get_slot_from_sysfs(full_pci_address):
     if not os.path.isfile(f"/proc/device-tree/{devspec}/ibm,loc-code"):
         return None
     slot = genio.read_file(f"/proc/device-tree/{devspec}/ibm,loc-code")
-    slot_ibm = re.match(r"((\w+)[.])+(\w+)-[PC(\d+)-]*C(\d+)", slot)
+    slot_ibm = re.match(r"((\w+)[.])+(\w+)-[PC(\d+)-]*C(\d+)(?:-R\d+)?", slot)
     if slot_ibm:
         return slot_ibm.group()
     slot_openpower = re.match(r"(\w+)[\s]*(\w+)(\d*)", slot)


### PR DESCRIPTION
- Updated regex for `slot_ibm` to include optional `-R\d+` segment.
  This allows matching both standard and extended slot formats:
    - Standard: U50EE.001.WZS00TL-P3-C14
    - Extended: U50EE.001.WZS00TL-P3-C14-R1
- Change ensures compatibility with newer hardware naming conventions
  that include resource identifiers after the slot number.

Backward Compatibility:
- Existing slot formats without `-R` remain fully supported.
- No impact on current parsing logic for standard slot names.

Testing Impact:
- Verified regex against both formats to ensure correct matching.
- Additional unit tests recommended for extended slot names to prevent
  regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PCI slot pattern recognition to support IBM slot naming conventions with revision/reset suffixes, improving compatibility with a broader range of system configurations and ensuring accurate slot identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->