### PR TITLE
Provide entry point support for both pkg_resources and importlib

### DIFF
--- a/avocado/core/output.py
+++ b/avocado/core/output.py
@@ -26,6 +26,7 @@ import traceback
 from avocado.core import exit_codes
 from avocado.core.settings import settings
 from avocado.core.streams import BUILTIN_STREAMS
+from avocado.core.utils.entry_points import get_entry_point_module_name
 from avocado.utils import path as utils_path
 
 #: Handle cases of logging exceptions which will lead to recursion error
@@ -768,12 +769,13 @@ def log_plugin_failures(failures):
     """
     msg_fmt = 'Failed to load plugin from module "%s": %s :\n%s'
     config = settings.as_dict()
-    silenced = config.get("plugins.skip_broken_plugin_notification")
+    silenced = config.get("plugins.skip_broken_plugin_notification") or []
     for failure in failures:
-        if failure[0].module_name in silenced:
+        module_name = get_entry_point_module_name(failure[0])
+        if module_name in silenced:
             continue
         if hasattr(failure[1], "__traceback__"):
             str_tb = "".join(traceback.format_tb(failure[1].__traceback__))
         else:
             str_tb = "Traceback not available"
-        LOG_UI.error(msg_fmt, failure[0].module_name, repr(failure[1]), str_tb)
+        LOG_UI.error(msg_fmt, module_name, repr(failure[1]), str_tb)

--- a/avocado/core/utils/entry_points.py
+++ b/avocado/core/utils/entry_points.py
@@ -65,6 +65,27 @@ def get_entry_points_for(group):
     return _entry_points(group=group)
 
 
+def get_entry_point_module_name(entry_point):
+    """Return the module name declared by an entry point."""
+    if entry_point is None:
+        return ""
+    if isinstance(entry_point, str):
+        return entry_point
+
+    module_name = getattr(entry_point, "module_name", None)
+    if module_name is not None:
+        return module_name
+
+    module = getattr(entry_point, "module", None)
+    if module is not None:
+        return module
+
+    value = getattr(entry_point, "value", "")
+    if not isinstance(value, str):
+        return ""
+    return value.split(":", 1)[0].split("[", 1)[0].strip()
+
+
 def get_entry_point_groups():
     """Return all registered entry point group names, compatible with Python 3.8+.
 

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 90,
     "nrunner-requirement": 28,
-    "unit": 1009,
+    "unit": 1016,
     "jobs": 11,
     "functional-parallel": 368,
     "functional-serial": 7,

--- a/selftests/unit/output.py
+++ b/selftests/unit/output.py
@@ -1,5 +1,7 @@
 import sys
+import types
 import unittest.mock
+from importlib.metadata import EntryPoint
 
 from avocado.core import output
 from avocado.utils import path as utils_path
@@ -25,6 +27,103 @@ class TestStdOutput(unittest.TestCase):
             std.enable_paginator()
         self.assertEqual(self.stdout, sys.stdout)
         self.assertEqual(self.stderr, sys.stderr)
+
+
+class TestLogPluginFailures(unittest.TestCase):
+    @staticmethod
+    def _raised_import_error():
+        try:
+            raise ImportError("broken plugin with traceback")
+        except ImportError as exception:
+            return exception
+
+    @staticmethod
+    def _log_plugin_failure(entry_point, exception=None, silenced=None):
+        config = {"plugins.skip_broken_plugin_notification": silenced or []}
+        if exception is None:
+            exception = ImportError("broken plugin")
+        with unittest.mock.patch.object(
+            output.settings, "as_dict", return_value=config
+        ), unittest.mock.patch.object(output.LOG_UI, "error") as log_error:
+            output.log_plugin_failures([(entry_point, exception)])
+        return log_error
+
+    def test_importlib_entry_point(self):
+        entry_point = EntryPoint(
+            name="vt",
+            value="avocado_vt.plugins.vt:VTCli",
+            group="avocado.plugins.cli",
+        )
+
+        log_error = self._log_plugin_failure(entry_point)
+
+        log_error.assert_called_once()
+        self.assertEqual(log_error.call_args[0][1], "avocado_vt.plugins.vt")
+
+    def test_pkg_resources_entry_point(self):
+        entry_point = types.SimpleNamespace(module_name="avocado.plugins.jobs")
+
+        log_error = self._log_plugin_failure(entry_point)
+
+        log_error.assert_called_once()
+        self.assertEqual(log_error.call_args[0][1], "avocado.plugins.jobs")
+
+    def test_entry_point_value_fallback(self):
+        entry_point = types.SimpleNamespace(
+            value="avocado.plugins.legacy:LegacyPlugin [extra]"
+        )
+
+        log_error = self._log_plugin_failure(entry_point)
+
+        log_error.assert_called_once()
+        self.assertEqual(log_error.call_args[0][1], "avocado.plugins.legacy")
+
+    def test_entry_point_value_fallback_with_extras(self):
+        entry_point = types.SimpleNamespace(value="avocado.plugins.legacy [extra]")
+
+        log_error = self._log_plugin_failure(entry_point)
+
+        log_error.assert_called_once()
+        self.assertEqual(log_error.call_args[0][1], "avocado.plugins.legacy")
+
+    def test_traceback_is_logged_for_plugin_failure(self):
+        entry_point = EntryPoint(
+            name="vt",
+            value="avocado_vt.plugins.vt:VTCli",
+            group="avocado.plugins.cli",
+        )
+        exception = self._raised_import_error()
+
+        log_error = self._log_plugin_failure(entry_point, exception=exception)
+
+        log_error.assert_called_once()
+        logged_traceback = log_error.call_args[0][3]
+        self.assertIn("_raised_import_error", logged_traceback)
+        self.assertIn(
+            'raise ImportError("broken plugin with traceback")', logged_traceback
+        )
+
+    def test_silenced_importlib_entry_point(self):
+        entry_point = EntryPoint(
+            name="vt",
+            value="avocado_vt.plugins.vt:VTCli",
+            group="avocado.plugins.cli",
+        )
+
+        log_error = self._log_plugin_failure(
+            entry_point, silenced=["avocado_vt.plugins.vt"]
+        )
+
+        log_error.assert_not_called()
+
+    def test_silenced_pkg_resources_entry_point(self):
+        entry_point = types.SimpleNamespace(module_name="avocado.plugins.jobs")
+
+        log_error = self._log_plugin_failure(
+            entry_point, silenced=["avocado.plugins.jobs"]
+        )
+
+        log_error.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Log the plugin failure based on a module name that is supported across multiple python versions. Test both main cases and a fallback case, as well as additional use with stack trace.