### PR TITLE
Utils / gdb: remove duplicate docstring line

### DIFF
--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -838,7 +838,6 @@ class GDBRemote:
         :param expected_response: the (optional) response that is expected
                                   as a response for the command sent
         :type expected_response: str
-        :raises: RetransmissionRequestedError, UnexpectedResponseError
         :returns: raw data read from from the remote server
         :rtype: str
         :raises NotConnectedError: if the socket is not initialized


### PR DESCRIPTION
Reference: https://github.com/avocado-framework/aautils/pull/99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated docstring declarations to improve accuracy. Removed outdated exception declarations from documentation without affecting any functional behavior or public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->