### PR TITLE
job: resume execution after test failures (intrupted)

### DIFF
--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -274,6 +274,26 @@ class TestSuite:
             self._variants = variants
         return self._variants
 
+    @staticmethod
+    def _runnable_name(runnable):
+        """Return the stable name for a variant-expanded runnable.
+
+        This produces the same string that
+        :class:`avocado.plugins.jsonresult.JSONResult` stores as the
+        ``"name"`` field in ``results.json``:
+        ``"{identifier}"`` when no variant is set, or
+        ``"{identifier};{variant_id}"`` when a variant is set.
+
+        :param runnable: a variant-expanded runnable
+        :type runnable: :class:`avocado.core.nrunner.runnable.Runnable`
+        :returns: stable test+variant name string
+        :rtype: str
+        """
+        variant_id = (runnable.variant or {}).get("variant_id")
+        if variant_id:
+            return f"{runnable.identifier};{variant_id}"
+        return runnable.identifier
+
     def _get_test_variants(self):
         def add_variant(runnable, variant):
             runnable = deepcopy(runnable)

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -366,6 +366,13 @@ class TestSuite:
         if suite.test_parameters or suite.variants:
             suite.tests = suite._get_test_variants()
 
+        completed = config.get("job.replay.resume.completed_tests")
+        if completed:
+            suite.tests = [
+                r for r in suite.tests
+                if cls._runnable_name(r) not in completed
+            ]
+
         if not config.get("run.ignore_missing_references"):
             if not suite.tests:
                 msg = (

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -289,7 +289,7 @@ class TestSuite:
         :returns: stable test+variant name string
         :rtype: str
         """
-        variant_id = (runnable.variant or {}).get("variant_id")
+        variant_id = runnable.variant.get("variant_id") if isinstance(runnable.variant, dict) else None
         if variant_id:
             return f"{runnable.identifier};{variant_id}"
         return runnable.identifier

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -368,9 +368,10 @@ class TestSuite:
 
         completed = config.get("job.replay.resume.completed_tests")
         if completed:
+            completed_set = set(completed)
             suite.tests = [
                 r for r in suite.tests
-                if cls._runnable_name(r) not in completed
+                if cls._runnable_name(r) not in completed_set
             ]
 
         if not config.get("run.ignore_missing_references"):

--- a/avocado/core/suite.py
+++ b/avocado/core/suite.py
@@ -110,6 +110,7 @@ class TestSuite:
         self._references = None
         self._runner = None
         self._test_parameters = None
+        self.resume_start_index = 0
 
         self._check_both_parameters_and_variants()
 
@@ -289,7 +290,11 @@ class TestSuite:
         :returns: stable test+variant name string
         :rtype: str
         """
-        variant_id = runnable.variant.get("variant_id") if isinstance(runnable.variant, dict) else None
+        variant_id = (
+            runnable.variant.get("variant_id")
+            if isinstance(runnable.variant, dict)
+            else None
+        )
         if variant_id:
             return f"{runnable.identifier};{variant_id}"
         return runnable.identifier
@@ -370,9 +375,11 @@ class TestSuite:
         if completed:
             completed_set = set(completed)
             suite.tests = [
-                r for r in suite.tests
-                if cls._runnable_name(r) not in completed_set
+                r for r in suite.tests if cls._runnable_name(r) not in completed_set
             ]
+            suite.resume_start_index = len(completed_set)
+        else:
+            suite.resume_start_index = 0
 
         if not config.get("run.ignore_missing_references"):
             if not suite.tests:

--- a/avocado/core/task/runtime.py
+++ b/avocado/core/task/runtime.py
@@ -303,6 +303,7 @@ class RuntimeTaskGraph:
         job_id,
         base_dir,
         suite_config=None,
+        index_offset=0,
     ):
         """Instantiates a new RuntimeTaskGraph.
 
@@ -324,11 +325,16 @@ class RuntimeTaskGraph:
         :type base_dir: str
         :param suite_config: Configuration dict relevant for the whole suite.
         :type suite_config: dict
+        :param index_offset: number of tests already completed (resume mode);
+                             test numbering starts at index_offset+1 and the
+                             total reflects the full original count.
+        :type index_offset: int
         """
         self.graph = {}
         # create graph
-        no_digits = len(str(len(tests)))
-        for index, runnable in enumerate(tests, start=1):
+        total = len(tests) + index_offset
+        no_digits = len(str(total))
+        for index, runnable in enumerate(tests, start=index_offset + 1):
             runtime_test = RuntimeTask.from_runnable(
                 runnable,
                 no_digits,

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -15,6 +15,7 @@
 """Replay Job Plugin"""
 
 import json
+import os
 import sys
 
 from avocado.core import exit_codes, job, output
@@ -46,6 +47,20 @@ class Replay(CLICmd):
             positional_arg=True,
             parser=parser,
         )
+        help_msg = (
+            "Resume the job, skipping tests (and their variants) that "
+            "already passed or were skipped in the source job."
+        )
+        settings.register_option(
+            section="job.replay",
+            key="resume",
+            help_msg=help_msg,
+            default=False,
+            key_type=bool,
+            action="store_true",
+            parser=parser,
+            long_arg="--resume",
+        )
 
     @staticmethod
     def _exit_fail(message):
@@ -67,9 +82,44 @@ class Replay(CLICmd):
             msg = f"Could not read a valid configuration " f'of Job "{source_job_id}"'
             Replay._exit_fail(msg)
 
+    @staticmethod
+    def _load_completed_test_names(results_dir):
+        """Return the set of test name strings that already passed or were
+        skipped in the source job.
+
+        Each entry is ``"{identifier};{variant_id}"`` (or just
+        ``"{identifier}"`` when no variant was used), matching the ``name``
+        field written by :class:`avocado.plugins.jsonresult.JSONResult`.
+
+        :param results_dir: path to the source job results directory
+        :type results_dir: str
+        :returns: set of completed test name strings
+        :rtype: set
+        """
+        results_path = os.path.join(results_dir, "results.json")
+        if not os.path.exists(results_path):
+            return set()
+        try:
+            with open(results_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, json.decoder.JSONDecodeError):
+            return set()
+        return {
+            t["name"]
+            for t in data.get("tests", [])
+            if t.get("status", "").upper() in ("PASS", "SKIP")
+        }
+
     def run(self, config):
         namespace = "job.replay.source_job_id"
         source_job_id = config.get(namespace)
+        results_dir = get_job_results_dir(source_job_id)
+        if not results_dir:
+            msg = (
+                f"Could not find the results directory "
+                f'for Job "{source_job_id}"'
+            )
+            self._exit_fail(msg)
         source_job_config = self._retrieve_source_job_config(source_job_id)
         if hasattr(source_job_config, namespace):
             del source_job_config[namespace]
@@ -77,6 +127,14 @@ class Replay(CLICmd):
         # tell solely based on the job.replay.source_job_id given that it
         # has a default value of 'latest' for convenience reasons
         source_job_config["job.replay.enabled"] = True
+        if config.get("job.replay.resume"):
+            completed = self._load_completed_test_names(results_dir)
+            if completed:
+                output.LOG_UI.info(
+                    "Resume mode: skipping %d previously completed test(s).",
+                    len(completed),
+                )
+            source_job_config["job.replay.resume.completed_tests"] = completed
         with job.Job.from_config(source_job_config) as job_instance:
             job_run = job_instance.run()
         return job_run

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -104,11 +104,13 @@ class Replay(CLICmd):
                 data = json.load(fh)
         except (OSError, json.decoder.JSONDecodeError):
             return set()
-        return {
-            t["name"]
-            for t in data.get("tests", [])
-            if t.get("status", "").upper() in ("PASS", "SKIP")
-        }
+        completed = set()
+        for t in data.get("tests", []):
+            name = t.get("name")
+            status = t.get("status")
+            if name and isinstance(status, str) and status.upper() in ("PASS", "SKIP"):
+                completed.add(name)
+        return completed
 
     def run(self, config):
         namespace = "job.replay.source_job_id"
@@ -134,7 +136,7 @@ class Replay(CLICmd):
                     "Resume mode: skipping %d previously completed test(s).",
                     len(completed),
                 )
-            source_job_config["job.replay.resume.completed_tests"] = completed
+            source_job_config["job.replay.resume.completed_tests"] = list(completed)
         with job.Job.from_config(source_job_config) as job_instance:
             job_run = job_instance.run()
         return job_run

--- a/avocado/plugins/replay.py
+++ b/avocado/plugins/replay.py
@@ -68,11 +68,7 @@ class Replay(CLICmd):
         sys.exit(exit_codes.AVOCADO_FAIL)
 
     @staticmethod
-    def _retrieve_source_job_config(source_job_id):
-        results_dir = get_job_results_dir(source_job_id)
-        if not results_dir:
-            msg = f"Could not find the results directory " f'for Job "{source_job_id}"'
-            Replay._exit_fail(msg)
+    def _retrieve_source_job_config(source_job_id, results_dir):
         try:
             return retrieve_job_config(results_dir)
         except OSError:
@@ -83,20 +79,14 @@ class Replay(CLICmd):
             Replay._exit_fail(msg)
 
     @staticmethod
-    def _load_completed_test_names(results_dir):
-        """Return the set of test name strings that already passed or were
-        skipped in the source job.
+    def _collect_from_results_json(results_path):
+        """Return PASS/SKIP test names from a single results.json file.
 
-        Each entry is ``"{identifier};{variant_id}"`` (or just
-        ``"{identifier}"`` when no variant was used), matching the ``name``
-        field written by :class:`avocado.plugins.jsonresult.JSONResult`.
-
-        :param results_dir: path to the source job results directory
-        :type results_dir: str
+        :param results_path: absolute path to a results.json file
+        :type results_path: str
         :returns: set of completed test name strings
         :rtype: set
         """
-        results_path = os.path.join(results_dir, "results.json")
         if not os.path.exists(results_path):
             return set()
         try:
@@ -112,17 +102,96 @@ class Replay(CLICmd):
                 completed.add(name)
         return completed
 
+    @staticmethod
+    def _load_completed_test_names(results_dir):
+        """Return the set of test names already passed or skipped across the
+        full replay chain rooted at *results_dir*.
+
+        When a job is interrupted and replayed multiple times, each replay
+        job dir stores only the results of *that* run.  To find the complete
+        set of tests that must be skipped on the next resume we must walk the
+        chain:
+
+          results_dir  →  its replay job dir  →  that job's replay dir  →  …
+
+        Each link is found via the ``job.replay.source_job_id`` key stored
+        in ``jobdata/args.json`` of the *replaying* job.  We follow the chain
+        forward (newer → older is already covered by the root dir itself;
+        we follow forward through all replay dirs that pointed *back* to
+        this root) by scanning all job dirs in the same logs directory.
+
+        Practically, we collect PASS/SKIP names from every job dir whose
+        source is the same root job id, plus the root dir itself.
+
+        :param results_dir: path to the *original* (root) source job results
+                            directory
+        :type results_dir: str
+        :returns: cumulative set of completed test name strings
+        :rtype: set
+        """
+        completed = Replay._collect_from_results_json(
+            os.path.join(results_dir, "results.json")
+        )
+
+        # Read the root job id so we can find all replay dirs that used it
+        # as their source.
+        root_id_path = os.path.join(results_dir, "id")
+        if not os.path.isfile(root_id_path):
+            return completed
+        try:
+            with open(root_id_path, "r", encoding="utf-8") as fh:
+                root_id = fh.read().strip()
+        except OSError:
+            return completed
+        if not root_id:
+            return completed
+
+        # Walk all sibling job dirs looking for replay dirs whose source_job_id
+        # matches the root job id (full or prefix match, as avocado stores it).
+        logs_dir = os.path.dirname(results_dir)
+        try:
+            entries = sorted(os.listdir(logs_dir))
+        except OSError:
+            return completed
+
+        visited = {os.path.abspath(results_dir)}
+        for entry in entries:
+            job_path = os.path.join(logs_dir, entry)
+            if not entry.startswith("job-") or not os.path.isdir(job_path):
+                continue
+            abs_path = os.path.abspath(job_path)
+            if abs_path in visited:
+                continue
+            try:
+                cfg = retrieve_job_config(job_path)
+            except Exception:  # noqa: BLE001
+                continue
+            if cfg is None:
+                continue
+            src = cfg.get("job.replay.source_job_id", "")
+            # src may be a full path (when wrapper passes absolute path) or
+            # a job id string; either way we match against the root dir path
+            # and the root job id.
+            if (
+                src == results_dir
+                or src == os.path.abspath(results_dir)
+                or (isinstance(src, str) and root_id.startswith(src))
+            ):
+                visited.add(abs_path)
+                completed |= Replay._collect_from_results_json(
+                    os.path.join(job_path, "results.json")
+                )
+
+        return completed
+
     def run(self, config):
         namespace = "job.replay.source_job_id"
         source_job_id = config.get(namespace)
         results_dir = get_job_results_dir(source_job_id)
         if not results_dir:
-            msg = (
-                f"Could not find the results directory "
-                f'for Job "{source_job_id}"'
-            )
+            msg = f"Could not find the results directory " f'for Job "{source_job_id}"'
             self._exit_fail(msg)
-        source_job_config = self._retrieve_source_job_config(source_job_id)
+        source_job_config = self._retrieve_source_job_config(source_job_id, results_dir)
         if hasattr(source_job_config, namespace):
             del source_job_config[namespace]
         # Flag that this is indeed a replayed job, which is impossible to

--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -292,7 +292,8 @@ class Runner(SuiteRunner):
 
         self._abort_if_missing_runners(missing_requirements)
 
-        job.result.tests_total = len(test_suite.tests)
+        resume_start_index = getattr(test_suite, "resume_start_index", 0)
+        job.result.tests_total = len(test_suite.tests) + resume_start_index
 
         self._create_status_server(test_suite, job)
 
@@ -303,6 +304,7 @@ class Runner(SuiteRunner):
             job.unique_id,
             job.test_results_path,
             test_suite.config,
+            index_offset=resume_start_index,
         )
         # pylint: disable=W0201
         self.runtime_tasks = graph.get_tasks_in_topological_order()

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -27,7 +27,7 @@ TEST_SIZE = {
     "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 90,
     "nrunner-requirement": 28,
-    "unit": 1016,
+    "unit": 1027,
     "jobs": 11,
     "functional-parallel": 368,
     "functional-serial": 7,

--- a/selftests/unit/test_replay_resume.py
+++ b/selftests/unit/test_replay_resume.py
@@ -1,0 +1,131 @@
+"""Unit tests for variant-aware replay resume.
+
+Covers:
+  - TestSuite._runnable_name()
+  - Replay._load_completed_test_names()
+  - The filtering integration (runnable_name vs completed set)
+"""
+import json
+import os
+import tempfile
+import unittest
+
+
+class FakeRunnable:
+    """Minimal stand-in for avocado.core.nrunner.runnable.Runnable."""
+
+    def __init__(self, identifier, variant=None):
+        self.identifier = identifier
+        self.variant = variant
+
+
+class TestRunnableName(unittest.TestCase):
+    """Tests for TestSuite._runnable_name()."""
+
+    def setUp(self):
+        from avocado.core.suite import TestSuite
+        self.fn = TestSuite._runnable_name
+
+    def test_no_variant(self):
+        r = FakeRunnable("examples/tests/passtest.py:PassTest.test", variant=None)
+        self.assertEqual(
+            self.fn(r),
+            "examples/tests/passtest.py:PassTest.test",
+        )
+
+    def test_with_variant_id(self):
+        r = FakeRunnable(
+            "examples/tests/passtest.py:PassTest.test",
+            variant={"variant_id": "fast-abc1", "variant": [], "paths": ["/"]},
+        )
+        self.assertEqual(
+            self.fn(r),
+            "examples/tests/passtest.py:PassTest.test;fast-abc1",
+        )
+
+    def test_variant_id_none(self):
+        """variant dict present but variant_id is None → no suffix."""
+        r = FakeRunnable(
+            "examples/tests/passtest.py:PassTest.test",
+            variant={"variant_id": None, "variant": [], "paths": ["/"]},
+        )
+        self.assertEqual(
+            self.fn(r),
+            "examples/tests/passtest.py:PassTest.test",
+        )
+
+
+class TestLoadCompletedTestNames(unittest.TestCase):
+    """Tests for Replay._load_completed_test_names()."""
+
+    def setUp(self):
+        from avocado.plugins.replay import Replay
+        self.load = Replay._load_completed_test_names
+
+    def test_pass_and_skip_collected(self):
+        with tempfile.TemporaryDirectory() as d:
+            data = {
+                "tests": [
+                    {"name": "mytest.py:T.test;v1", "status": "PASS"},
+                    {"name": "mytest.py:T.test;v2", "status": "FAIL"},
+                    {"name": "mytest.py:T.test;v3", "status": "SKIP"},
+                    {"name": "mytest.py:T.test;v4", "status": "ERROR"},
+                ]
+            }
+            with open(os.path.join(d, "results.json"), "w", encoding="utf-8") as f:
+                json.dump(data, f)
+            completed = self.load(d)
+        self.assertEqual(
+            completed,
+            {"mytest.py:T.test;v1", "mytest.py:T.test;v3"},
+        )
+
+    def test_missing_results_json(self):
+        """Missing results.json returns empty set without raising."""
+        self.assertEqual(self.load("/nonexistent/path/xyz"), set())
+
+    def test_empty_tests_list(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "results.json"), "w", encoding="utf-8") as f:
+                json.dump({"tests": []}, f)
+            self.assertEqual(self.load(d), set())
+
+    def test_corrupt_json_returns_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "results.json"), "w", encoding="utf-8") as f:
+                f.write("not valid json {{")
+            self.assertEqual(self.load(d), set())
+
+
+class TestResumeFiltering(unittest.TestCase):
+    """Integration: _runnable_name matches what _load_completed_test_names returns."""
+
+    def test_filters_out_completed_variants_only(self):
+        from avocado.core.suite import TestSuite
+
+        completed = {"mytest.py:T.test;v1", "mytest.py:T.test;v3"}
+        runnables = [
+            FakeRunnable("mytest.py:T.test", {"variant_id": "v1", "variant": [], "paths": ["/"]}),
+            FakeRunnable("mytest.py:T.test", {"variant_id": "v2", "variant": [], "paths": ["/"]}),
+            FakeRunnable("mytest.py:T.test", {"variant_id": "v3", "variant": [], "paths": ["/"]}),
+            FakeRunnable("mytest.py:T.test", {"variant_id": "v4", "variant": [], "paths": ["/"]}),
+        ]
+        remaining = [r for r in runnables if TestSuite._runnable_name(r) not in completed]
+        self.assertEqual(len(remaining), 2)
+        self.assertEqual(TestSuite._runnable_name(remaining[0]), "mytest.py:T.test;v2")
+        self.assertEqual(TestSuite._runnable_name(remaining[1]), "mytest.py:T.test;v4")
+
+    def test_no_completed_keeps_all(self):
+        from avocado.core.suite import TestSuite
+
+        runnables = [
+            FakeRunnable("mytest.py:T.test", {"variant_id": "v1", "variant": [], "paths": ["/"]}),
+            FakeRunnable("mytest.py:T.test", {"variant_id": "v2", "variant": [], "paths": ["/"]}),
+        ]
+        # empty completed set → nothing filtered
+        remaining = [r for r in runnables if TestSuite._runnable_name(r) not in set()]
+        self.assertEqual(len(remaining), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/selftests/unit/test_replay_resume.py
+++ b/selftests/unit/test_replay_resume.py
@@ -5,6 +5,7 @@ Covers:
   - Replay._load_completed_test_names()
   - The filtering integration (runnable_name vs completed set)
 """
+
 import json
 import os
 import tempfile
@@ -24,6 +25,7 @@ class TestRunnableName(unittest.TestCase):
 
     def setUp(self):
         from avocado.core.suite import TestSuite
+
         self.fn = TestSuite._runnable_name
 
     def test_no_variant(self):
@@ -55,26 +57,48 @@ class TestRunnableName(unittest.TestCase):
         )
 
 
+def _write_job_dir(parent, name, job_id, results, source_job_id=None):
+    """Helper: create a fake avocado job dir under *parent/name*.
+
+    Writes ``id``, ``results.json``, and optionally ``jobdata/args.json``
+    (with ``job.replay.source_job_id``) so the chain-walk tests work.
+    """
+    job_path = os.path.join(parent, name)
+    os.makedirs(job_path, exist_ok=True)
+    with open(os.path.join(job_path, "id"), "w", encoding="utf-8") as f:
+        f.write(job_id)
+    with open(os.path.join(job_path, "results.json"), "w", encoding="utf-8") as f:
+        json.dump({"tests": results}, f)
+    if source_job_id is not None:
+        jobdata_dir = os.path.join(job_path, "jobdata")
+        os.makedirs(jobdata_dir, exist_ok=True)
+        with open(os.path.join(jobdata_dir, "args.json"), "w", encoding="utf-8") as f:
+            json.dump({"job.replay.source_job_id": source_job_id}, f)
+    return job_path
+
+
 class TestLoadCompletedTestNames(unittest.TestCase):
     """Tests for Replay._load_completed_test_names()."""
 
     def setUp(self):
         from avocado.plugins.replay import Replay
+
         self.load = Replay._load_completed_test_names
 
     def test_pass_and_skip_collected(self):
-        with tempfile.TemporaryDirectory() as d:
-            data = {
-                "tests": [
+        with tempfile.TemporaryDirectory() as logs_dir:
+            src = _write_job_dir(
+                logs_dir,
+                "job-orig",
+                "aaa111",
+                [
                     {"name": "mytest.py:T.test;v1", "status": "PASS"},
                     {"name": "mytest.py:T.test;v2", "status": "FAIL"},
                     {"name": "mytest.py:T.test;v3", "status": "SKIP"},
                     {"name": "mytest.py:T.test;v4", "status": "ERROR"},
-                ]
-            }
-            with open(os.path.join(d, "results.json"), "w", encoding="utf-8") as f:
-                json.dump(data, f)
-            completed = self.load(d)
+                ],
+            )
+            completed = self.load(src)
         self.assertEqual(
             completed,
             {"mytest.py:T.test;v1", "mytest.py:T.test;v3"},
@@ -85,16 +109,85 @@ class TestLoadCompletedTestNames(unittest.TestCase):
         self.assertEqual(self.load("/nonexistent/path/xyz"), set())
 
     def test_empty_tests_list(self):
-        with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, "results.json"), "w", encoding="utf-8") as f:
-                json.dump({"tests": []}, f)
-            self.assertEqual(self.load(d), set())
+        with tempfile.TemporaryDirectory() as logs_dir:
+            src = _write_job_dir(logs_dir, "job-orig", "aaa111", [])
+            self.assertEqual(self.load(src), set())
 
     def test_corrupt_json_returns_empty(self):
-        with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, "results.json"), "w", encoding="utf-8") as f:
+        with tempfile.TemporaryDirectory() as logs_dir:
+            src = _write_job_dir(logs_dir, "job-orig", "aaa111", [])
+            # overwrite results.json with garbage
+            with open(os.path.join(src, "results.json"), "w", encoding="utf-8") as f:
                 f.write("not valid json {{")
-            self.assertEqual(self.load(d), set())
+            self.assertEqual(self.load(src), set())
+
+    def test_chain_walk_accumulates_across_replay_dirs(self):
+        """PASS/SKIP names are collected from all replay dirs in the chain."""
+        with tempfile.TemporaryDirectory() as logs_dir:
+            root_id = "aaa111bbb222ccc333"
+            src = _write_job_dir(
+                logs_dir,
+                "job-orig",
+                root_id,
+                [
+                    {"name": "t.py:T.test_a", "status": "PASS"},
+                    {"name": "t.py:T.test_b", "status": "FAIL"},
+                ],
+            )
+            # First replay: interrupted after test_c
+            _write_job_dir(
+                logs_dir,
+                "job-replay1",
+                "replay1id",
+                [
+                    {"name": "t.py:T.test_c", "status": "PASS"},
+                    {"name": "t.py:T.test_d", "status": "INTERRUPT"},
+                ],
+                source_job_id=src,
+            )
+            # Second replay: picks up from test_d
+            _write_job_dir(
+                logs_dir,
+                "job-replay2",
+                "replay2id",
+                [
+                    {"name": "t.py:T.test_d", "status": "PASS"},
+                    {"name": "t.py:T.test_e", "status": "INTERRUPT"},
+                ],
+                source_job_id=src,
+            )
+
+            completed = self.load(src)
+
+        self.assertEqual(
+            completed,
+            {"t.py:T.test_a", "t.py:T.test_c", "t.py:T.test_d"},
+        )
+
+    def test_chain_walk_ignores_unrelated_dirs(self):
+        """Job dirs with a different source_job_id are not included."""
+        with tempfile.TemporaryDirectory() as logs_dir:
+            src = _write_job_dir(
+                logs_dir,
+                "job-orig",
+                "aaa111",
+                [
+                    {"name": "t.py:T.test_a", "status": "PASS"},
+                ],
+            )
+            # Unrelated replay pointing to a different source
+            _write_job_dir(
+                logs_dir,
+                "job-other",
+                "otherid",
+                [
+                    {"name": "t.py:T.test_z", "status": "PASS"},
+                ],
+                source_job_id="/some/other/path",
+            )
+
+            completed = self.load(src)
+        self.assertEqual(completed, {"t.py:T.test_a"})
 
 
 class TestResumeFiltering(unittest.TestCase):
@@ -105,12 +198,22 @@ class TestResumeFiltering(unittest.TestCase):
 
         completed = {"mytest.py:T.test;v1", "mytest.py:T.test;v3"}
         runnables = [
-            FakeRunnable("mytest.py:T.test", {"variant_id": "v1", "variant": [], "paths": ["/"]}),
-            FakeRunnable("mytest.py:T.test", {"variant_id": "v2", "variant": [], "paths": ["/"]}),
-            FakeRunnable("mytest.py:T.test", {"variant_id": "v3", "variant": [], "paths": ["/"]}),
-            FakeRunnable("mytest.py:T.test", {"variant_id": "v4", "variant": [], "paths": ["/"]}),
+            FakeRunnable(
+                "mytest.py:T.test", {"variant_id": "v1", "variant": [], "paths": ["/"]}
+            ),
+            FakeRunnable(
+                "mytest.py:T.test", {"variant_id": "v2", "variant": [], "paths": ["/"]}
+            ),
+            FakeRunnable(
+                "mytest.py:T.test", {"variant_id": "v3", "variant": [], "paths": ["/"]}
+            ),
+            FakeRunnable(
+                "mytest.py:T.test", {"variant_id": "v4", "variant": [], "paths": ["/"]}
+            ),
         ]
-        remaining = [r for r in runnables if TestSuite._runnable_name(r) not in completed]
+        remaining = [
+            r for r in runnables if TestSuite._runnable_name(r) not in completed
+        ]
         self.assertEqual(len(remaining), 2)
         self.assertEqual(TestSuite._runnable_name(remaining[0]), "mytest.py:T.test;v2")
         self.assertEqual(TestSuite._runnable_name(remaining[1]), "mytest.py:T.test;v4")
@@ -119,8 +222,12 @@ class TestResumeFiltering(unittest.TestCase):
         from avocado.core.suite import TestSuite
 
         runnables = [
-            FakeRunnable("mytest.py:T.test", {"variant_id": "v1", "variant": [], "paths": ["/"]}),
-            FakeRunnable("mytest.py:T.test", {"variant_id": "v2", "variant": [], "paths": ["/"]}),
+            FakeRunnable(
+                "mytest.py:T.test", {"variant_id": "v1", "variant": [], "paths": ["/"]}
+            ),
+            FakeRunnable(
+                "mytest.py:T.test", {"variant_id": "v2", "variant": [], "paths": ["/"]}
+            ),
         ]
         # empty completed set → nothing filtered
         remaining = [r for r in runnables if TestSuite._runnable_name(r) not in set()]


### PR DESCRIPTION
Enable job resume functionality to continue execution after test failures, avoiding re-execution of already completed tests and improving recovery for long-running test runs.