### PR TITLE
Deprecation Warnings

### DIFF
--- a/.github/workflows/autils_migration_announcement.yml
+++ b/.github/workflows/autils_migration_announcement.yml
@@ -6,12 +6,17 @@ on:
       - opened
     paths:
       - '**/ar.py'
-      - '**/path.py'
+      - '**/astring.py'
       - '**/data_structures.py'
-      - '**/network/ports.py'
       - '**/external/gdbmi_parser.py'
       - '**/external/spark.py'
+      - '**/gdb.py'
+      - '**/network/ports.py'
       - '**/output.py'
+      - '**/path.py'
+      - '**/process.py'
+      - '**/script.py'
+      - '**/wait.py'
 
 jobs:
   commnet-to-pr:

--- a/avocado/utils/ar.py
+++ b/avocado/utils/ar.py
@@ -119,3 +119,9 @@ class Ar:
                     open_file.seek(member.offset)
                     return open_file.read(member.size)
         return None
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("ar")

--- a/avocado/utils/astring.py
+++ b/avocado/utils/astring.py
@@ -508,3 +508,9 @@ def to_text(data, encoding=ENCODING, errors="strict"):
     if not isinstance(data, str):
         return str(data)
     return data
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("astring")

--- a/avocado/utils/gdb.py
+++ b/avocado/utils/gdb.py
@@ -894,3 +894,9 @@ class GDBRemote:
 
         if self._extended_mode:
             self.set_extended_mode()
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("gdb")

--- a/avocado/utils/process.py
+++ b/avocado/utils/process.py
@@ -1459,3 +1459,9 @@ def get_command_output_matching(command, pattern):
         ['file1.txt', 'file2.txt']
     """
     return [line for line in run(command).stdout_text.splitlines() if pattern in line]
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("process")

--- a/avocado/utils/script.py
+++ b/avocado/utils/script.py
@@ -199,3 +199,9 @@ def make_temp_script(name, content, prefix="avocado_script", mode=DEFAULT_MODE):
     scpt = TemporaryScript(name, content, prefix=prefix, mode=mode)
     scpt.save()
     return scpt.path
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("script")

--- a/avocado/utils/wait.py
+++ b/avocado/utils/wait.py
@@ -102,3 +102,9 @@ def wait_for(func, timeout, first=0.0, step=1.0, text=None, args=None, kwargs=No
         time.sleep(step)
 
     return None
+
+
+# pylint: disable=wrong-import-position
+from avocado.utils.deprecation import log_deprecation
+
+log_deprecation.warning("wait")


### PR DESCRIPTION
Updated list of announcements in PR's related
to migrated modules.

Assisted-By: Cursor-Claude-4-Sonnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Six utility modules are now deprecated with warnings emitted upon import: ar, astring, gdb, process, script, and wait. Users importing these modules will receive deprecation notices.

* **Chores**
  * Updated GitHub workflow triggers to expand PR target coverage for improved testing across utility and network-related files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->