### PR TITLE
feat: make job log prefixes configurable

### DIFF
--- a/avocado/core/job.py
+++ b/avocado/core/job.py
@@ -102,6 +102,27 @@ def register_job_options():
         key_type=int,
     )
 
+    settings.register_option(
+        section="job.run",
+        key="logging_format",
+        help_msg=(
+            "Format string used for file-based log records. It follows the "
+            "Python logging format syntax."
+        ),
+        default=(
+            "%(asctime)s %(name)s %(module)-16.16s L%(lineno)-.4d "
+            "%(levelname)-5.5s| %(message)s"
+        ),
+    )
+
+    settings.register_option(
+        section="job.run",
+        key="log_task_identifier",
+        help_msg="Whether to prefix test log messages with the task identifier.",
+        default=True,
+        key_type=bool,
+    )
+
 
 register_job_options()
 
@@ -222,7 +243,7 @@ class Job:
     def __start_job_logging(self):
         # Enable test logger
         full_log = os.path.join(self.logdir, "full.log")
-        fmt = "%(asctime)s %(name)s %(module)-16.16s L%(lineno)-.4d %(levelname)-5.5s| %(message)s"
+        fmt = self.config.get("job.run.logging_format")
         buffer_size = self.config.get("job.run.logging_buffer_size")
         output.add_log_handler(
             LOG_JOB,

--- a/avocado/core/messages.py
+++ b/avocado/core/messages.py
@@ -374,7 +374,9 @@ class LogMessageHandler(BaseRunningMessageHandler):
         if log_name is not None and log_name != "avocado.app":
             logger = logging.getLogger(log_name)
             level = logging.getLevelName(message.get("log_levelname"))
-            log_message = f"{task.identifier}: {message.get('log').decode(message.get('encoding'))}"
+            log_message = message.get("log").decode(message.get("encoding"))
+            if job.config.get("job.run.log_task_identifier", True):
+                log_message = f"{task.identifier}: {log_message}"
             logger_level = logger.level
             try:
                 logger.setLevel(level)

--- a/docs/source/guides/writer/chapters/logging.rst
+++ b/docs/source/guides/writer/chapters/logging.rst
@@ -198,6 +198,17 @@ Again you could watch the progress with::
     2023-04-13 17:54:18,916 avocado.job INFO |  'core.show': {'app'},
     ...
 
+The file log prefix can be customized with the ``job.run.logging_format``
+setting. It accepts the standard Python logging format fields. For example,
+to keep only the timestamp, logger name, level, and message, set::
+
+    [job.run]
+    logging_format = "%(asctime)s %(name)s %(levelname)s| %(message)s"
+
+Test messages include their task identifier by default. Set
+``job.run.log_task_identifier`` to ``False`` when the identifier is already
+present in another part of the output or when a shorter log is preferred.
+
 External logs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

- make the format of file-based job log records configurable via `job.run.logging_format`
- add `job.run.log_task_identifier` to control task-id prefixes on named test loggers
- document both settings with an example

## Why

Avocado currently hardcodes a verbose prefix and always prepends the full task identifier to test logger messages. This makes `full.log` and `--show` output harder to scan for projects with long paths. Defaults are unchanged, while users can now choose a compact format and disable the redundant identifier when needed.

## Validation

- `python -m compileall -q avocado/core/job.py avocado/core/messages.py`
- `git diff --check`

Fixes #6263