### PR TITLE
[utils/dmesg.py]: Add helper for journalctl logs and kernel cmdline parameters

### DIFF
--- a/avocado/utils/dmesg.py
+++ b/avocado/utils/dmesg.py
@@ -201,3 +201,32 @@ def check_kernel_logs(pattern):
         return True
 
     return False
+
+
+def check_kernel_cmdline_param(param: str) -> bool:
+    """
+    Check if a given kernel cmdline parameter is present in /proc/cmdline.
+
+    :param param: Kernel cmdline parameter string to search for (e.g. "fred=on")
+    :return: True if the parameter is found, False otherwise
+    """
+    try:
+        with open("/proc/cmdline", "r", encoding="utf-8") as f:
+            cmdline = f.read()
+            return param in cmdline
+    except OSError as e:
+        LOGGER.error("Unable to read /proc/cmdline: %s", e)
+        return False
+
+
+def collect_journalctl_logs(pattern: str) -> list:
+    """Collect kernel logs from journalctl that match a given pattern.
+
+    :param pattern: String to search for in journalctl logs
+    :returns: List of matching log lines
+    """
+    cmd = "journalctl -k -b"
+    output = process.run(cmd, ignore_status=True, verbose=False, sudo=True).stdout_text
+    if output:
+        return [line for line in output.splitlines() if pattern in line]
+    return []


### PR DESCRIPTION
Add utilities to:
**Collect kernel log pattern matches**
Run journalctl -k -b to fetch current boot kernel logs, filter for a given pattern, and return matching lines for validation in tests.
**Verify kernel cmdline parameters**
Read /proc/cmdline and check for a specified boot parameter, returning True if present, otherwise False, to confirm features were enabled at boot.