### PR TITLE
fix(pmem): correct parent_uuid format specifier in args_dict

### DIFF
--- a/avocado/utils/pmem.py
+++ b/avocado/utils/pmem.py
@@ -463,7 +463,7 @@ class PMem:
             "size": "-s %s",
             "align": "-a %s",
             "uuid": "-u %s",
-            "parent_uuid": "-p %",
+            "parent_uuid": "-p %s",
             "offset": "-O %s",
         }
         args = ""


### PR DESCRIPTION
the `parent_uuid` format string in `args_dict` was `"-p %"`, missing the format specifier `s`. This causes incorrect formatting when passing `parent_uuid` to ndctl commands.

Change `"parent_uuid": "-p %"` to `"parent_uuid": "-p %s"`.