### PR TITLE
Close nrunner status server before cancellation

### DIFF
--- a/avocado/plugins/runner_nrunner.py
+++ b/avocado/plugins/runner_nrunner.py
@@ -386,6 +386,8 @@ class Runner(SuiteRunner):
         loop.run_until_complete(asyncio.sleep(0.05))
 
         job.result.end_tests()
+        # Wake the status server before waiting for its serve_forever task.
+        self.status_server.close()
         # Cancel pending asyncio tasks before closing
         for task_attr in ('status_updater_task', 'status_server_task'):
             task = getattr(self, task_attr, None)
@@ -396,7 +398,6 @@ class Runner(SuiteRunner):
                         loop.run_until_complete(task)
                     except asyncio.CancelledError:
                         pass
-        self.status_server.close()
         if self.status_server_dir is not None:
             self.status_server_dir.cleanup()
 


### PR DESCRIPTION
The nrunner cleanup path cancelled the StatusServer.serve_forever() task and only closed the underlying server afterwards. On Python 3.12 this can leave the task stuck in a cancelling state, so the job hangs after the final test status and never reaches result reporting.

Close the server first so serve_forever is explicitly woken up, then keep the existing cancellation flow for pending asyncio tasks.

More details:

Cancelling serve_forever() is normal and Python documents that as the intended way to stop a serve_forever() coroutine: cancellation makes the server close. The subtlety is that server.close() and the event “the serve_forever task is gone” are different things, at least in some transitional and less stable python versions.

The Avocado calls ordering relies on cancellation itself to drive the whole server shutdown. In the Python 3.12 CI, the task entered such “cancelling” but stayed parked inside serve_forever() cleanup, so Avocado never reached self.status_server.close().

This explicitly wakes/closes the underlying server first, then cancels/awaits the long-lived task so it can be reaped. The fix is that cancellation should not be the only thing responsible for initiating server shutdown and turns an implicit shutdown via task cancellation into an explicit resource shutdown followed by task cleanup. It should sound cosmetic but actually fixed Python 3.12 runs.