### PR TITLE
Pre-release deployment check: update to Fedora 42

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -71,7 +71,7 @@ jobs:
     name: Avocado deployment
     runs-on: ubuntu-latest
     container:
-      image: fedora:40
+      image: fedora:42
     env:
       GIT_URL: 'https://github.com/avocado-framework/avocado'
       INVENTORY: 'selftests/deployment/inventory'


### PR DESCRIPTION
COPR is used to install Avocado packages, but we're not building those packages for Fedora 40 anymore on COPR.  The version bump solves the check failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure to use a newer base container image version, ensuring access to the latest patches and improvements in the runtime environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->