### PR TITLE
Process CI Selftests Failure

### DIFF
--- a/selftests/unit/utils/process.py
+++ b/selftests/unit/utils/process.py
@@ -567,14 +567,14 @@ class MiscProcessTests(unittest.TestCase):
         system_mock.return_value = 0
         self.assertTrue(process.can_sudo("ls -l"))
 
-    @unittest.mock.patch("avocado.utils.process.system")
+    @unittest.mock.patch("avocado.utils.process.getoutput")
     @unittest.mock.patch("avocado.utils.path.find_command")
     @unittest.mock.patch("avocado.utils.process.os.getuid")
-    def test_can_sudo_oserror(self, getuid_mock, find_cmd_mock, system_mock):
+    def test_can_sudo_oserror(self, getuid_mock, find_cmd_mock, getoutput_mock):
         """Test can_sudo when OSError occurs"""
         getuid_mock.return_value = 1000
         find_cmd_mock.return_value = "/usr/bin/sudo"
-        system_mock.side_effect = OSError()
+        getoutput_mock.side_effect = OSError()
         self.assertFalse(process.can_sudo())
 
     @unittest.mock.patch("avocado.utils.process.get_capabilities")


### PR DESCRIPTION
Mock system_output instead of system since can_sudo() without cmd calls system_output.

Assisted-By: Claude 4.5 Sonnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated unit test to simulate a command execution raising an OSError and verify the sudo-check behavior returns false, enhancing error-handling coverage for process utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->