### PR TITLE
Be more lenient with test error messages

### DIFF
--- a/selftests/functional/basic.py
+++ b/selftests/functional/basic.py
@@ -647,13 +647,13 @@ class RunnerOperationTest(TestCaseTmpDir):
         )
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
-        self.assertEqual(
-            result.stderr,
+        self.assertIn(
             (
                 b"Test Suite could not be created. No test references"
                 b" provided nor any other arguments resolved into "
                 b"tests\n"
             ),
+            result.stderr,
         )
 
     def test_not_found(self):
@@ -664,10 +664,10 @@ class RunnerOperationTest(TestCaseTmpDir):
         result = process.run(cmd_line, ignore_status=True)
         self.assertEqual(result.exit_status, exit_codes.AVOCADO_JOB_FAIL)
         self.assertEqual(result.stdout, b"")
-        self.assertEqual(
-            result.stderr,
+        self.assertIn(
             b"No tests found for given test references: sbrubles\n"
             b"Try 'avocado -V list sbrubles' for details\n",
+            result.stderr,
         )
 
     def test_invalid_unique_id(self):


### PR DESCRIPTION
On latest Fedora rawhide, current setuptools usage will produce warning messages on STDERR.  This makes the checking more lenient with extra content that may show up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated error message validation in functional tests to use more flexible pattern matching instead of exact output comparison.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->