### PR TITLE
Fix install_distro_packages() to return True when packages already installed

### DIFF
--- a/avocado/utils/software_manager/distro_packages.py
+++ b/avocado/utils/software_manager/distro_packages.py
@@ -22,7 +22,8 @@ def install_distro_packages(distro_pkg_map, interactive=False):
     :type distro_pkg_map: dict
     :param distro_pkg_map: mapping of distro name, as returned by
         utils.get_os_vendor(), to a list of package names
-    :return: True if any packages were actually installed, False otherwise
+    :return: True if all required packages are available (either just
+        installed or already present), False otherwise
     """
     if not interactive:
         os.environ["DEBIAN_FRONTEND"] = "noninteractive"
@@ -72,6 +73,9 @@ def install_distro_packages(distro_pkg_map, interactive=False):
             text = " ".join(needed_pkgs)
             log.info('Installing packages "%s"', text)
             result = software_manager.install(text)
+        else:
+            log.info("All required packages already installed")
+            result = True
     return result
 
 


### PR DESCRIPTION
**Problem**
The `install_distro_packages()` function returns `False` when all required packages are already installed. This causes `ensure_tool()` (introduced in #6272) to incorrectly raise a `RuntimeError`, even though the packages are available.

**Root Cause**
The function initializes `result = False` and only sets it to True when `software_manager.install()` is called. When all packages are already installed, the installation block is skipped, leaving result as False.

This bug was exposed when testing avocado-misc-tests PR #3087, which uses ensure_tool() on systems where packages are already installed. The tests fail with `RuntimeError: Failed to install packages for perf` even though perf is installed and functional.