### PR TITLE
core: replace pkg_resources with importlib.metadata

### DIFF
--- a/avocado/core/__init__.py
+++ b/avocado/core/__init__.py
@@ -15,11 +15,10 @@
 
 import os
 
-import pkg_resources
-
 from avocado.core.dispatcher import InitDispatcher
 from avocado.core.settings import settings as stgs
 from avocado.core.streams import BUILTIN_STREAM_SETS, BUILTIN_STREAMS_DESCRIPTION
+from avocado.core.utils.entry_points import get_entry_point_groups
 from avocado.core.utils.path import prepend_base_path
 
 
@@ -229,8 +228,9 @@ def initialize_plugin_infrastructure():
         section="plugins", key="disable", key_type=list, default=[], help_msg=help_msg
     )
 
-    kinds = list(pkg_resources.get_entry_map("avocado-framework").keys())
-    plugin_types = [kind[8:] for kind in kinds if kind.startswith("avocado.plugins.")]
+    plugin_types = [
+        g[8:] for g in get_entry_point_groups() if g.startswith("avocado.plugins.")
+    ]
     for plugin_type in plugin_types:
         help_msg = f'Execution order for "{plugin_type}" plugins'
         stgs.register_option(

--- a/avocado/core/extension_manager.py
+++ b/avocado/core/extension_manager.py
@@ -24,9 +24,8 @@ import enum
 import logging
 import sys
 
-import pkg_resources
-
 from avocado.core.exceptions import JobBaseException
+from avocado.core.utils.entry_points import get_entry_points_for
 from avocado.utils import stacktrace
 
 # This is also defined in avocado.core.output, but this avoids a
@@ -90,7 +89,7 @@ class ExtensionManager:
             invoke_kwds = {}
 
         # load plugins
-        for ep in pkg_resources.iter_entry_points(self.namespace):
+        for ep in get_entry_points_for(self.namespace):
             try:
                 plugin = ep.load()
                 obj = plugin(**invoke_kwds)

--- a/avocado/core/nrunner/app.py
+++ b/avocado/core/nrunner/app.py
@@ -5,9 +5,8 @@ import os
 import re
 import sys
 
-import pkg_resources
-
 from avocado.core.nrunner.runnable import Runnable
+from avocado.core.utils.entry_points import get_entry_points_for
 from avocado.core.nrunner.task import TASK_DEFAULT_CATEGORY, Task
 
 
@@ -227,14 +226,13 @@ class BaseRunnerApp:
         """
         config_used = []
         for kind in self.RUNNABLE_KINDS_CAPABLE:
-            for ep in pkg_resources.iter_entry_points(
-                "avocado.plugins.runnable.runner", kind
-            ):
-                try:
-                    runner = ep.load()
-                    config_used += runner.CONFIGURATION_USED
-                except ImportError:
-                    continue
+            for ep in get_entry_points_for("avocado.plugins.runnable.runner"):
+                if ep.name == kind:
+                    try:
+                        runner = ep.load()
+                        config_used += runner.CONFIGURATION_USED
+                    except ImportError:
+                        continue
         return list(set(config_used))
 
     def command_capabilities(self, _):

--- a/avocado/core/nrunner/runnable.py
+++ b/avocado/core/nrunner/runnable.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import warnings
 
-import pkg_resources
+from importlib.resources import files as resource_files
 
 try:
     import jsonschema
@@ -21,6 +21,7 @@ from avocado.core.dependencies.dependency import Dependency
 from avocado.core.nrunner.config import ConfigDecoder, ConfigEncoder
 from avocado.core.settings import settings
 from avocado.core.utils.eggenv import get_python_path_env_if_egg
+from avocado.core.utils.entry_points import get_entry_points_for
 
 LOG = logging.getLogger(__name__)
 
@@ -268,9 +269,7 @@ class Runnable:
         if not JSONSCHEMA_AVAILABLE:
             return False
         schema_filename = "runnable-recipe.schema.json"
-        schema_path = pkg_resources.resource_filename(
-            "avocado", os.path.join("schemas", schema_filename)
-        )
+        schema_path = str(resource_files("avocado").joinpath("schemas", schema_filename))
         if not os.path.exists(schema_path):
             schema_path = os.path.join(SYSTEM_WIDE_SCHEMA_PATH, schema_filename)
             if not os.path.exists(schema_path):
@@ -639,8 +638,9 @@ class Runnable:
         :returns: a module that can be run with "python -m" or None"""
         namespace = "console_scripts"
         section = f"avocado-runner-{kind}"
-        for ep in pkg_resources.iter_entry_points(namespace, section):
-            return ep.module_name
+        for ep in get_entry_points_for(namespace):
+            if ep.name == section:
+                return ep.value.split(":")[0]
 
     @staticmethod
     def pick_runner_class_from_entry_point_kind(kind):
@@ -653,12 +653,13 @@ class Runnable:
         :returns: a class that inherits from :class:`BaseRunner` or None
         """
         namespace = "avocado.plugins.runnable.runner"
-        for ep in pkg_resources.iter_entry_points(namespace, kind):
-            try:
-                obj = ep.load()
-                return obj
-            except ImportError:
-                return
+        for ep in get_entry_points_for(namespace):
+            if ep.name == kind:
+                try:
+                    obj = ep.load()
+                    return obj
+                except ImportError:
+                    return
 
     def pick_runner_class_from_entry_point(self):
         """Selects a runner class from entry points based on kind.

--- a/avocado/core/utils/eggenv.py
+++ b/avocado/core/utils/eggenv.py
@@ -1,6 +1,6 @@
 import os
 
-import pkg_resources
+from importlib.metadata import distribution
 
 
 def get_python_path_env_if_egg():
@@ -16,15 +16,16 @@ def get_python_path_env_if_egg():
     :returns: environment mapping with an extra PYTHONPATH for the egg or None
     :rtype: os.environ mapping or None
     """
-    dist = pkg_resources.get_distribution("avocado-framework")
-    if not (dist.location.endswith(".egg") and os.path.isfile(dist.location)):
+    dist = distribution("avocado-framework")
+    location = str(dist.locate_file(""))
+    if not (location.endswith(".egg") and os.path.isfile(location)):
         return None
 
     python_path = os.environ.get("PYTHONPATH", "")
     python_path_entries = python_path.split(":")
-    if dist.location in python_path_entries:
+    if location in python_path_entries:
         return None
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = f"{dist.location}:{python_path}"
+    env["PYTHONPATH"] = f"{location}:{python_path}"
     return env

--- a/avocado/core/utils/entry_points.py
+++ b/avocado/core/utils/entry_points.py
@@ -35,14 +35,32 @@ def _eps_raw():
 def get_entry_points_for(group):
     """Return entry points belonging to *group*, compatible with Python 3.8+.
 
+    On Python 3.9 (el9), ``importlib.metadata.entry_points()`` is called with
+    no arguments and returns a plain dict.  In RPM build environments the same
+    package version can appear in more than one ``dist-info`` directory on
+    ``sys.path`` (e.g. both the system install and the BUILDROOT install), which
+    causes the same entry point to be listed multiple times in that dict.  The
+    deduplication below guards against loading a plugin class more than once,
+    which would otherwise cause every plugin method to be invoked twice per
+    event (leading to errors like ``FileExistsError`` in the bystatus plugin).
+
     :param group: entry point group name (e.g. ``"avocado.plugins.cli"``)
     :type group: str
-    :returns: sequence of entry points in the requested group
+    :returns: sequence of entry points in the requested group, deduplicated
     """
     eps = _eps_raw()
     # Python 3.8/3.9 (el9): entry_points() returns a plain dict keyed by group
     if isinstance(eps, dict):
-        return eps.get(group, [])
+        seen = set()
+        result = []
+        for ep in eps.get(group, []):
+            # (name, value) uniquely identifies a plugin regardless of which
+            # dist-info directory it was discovered from.
+            key = (ep.name, ep.value)
+            if key not in seen:
+                seen.add(key)
+                result.append(ep)
+        return result
     # Python 3.10+: EntryPoints / SelectableGroups — use group= kwarg directly
     return _entry_points(group=group)
 

--- a/avocado/core/utils/entry_points.py
+++ b/avocado/core/utils/entry_points.py
@@ -1,0 +1,59 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: IBM Corp. 2026
+# Author: Praveen K Pandey <praveen@linux.ibm.com>
+
+"""
+Compatibility helpers for importlib.metadata.entry_points.
+
+The entry_points() API changed across Python versions:
+
+ Python 3.8/3.9 - returns a plain dict; group= kwarg not supported
+ Python 3.10/3.11 - returns SelectableGroups; group= kwarg supported
+ Python 3.12+ - returns EntryPoints; group= kwarg supported; no .get()/.groups
+
+These helpers provide a single version-agnostic API for the whole codebase.
+"""
+
+from importlib.metadata import entry_points as _entry_points
+
+
+def get_entry_points_for(group):
+    """Return entry points belonging to *group*, compatible with Python 3.8+.
+
+    :param group: entry point group name (e.g. ``"avocado.plugins.cli"``)
+    :type group: str
+    :returns: sequence of entry points in the requested group
+    """
+    try:
+        # Python 3.10+: group= kwarg is supported
+        return _entry_points(group=group)
+    except TypeError:
+        # Python 3.8/3.9: entry_points() returns a plain dict, no group= kwarg
+        return _entry_points().get(group, [])
+
+
+def get_entry_point_groups():
+    """Return all registered entry point group names, compatible with Python 3.8+.
+
+    :returns: list of group name strings
+    :rtype: list
+    """
+    eps = _entry_points()
+    # Python 3.8/3.9: plain dict
+    if isinstance(eps, dict):
+        return list(eps.keys())
+    # Python 3.10/3.11: SelectableGroups has .groups
+    if hasattr(eps, "groups"):
+        return list(eps.groups)
+    # Python 3.12+: EntryPoints — collect unique group names from entries
+    return list({ep.group for ep in eps})

--- a/avocado/core/utils/entry_points.py
+++ b/avocado/core/utils/entry_points.py
@@ -27,6 +27,11 @@ These helpers provide a single version-agnostic API for the whole codebase.
 from importlib.metadata import entry_points as _entry_points
 
 
+def _eps_raw():
+    """Call entry_points() with no arguments and return the raw result."""
+    return _entry_points()
+
+
 def get_entry_points_for(group):
     """Return entry points belonging to *group*, compatible with Python 3.8+.
 
@@ -34,12 +39,12 @@ def get_entry_points_for(group):
     :type group: str
     :returns: sequence of entry points in the requested group
     """
-    try:
-        # Python 3.10+: group= kwarg is supported
-        return _entry_points(group=group)
-    except TypeError:
-        # Python 3.8/3.9: entry_points() returns a plain dict, no group= kwarg
-        return _entry_points().get(group, [])
+    eps = _eps_raw()
+    # Python 3.8/3.9 (el9): entry_points() returns a plain dict keyed by group
+    if isinstance(eps, dict):
+        return eps.get(group, [])
+    # Python 3.10+: EntryPoints / SelectableGroups — use group= kwarg directly
+    return _entry_points(group=group)
 
 
 def get_entry_point_groups():
@@ -48,12 +53,12 @@ def get_entry_point_groups():
     :returns: list of group name strings
     :rtype: list
     """
-    eps = _entry_points()
+    eps = _eps_raw()
     # Python 3.8/3.9: plain dict
     if isinstance(eps, dict):
         return list(eps.keys())
     # Python 3.10/3.11: SelectableGroups has .groups
     if hasattr(eps, "groups"):
         return list(eps.groups)
-    # Python 3.12+: EntryPoints — collect unique group names from entries
+    # Python 3.12+: EntryPoints — collect unique group names by iterating entries
     return list({ep.group for ep in eps})

--- a/avocado/core/utils/path.py
+++ b/avocado/core/utils/path.py
@@ -1,14 +1,15 @@
 import os
 import platform
 
-from pkg_resources import get_distribution
+from importlib.metadata import distribution
 
 
 def prepend_base_path(value):
     expanded = os.path.expanduser(value)
     if not expanded.startswith(("/", "~", ".")):
-        dist = get_distribution("avocado-framework")
-        return os.path.join(dist.location, "avocado", expanded)
+        dist = distribution("avocado-framework")
+        location = str(dist.locate_file(""))
+        return os.path.join(location, "avocado", expanded)
     return expanded
 
 

--- a/avocado/core/version.py
+++ b/avocado/core/version.py
@@ -14,11 +14,11 @@
 
 __all__ = ["MAJOR", "MINOR", "VERSION"]
 
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    VERSION = pkg_resources.get_distribution("avocado-framework").version
-except pkg_resources.DistributionNotFound:
+    VERSION = version("avocado-framework")
+except PackageNotFoundError:
     VERSION = "unknown.unknown"
 
 MAJOR, MINOR = VERSION.split(".")

--- a/avocado/plugins/exec_path.py
+++ b/avocado/plugins/exec_path.py
@@ -16,7 +16,7 @@ Libexec PATHs modifier
 
 import os
 
-from pkg_resources import resource_filename
+from importlib.resources import files as resource_files
 
 from avocado.core.output import LOG_UI
 from avocado.core.plugin_interfaces import CLICmd
@@ -40,4 +40,4 @@ class ExecPath(CLICmd):
         if os.path.isdir(system_wide):
             LOG_UI.debug(system_wide)
         else:
-            LOG_UI.debug(resource_filename("avocado", "libexec"))
+            LOG_UI.debug(str(resource_files("avocado").joinpath("libexec")))

--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -5,7 +5,8 @@ import subprocess
 import sys
 import tempfile
 
-import pkg_resources
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 
 from avocado.core.nrunner.app import BaseRunnerApp
 from avocado.core.nrunner.runner import BaseRunner
@@ -83,12 +84,12 @@ class ExecTestRunner(BaseRunner):
     @staticmethod
     def _get_avocado_version():
         """Return the Avocado package version, if installed"""
-        version = "unknown.unknown"
+        ver = "unknown.unknown"
         try:
-            version = pkg_resources.get_distribution("avocado-framework").version
-        except pkg_resources.DistributionNotFound:
+            ver = pkg_version("avocado-framework")
+        except PackageNotFoundError:
             pass
-        return version
+        return ver
 
     def _get_env_variables(self, runnable):
         """Get the default AVOCADO_* environment variables

--- a/optional_plugins/robot/tests/resolver.py
+++ b/optional_plugins/robot/tests/resolver.py
@@ -1,8 +1,8 @@
 import os
 import unittest
+from importlib.metadata import PackageNotFoundError, distribution
 
 import avocado_robot.robot
-import pkg_resources
 
 from avocado.core.resolver import ReferenceResolutionResult
 
@@ -17,9 +17,9 @@ def python_module_available(module_name):
     :rtype: bool
     """
     try:
-        pkg_resources.require(module_name)
+        distribution(module_name)
         return True
-    except pkg_resources.DistributionNotFound:
+    except PackageNotFoundError:
         return False
 
 

--- a/selftests/unit/safeloader_module.py
+++ b/selftests/unit/safeloader_module.py
@@ -21,7 +21,7 @@ class PythonModuleSelf(unittest.TestCase):
 
     def test_add_imported_symbols_from_module(self):
         import_stm = ast.ImportFrom(
-            module="foo", names=[ast.Name(name="bar", asname=None)]
+            module="foo", names=[ast.alias(name="bar", asname=None)]
         )
         self.module.add_imported_symbol(import_stm)
         self.assertEqual(self.module.imported_symbols["bar"].module_path, "foo")
@@ -29,14 +29,14 @@ class PythonModuleSelf(unittest.TestCase):
 
     def test_add_imported_object_from_module_asname(self):
         import_stm = ast.ImportFrom(
-            module="foo", names=[ast.Name(name="bar", asname="baz")]
+            module="foo", names=[ast.alias(name="bar", asname="baz")]
         )
         self.module.add_imported_symbol(import_stm)
         self.assertEqual(self.module.imported_symbols["baz"].module_path, "foo")
         self.assertEqual(self.module.imported_symbols["baz"].symbol, "bar")
 
     def test_is_not_avocado_test(self):
-        self.assertFalse(self.module.is_matching_klass(ast.ClassDef()))
+        self.assertFalse(self.module.is_matching_klass(ast.ClassDef(name="")))
 
     def test_is_not_avocado_tests(self):
         for klass in self.module.iter_classes():

--- a/selftests/utils.py
+++ b/selftests/utils.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 import unittest
 
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, distribution
 
 from avocado.utils import path as avocado_path
 
@@ -26,9 +26,9 @@ def python_module_available(module_name):
     :rtype: bool
     """
     try:
-        pkg_resources.require(module_name)
+        distribution(module_name)
         return True
-    except pkg_resources.DistributionNotFound:
+    except PackageNotFoundError:
         return False
 
 

--- a/setup.py
+++ b/setup.py
@@ -509,6 +509,5 @@ if __name__ == "__main__":
             "plugin": Plugin,
             "test": Test,
         },
-        # Pin setuptools<82: 82.0.0+ removed pkg_resources, which avocado.core still uses
-        install_requires=["setuptools>=45.0.0,<82"],
+        install_requires=[],
     )


### PR DESCRIPTION
pkg_resources (from setuptools) is no longer bundled in Python 3.15+ and Fedora Rawhide does not pre-install it, causing an import failure.

Replace with importlib.metadata from the stdlib (available since Python 3.8), with a compatibility guard for the dict-style API on Python 3.8/3.9 vs the SelectableGroups API on Python 3.10+.

Fixes: ModuleNotFoundError: No module named 'pkg_resources'