### PR TITLE
Pin setuptools<82 for pkg_resources compatibility

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,1 +1,3 @@
 sphinx-rtd-theme==2.0.0
+# Pin <82: setuptools 82.0.0+ removed pkg_resources (avocado.core still uses it at doc build time)
+setuptools>=45.0.0,<82

--- a/setup.py
+++ b/setup.py
@@ -509,5 +509,6 @@ if __name__ == "__main__":
             "plugin": Plugin,
             "test": Test,
         },
-        install_requires=["setuptools"],
+        # Pin setuptools<82: 82.0.0+ removed pkg_resources, which avocado.core still uses
+        install_requires=["setuptools>=45.0.0,<82"],
     )


### PR DESCRIPTION
setuptools 82.0.0 removed pkg_resources; avocado.core uses it (e.g. the
doc build imports it via conf.py). Pin setuptools>=45.0.0,<82 in
requirements-doc.txt and in setup.py install_requires so doc builds and
all installs get a compatible setuptools.

Temporary fix until Avocado is updated to new methods.