### PR TITLE
utils/multipath: get_path_status returns None.

### DIFF
--- a/avocado/utils/multipath.py
+++ b/avocado/utils/multipath.py
@@ -273,9 +273,11 @@ def fail_path(path):
 
     def is_failed():
         path_stat = get_path_status(path)
-        if path_stat[0] == "failed" and path_stat[2] == "faulty":
-            return True
-        return False
+        return (
+            path_stat is not None
+            and path_stat[0] == "failed"
+            and path_stat[2] == "faulty"
+        )
 
     cmd = f'multipathd -k"fail path {path}"'
     if not process.system(cmd):
@@ -293,9 +295,11 @@ def reinstate_path(path):
 
     def is_reinstated():
         path_stat = get_path_status(path)
-        if path_stat[0] == "active" and path_stat[2] == "ready":
-            return True
-        return False
+        return (
+            path_stat is not None
+            and path_stat[0] == "active"
+            and path_stat[2] == "ready"
+        )
 
     cmd = f'multipathd -k"reinstate path {path}"'
     if not process.system(cmd):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to avoid errors when path status information is missing, improving stability and preventing unexpected exceptions during fail/reinstate flows.
  * Tightened status validation so fail/reinstate actions only proceed when explicit status combinations are present, ensuring intended behavior when complete status data is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->