### PR TITLE
avocado.utils.archive: log file path on chmod-failure warning

### DIFF
--- a/avocado/utils/archive.py
+++ b/avocado/utils/archive.py
@@ -452,7 +452,7 @@ class ArchiveFile:
                 try:
                     os.chmod(dst, mode)
                 except (OSError, FileNotFoundError) as e:
-                    LOG.warning("Failed to update permissions for '%s'", e)
+                    LOG.warning("Failed to update permissions for '%s': %s", dst, e)
 
     def close(self):
         """


### PR DESCRIPTION
The chmod branch of _update_zip_extra_attrs logged the exception object in place of the file path, so a permission update failure named 'OSError(...)' instead of the affected archive member.  The adjacent symlink branch already logged (dst, e) correctly; align the chmod branch with it so failures point at the actual file.