### PR TITLE
Fix #6276: Type for timeout config options

### DIFF
--- a/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
+++ b/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
@@ -37,12 +37,20 @@ class RemoteSpawnerInit(Init):
 
         help_msg = "Test timeout enforced for remote host setup hook"
         settings.register_option(
-            section=section, key="setup_timeout", help_msg=help_msg, default=3600
+            section=section,
+            key="setup_timeout",
+            help_msg=help_msg,
+            key_type=int,
+            default=3600,
         )
 
         help_msg = "Test timeout enforced for sessions (just for this spawner)"
         settings.register_option(
-            section=section, key="test_timeout", help_msg=help_msg, default=14400
+            section=section,
+            key="test_timeout",
+            help_msg=help_msg,
+            key_type=int,
+            default=14400,
         )
 
 


### PR DESCRIPTION
When setup_timeout or test_timeout are provided via a configuration
file, they are parsed as strings by default. This causes a TypeError
in aexpect when it attempts to calculate deadlines (float + str).

This explicitly sets key_type=int during option registration to
ensure proper casting.