### PR TITLE
Fix zypper install error v3

### DIFF
--- a/avocado/utils/software_manager/backends/zypper.py
+++ b/avocado/utils/software_manager/backends/zypper.py
@@ -37,7 +37,7 @@ class ZypperBackend(RpmBackend):
 
         :param name: Package Name.
         """
-        i_cmd = self.base_command + " install -l " + name
+        i_cmd = f"{self.base_command} install --force-resolution -l {name}"
         return self._run_cmd(i_cmd)
 
     def add_repo(self, url):


### PR DESCRIPTION
On recent distros zypper install is failing when we have conflicts with installed packages, fixing this error.