### PR TITLE
Multi-part download for `url_download` in utils/download.py 

### DIFF
--- a/avocado/utils/download.py
+++ b/avocado/utils/download.py
@@ -23,6 +23,7 @@ import shutil
 import socket
 import sys
 import time
+import typing
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from urllib.error import HTTPError
@@ -122,7 +123,7 @@ def _download_range(
 def url_download(
     url: str,
     filename: str,
-    data: bytes | None = None,
+    data: typing.Optional[bytes] = None,
     timeout: int = 300,
     segments: int = 4,
 ):

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -647,10 +647,13 @@ class RunnerOperationTest(TestCaseTmpDir):
         )
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
-        # TODO Modify this test to assertEqual, once the issue `deprecated pkg_resources` is solved
-        self.assertIn(
-            "Test Suite could not be created. No test references provided nor any other arguments resolved into tests",
-            str(result.stderr),
+        self.assertEqual(
+            result.stderr,
+            (
+                b"Test Suite could not be created. No test references"
+                b" provided nor any other arguments resolved into "
+                b"tests\n"
+            ),
         )
 
     def test_not_found(self):

--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -647,13 +647,10 @@ class RunnerOperationTest(TestCaseTmpDir):
         )
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
-        self.assertEqual(
-            result.stderr,
-            (
-                b"Test Suite could not be created. No test references"
-                b" provided nor any other arguments resolved into "
-                b"tests\n"
-            ),
+        # TODO Modify this test to assertEqual, once the issue `deprecated pkg_resources` is solved
+        self.assertIn(
+            "Test Suite could not be created. No test references provided nor any other arguments resolved into tests",
+            str(result.stderr),
         )
 
     def test_not_found(self):


### PR DESCRIPTION
fix: modify `url_download` to do multipart download using multi-threading when supported by the server, which shows better performance and consumes less resources
If server doesn't give `content-length` or if there is any `data` to POST into,  switch back to `_url_download` instead

This is a follow up for the discussion in #6236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Downloads now support parallel multipart transfers with configurable segment count for improved speed.
  * Added automatic detection of server capabilities to intelligently switch between parallel and standard download modes.
  * Enhanced download reliability with improved retry logic and timeout controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->