### PR TITLE
Fix list accumulation in get_all_disk_paths

### DIFF
--- a/avocado/utils/disk.py
+++ b/avocado/utils/disk.py
@@ -149,7 +149,7 @@ def get_all_disk_paths():
     :returns: a list of all disk path names
     :rtype: list of str
     """
-    disk_list = abs_path = []
+    disk_list = []
     for path in [
         "/dev",
         "/dev/mapper",
@@ -160,6 +160,7 @@ def get_all_disk_paths():
         "/dev/disk/by-partlabel",
     ]:
         if os.path.exists(path):
+            abs_path = []
             for device in os.listdir(path):
                 abs_path.append(os.path.join(path, device))
             disk_list.extend(abs_path)


### PR DESCRIPTION
Avoid reusing the same list across paths, which caused repeated
entries to be appended when iterating over multiple directories.