### PR TITLE
Fix job.output.loglevel not applying to external loggers

### DIFF
--- a/avocado/core/utils/messages.py
+++ b/avocado/core/utils/messages.py
@@ -259,7 +259,7 @@ def start_logging(config, queue):
     # root log
     logger = logging.getLogger("")
     logger.addHandler(log_handler)
-    logger.setLevel(logging.NOTSET)
+    logger.setLevel(log_level)
 
     # main log = 'avocado'
     logging.getLogger("avocado").setLevel(log_level)


### PR DESCRIPTION
The job.output.loglevel configuration option was not being respected for external loggers outside of the avocado logging namespace. This fix ensures that external loggers properly inherit and respect the configured log level from job.output.loglevel.

Reference: https://github.com/avocado-framework/avocado/discussions/6239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed root logger configuration to properly respect the configured log level, ensuring consistent log output visibility and default handling from application startup onwards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->