### PR TITLE
Updated regex for slot_ibm to include optional -R\d+ segment.

### DIFF
--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -192,7 +192,8 @@ def get_slot_from_sysfs(full_pci_address):
 
     :return: Removed port related details using re, only returns till
              physical slot of the adapter
-             Examples: U78CD.001.FZHAK92-P2-C3, U50EE.001.WZS0011-P3-C20-R1.
+             Examples: U78CD.001.FZHAK92-P2-C3
+                       U50EE.001.WZS0011-P3-C20-R1
     """
     if not os.path.isfile(f"/sys/bus/pci/devices/{full_pci_address}/devspec"):
         return None

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -201,7 +201,7 @@ def get_slot_from_sysfs(full_pci_address):
     if not os.path.isfile(f"/proc/device-tree/{devspec}/ibm,loc-code"):
         return None
     slot = genio.read_file(f"/proc/device-tree/{devspec}/ibm,loc-code")
-    slot_ibm = re.match(r"((\w+)[.])+(\w+)-[PC(\d+)-]*C(\d+)", slot)
+    slot_ibm = re.match(r"((\w+)[.])+(\w+)-[PC(\d+)-]*C(\d+)(?:-R\d+)?", slot)
     if slot_ibm:
         return slot_ibm.group()
     slot_openpower = re.match(r"(\w+)[\s]*(\w+)(\d*)", slot)

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -192,8 +192,8 @@ def get_slot_from_sysfs(full_pci_address):
 
     :return: Removed port related details using re, only returns till
              physical slot of the adapter
-             Examples: U78CD.001.FZHAK92-P2-C3
-                       U50EE.001.WZS0011-P3-C20-R1
+             Examples: U78CC.001.FZHAK92-P2-C3
+                       U50EE.001.WZS0011-P3-C20-R2
     """
     if not os.path.isfile(f"/sys/bus/pci/devices/{full_pci_address}/devspec"):
         return None

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -191,7 +191,8 @@ def get_slot_from_sysfs(full_pci_address):
     :param full_pci_address: Full PCI address including domain (0000:03:00.0)
 
     :return: Removed port related details using re, only returns till
-             physical slot of the adapter.
+             physical slot of the adapter
+             Examples: U78CD.001.FZHAK92-P2-C3, U50EE.001.WZS0011-P3-C20-R1.
     """
     if not os.path.isfile(f"/sys/bus/pci/devices/{full_pci_address}/devspec"):
         return None

--- a/avocado/utils/pci.py
+++ b/avocado/utils/pci.py
@@ -191,9 +191,11 @@ def get_slot_from_sysfs(full_pci_address):
     :param full_pci_address: Full PCI address including domain (0000:03:00.0)
 
     :return: Removed port related details using re, only returns till
-             physical slot of the adapter
-             Examples: U78CC.001.FZHAK92-P2-C3
-                       U50EE.001.WZS0011-P3-C20-R2
+             physical slot of the adapter.
+             Examples::
+
+                 U78CC.001.FZHAK92-P2-C3
+                 U50EE.001.WZS0011-P3-C20-R2
     """
     if not os.path.isfile(f"/sys/bus/pci/devices/{full_pci_address}/devspec"):
         return None


### PR DESCRIPTION
This allows matching both standard and extended slot formats: Standard: U50EE.001.WZS00TL-P3-C14
Extended: U50EE.001.WZS00TL-P3-C14-R1
Change ensures compatibility with newer hardware naming conventions that include resource identifiers after the slot number. Backward Compatibility:

Existing slot formats without -R remain fully supported. No impact on current parsing logic for standard slot names. Testing Impact:

Verified regex against both formats to ensure correct matching. Additional unit tests recommended for extended slot names to prevent regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PCI slot detection to support additional IBM hardware device code format variations with optional suffixes, enhancing compatibility with a broader range of systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->