### PR TITLE
Fix resource leak in Daemon.run()

### DIFF
--- a/avocado/utils/sysinfo.py
+++ b/avocado/utils/sysinfo.py
@@ -250,6 +250,9 @@ class Daemon(Command):
             raise CollectibleException(
                 f'Could not execute "{self.cmd}": ' f"{os_err}"
             ) from os_err
+        finally:
+            stdin.close()
+            stdout.close()
 
     def collect(self):
         """


### PR DESCRIPTION
Fix resource leak in `Daemon.run()` when `subprocess.Popen()` fails

The `Daemon.run()` method opens file objects for stdin and stdout but
doesn't close them when `subprocess.Popen()` raises an OSError. This
causes file descriptor leaks, especially problematic when commands
are misconfigured or don't exist.

Add a finally block to ensure file objects are always closed,
regardless of whether `Popen()` succeeds or fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource cleanup in daemon process to ensure stdin and stdout are properly closed in all scenarios, preventing resource leaks and improving system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->