### PR TITLE
Skip all regular workflows mean for the origin repo on forks

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,6 +10,7 @@ jobs:
 
   make-check:
     name: Run 'make check'
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
@@ -40,6 +41,7 @@ jobs:
 
   avocado-pre-release:
     name: Avocado pre-release job
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -60,9 +62,9 @@ jobs:
           retention-days: 1
 
   check-rpm-available-copr:
-    # temporarily disabled: current maintainers don't have COPR access
-    if: ${{ false }}
     name: Check the right RPM packages are available in COPR
+    # temporarily disabled: current maintainers don't have COPR access
+    if: ${{ github.repository == 'avocado-framework/avocado' && false }}
     runs-on: ubuntu-latest
     timeout-minutes: 130
     steps:
@@ -74,6 +76,7 @@ jobs:
 
   avocado-deployment-copr:
     name: Avocado deployment
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-latest
     container:
       image: fedora:42
@@ -101,6 +104,7 @@ jobs:
 
   package-build:
     name: Build Package (wheel/tarball)
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
@@ -116,7 +120,7 @@ jobs:
 
   publish-to-test-pypi:
     name: Publish Avocado to TestPyPI
-    if: github.repository == 'avocado-framework/avocado'
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     needs:
     - package-build
     runs-on: ubuntu-latest

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -12,6 +12,7 @@ jobs:
 
   user-installation:
     name: User installation commands
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -54,6 +55,7 @@ jobs:
 
   system-wide-installation:
     name: System wide installation commands
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -96,6 +98,7 @@ jobs:
 
   devel-user-installation:
     name: Developer user commands
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -137,6 +140,7 @@ jobs:
 
   devel-wide-system-installation:
     name: Developer system wide commands
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -178,6 +182,7 @@ jobs:
 
   virtualenv-installation:
     name: Virtualenv installation
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-22.04
 
     steps:
@@ -211,6 +216,7 @@ jobs:
 
   devel-virtualenv-installation:
     name: Developer Virtualenv installation
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,6 +12,7 @@ jobs:
 
   latest-python:
     name: Linux with Python ${{ matrix.python-version }}
+    if: ${{ github.repository == 'avocado-framework/avocado' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -61,9 +62,9 @@ jobs:
 
   without-plugins-latest-python:
     name: Test with Python without plugins ${{ matrix.python-version }}
+    if: ${{ github.repository == 'avocado-framework/avocado' && always() && needs.latest-python.outputs.job_status == 'failure' }}
     runs-on: ubuntu-22.04
     needs: latest-python
-    if: "always()&&(needs.latest-python.outputs.job_status=='failure')"
     strategy:
       matrix:
         # see list of available Python versions at https://github.com/actions/python-versions/blob/main/versions-manifest.json


### PR DESCRIPTION
Pre-release, weekly, and setup tests often assume the origin repo as the one under test failing for forks while also overloading the free CI plan availed by Github as provider via regular runs for each and every fork. Let's avoid that and separate maintenance burden from regular contributions.