### PR TITLE
Returning true for zero packet loss

### DIFF
--- a/avocado/utils/network/interfaces.py
+++ b/avocado/utils/network/interfaces.py
@@ -906,7 +906,7 @@ class NetworkInterface:
     def are_packets_lost(self, peer_ip, options=None, sudo=False):
         """Check packet loss that occurs during ping.
 
-        Function returns True for 0% packet loss and False
+        Function returns False for 0% packet loss and True
         if packet loss occurs.
 
         :param peer_ip: Peer IP address (IPv4 or IPv6)
@@ -915,7 +915,7 @@ class NetworkInterface:
         :type options: list
         :param sudo: If sudo permissions are needed. Default is False
         :type sudo: bool
-        :return: True for 0% packet loss, False otherwise.
+        :return: False for 0% packet loss, True otherwise.
         :rtype: bool
         :raises avocado.utils.network.exceptions.NWException: If the ping command fails.
         """


### PR DESCRIPTION
The function will return boolean values True or False according to the value of packet loss For zero percent packet loss the float value was 0.0 which was not greater than 0 So introducing the conditions correctly so that we get True for zero percent packet loss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected packet loss detection in network diagnostics so reported status matches actual loss — eliminates false loss indications and ensures no-loss cases are reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->