### PR TITLE
Remote task monitoring

### DIFF
--- a/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
+++ b/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
@@ -85,12 +85,9 @@ class RemoteSpawner(Spawner, SpawnerMixin):
         return True
 
     @staticmethod
-    async def run_remote_cmd_async(session, command, timeout):
-        loop = asyncio.get_event_loop()
+    def run_remote_cmd(session, command, timeout):
         try:
-            status, output = await loop.run_in_executor(
-                None, session.cmd_status_output, command, timeout
-            )
+            status, output = session.cmd_status_output(command, timeout)
         except exceptions.ShellTimeoutError:
             status, output = 2, f"Remote command timeout of {timeout} reached"
         except exceptions.ShellProcessTerminatedError:
@@ -176,7 +173,7 @@ class RemoteSpawner(Spawner, SpawnerMixin):
         # Customize and deploy test data to the container
         if setup_hook:
             setup_timeout = self.config.get("spawner.remote.setup_timeout")
-            status, output = await RemoteSpawner.run_remote_cmd_async(
+            status, output = RemoteSpawner.run_remote_cmd(
                 session, setup_hook, setup_timeout
             )
             LOG.debug(f"Customization command exited with code {status}")
@@ -189,7 +186,7 @@ class RemoteSpawner(Spawner, SpawnerMixin):
 
         cmd = shlex.join(entry_point_args) + " > /dev/null &"
         timeout = self.config.get("spawner.remote.test_timeout")
-        status, output = await RemoteSpawner.run_remote_cmd_async(session, cmd, timeout)
+        status, output = RemoteSpawner.run_remote_cmd(session, cmd, timeout)
         LOG.debug(f"Command exited with code {status}")
         if status != 0:
             LOG.error(

--- a/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
+++ b/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
@@ -88,11 +88,13 @@ class RemoteSpawner(Spawner, SpawnerMixin):
     @staticmethod
     def run_remote_cmd(session, command, timeout):
         try:
-            status, output = session.cmd_status_output(command, timeout)
+            status, output = session.cmd_status_output(command, timeout, safe=True)
         except exceptions.ShellTimeoutError:
             status, output = 2, f"Remote command timeout of {timeout} reached"
         except exceptions.ShellProcessTerminatedError:
             status, output = 2, "Remote command terminated prematurely"
+        except exceptions.ShellStatusError:
+            status, output = 3, f"Remote command could not retrieve status"
         return status, output
 
     @contextlib.contextmanager

--- a/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
+++ b/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
@@ -150,7 +150,7 @@ class RemoteSpawner(Spawner, SpawnerMixin):
         session = runtime_task.spawner_handle
         for _ in range(10):
             status, output = RemoteSpawner.run_remote_cmd(
-                session, f"pgrep -r R,S -f {runtime_task.task.identifier}", 10
+                session, f"pgrep -r R,S -f 'task-run -i {runtime_task.task.identifier}'", 10
             )
             LOG.debug(output)
             if status == 0:

--- a/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
+++ b/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import shlex
+import time
 
 from aexpect import exceptions, remote
 
@@ -145,9 +146,14 @@ class RemoteSpawner(Spawner, SpawnerMixin):
         # since each test is a session detached process, it is reasonable
         # to reuse the same session with a new command
         session = runtime_task.spawner_handle
-        status, _ = session.cmd_status_output(
-            f"pgrep -r R,S -f {runtime_task.task.identifier}"
-        )
+        for _ in range(10):
+            status, output = RemoteSpawner.run_remote_cmd(
+                session, f"pgrep -r R,S -f {runtime_task.task.identifier}", 10
+            )
+            LOG.debug(output)
+            if status == 0:
+                break
+            time.sleep(1)
         return status == 0
 
     @with_slot_reservation

--- a/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
+++ b/optional_plugins/spawner_remote/avocado_spawner_remote/__init__.py
@@ -145,7 +145,7 @@ class RemoteSpawner(Spawner, SpawnerMixin):
     def is_task_alive(runtime_task):
         if runtime_task.spawner_handle is None:
             return False
-        # NOTE: since this is called at the end of each test, it is reasonable
+        # since each test is a session detached process, it is reasonable
         # to reuse the same session with a new command
         session = runtime_task.spawner_handle
         status, _ = session.cmd_status_output(
@@ -187,7 +187,7 @@ class RemoteSpawner(Spawner, SpawnerMixin):
                 )
                 return False
 
-        cmd = shlex.join(entry_point_args) + " > /dev/null"
+        cmd = shlex.join(entry_point_args) + " > /dev/null &"
         timeout = self.config.get("spawner.remote.test_timeout")
         status, output = await RemoteSpawner.run_remote_cmd_async(session, cmd, timeout)
         LOG.debug(f"Command exited with code {status}")


### PR DESCRIPTION
Improve the integration between the avocado task state machine and the remote process spawner in order to properly monitor tasks and respect their configured or default timeouts.