### PR TITLE
Loosen resultsdb_api dep

### DIFF
--- a/optional_plugins/resultsdb/setup.py
+++ b/optional_plugins/resultsdb/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         f"avocado-framework=={VERSION}",
-        "resultsdb-api==2.1.5",
+        "resultsdb-api>=2.1.5,<2.2",
         "urllib3<2.3.0; python_version < '3.9'",
     ],
     entry_points={


### PR DESCRIPTION
We recently released 2.1.6. Following semver conventions, this version shouldn't break any compatibility, it has one bugfix and a bunch of linting cleanups.

There's no reason for this dep to be on a specific version, and it causes problems for downstream packaging. Let's loosen it to at least accept 2.1.5 or higher up to 2.2.