### PR TITLE
Fixed the issue #5550.Supports specifying port ranges, with automatic matching between listen and URI.

### DIFF
--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -1,7 +1,45 @@
 import asyncio
 import os
+import socket
 
 from avocado.core.settings import settings
+from avocado.core.output import LOG_JOB
+
+
+def resolve_listen_uri(uri):
+    """
+    Normalize a status server URI that may contain a port range into
+    a concrete "host:port" endpoint.
+    """
+    if ":" not in uri:
+        return uri
+    host, port_spec = uri.rsplit(":", 1)
+    if "-" not in port_spec:
+        return uri
+
+    start_s, end_s = port_spec.split("-", 1)
+    start = int(start_s)
+    end = int(end_s)
+    if start > end:
+        raise ValueError(
+            f"Invalid port range (start > end) in status server URI: {uri}"
+        )
+
+    last_exc = None
+    for port in range(start, end + 1):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((host, port))
+            return f"{host}:{port}"
+        except OSError as exc:
+            last_exc = exc
+        finally:
+            sock.close()
+
+    raise OSError(
+        f"Could not bind status server to any port in range {start}-{end} on {host}: {last_exc}"
+    )
 
 
 class StatusServer:
@@ -16,7 +54,7 @@ class StatusServer:
                      messages
         :type repo: :class:`avocado.core.status.repo.StatusRepo`
         """
-        self._uri = uri
+        self._uri = resolve_listen_uri(uri)
         self._repo = repo
         self._server_task = None
 
@@ -27,15 +65,17 @@ class StatusServer:
     async def create_server(self):
         limit = settings.as_dict().get("run.status_server_buffer_size")
         if ":" in self._uri:
-            host, port = self._uri.split(":")
+            host, port = self._uri.rsplit(":", 1)
             port = int(port)
             self._server_task = await asyncio.start_server(
                 self.cb, host=host, port=port, limit=limit
             )
+            LOG_JOB.info("Status server listening on %s", self._uri)
         else:
             self._server_task = await asyncio.start_unix_server(
                 self.cb, path=self._uri, limit=limit
             )
+            LOG_JOB.info("Status server listening on %s", self._uri)
 
     async def serve_forever(self):
         if self._server_task is None:

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -31,7 +31,7 @@ from avocado.core.output import LOG_JOB
 from avocado.core.plugin_interfaces import CLI, Init, SuiteRunner
 from avocado.core.settings import settings
 from avocado.core.status.repo import StatusRepo
-from avocado.core.status.server import StatusServer
+from avocado.core.status.server import StatusServer, resolve_listen_uri
 from avocado.core.task.runtime import RuntimeTaskGraph
 from avocado.core.task.statemachine import TaskStateMachine, Worker
 
@@ -240,10 +240,19 @@ class Runner(SuiteRunner):
     def _create_status_server(self, test_suite, job):
         self._sync_status_server_urls(test_suite.config)
         listen = self._determine_status_server(test_suite, "run.status_server_listen")
+        try:
+            resolved_listen = resolve_listen_uri(listen)
+        except (ValueError, OSError) as exc:
+            raise JobError(str(exc)) from exc
+        if resolved_listen != listen:
+            test_suite.config["run.status_server_listen"] = resolved_listen
+            server_uri = test_suite.config.get("run.status_server_uri")
+            if server_uri in (listen, DEFAULT_SERVER_URI):
+                test_suite.config["run.status_server_uri"] = resolved_listen
         # pylint: disable=W0201
         self.status_repo = StatusRepo(job.unique_id)
         # pylint: disable=W0201
-        self.status_server = StatusServer(listen, self.status_repo)
+        self.status_server = StatusServer(resolved_listen, self.status_repo)
 
     async def _update_status(self, job):
         message_handler = MessageHandler()

--- a/man/avocado.rst
+++ b/man/avocado.rst
@@ -185,15 +185,20 @@ Options for subcommand `run` (`avocado run --help`)::
                             server.
       --status-server-listen HOST_PORT
                             URI where status server will listen on. Usually a
-                            "HOST:PORT" string. This is only effective if
+                            "HOST:PORT" string, or a "HOST:START-END" port
+                            range (for example, "127.0.0.1:8888-9000") in which
+                            case an available port within the range will be
+                            chosen. This is only effective if
                             "status_server_auto" is disabled. If
                             "status_server_uri" is not set, the value from
-                            "status_server_listen " will be used.
+                            "status_server_listen" will be used.
       --status-server-uri HOST_PORT
                             URI for connecting to the status server, usually a
-                            "HOST:PORT" string. Use this if your status server is
-                            in another host, or different port. This is only
-                            effective if "status_server_auto" is disabled.  If
+                            "HOST:PORT" string, or a "HOST:START-END" port range
+                            where an available port within the range will be
+                            chosen. Use this if your status server is in another
+                            host, or different port. This is only effective if
+                            "status_server_auto" is disabled.  If
                             "status_server_listen" is not set, the value from
                             "status_server_uri" will be used.
       --max-parallel-tasks NUMBER_OF_TASKS


### PR DESCRIPTION
Fixed the issue #5550.Supports specifying port ranges, with automatic matching between listen and URI.

Command line: 
avocado run examples/tests/passtest.py --status-server-disable-auto --status-server-listen 127.0.0.1:8888-9000 --status-server-uri 127.0.0.1:8888-9000

Use the testing program to occupy ports 8888/8889 for verification

logs:
...
2026-03-04 15:06:58,073 avocado.job job              L0291 INFO |  'run.status_server_listen': '127.0.0.1:8888-9000',
2026-03-04 15:06:58,073 avocado.job job              L0291 INFO |  'run.status_server_uri': '127.0.0.1:8888-9000',
...
2026-03-04 15:06:58,439 avocado.job server           L0068 INFO | Status server listening on 127.0.0.1:8890
2026-03-04 15:06:58,740 avocado.job testlogs         L0132 INFO | examples/tests/passtest.py:PassTest.test: STARTED
2026-03-04 15:06:58,948 avocado.job testlogs         L0138 INFO | examples/tests/passtest.py:PassTest.test: PASS
...

Signed-off-by: xianglongfei <xianglongfei@uniontech.com>