### PR TITLE
Prevent OOM from infinitely raised exceptions (and growing traceback)

### DIFF
--- a/avocado/core/status/server.py
+++ b/avocado/core/status/server.py
@@ -56,8 +56,12 @@ class StatusServer:
         while True:
             try:
                 raw_message = await reader.readline()
-            except ConnectionResetError:
-                continue
+            except ConnectionResetError as e:
+                LOG.warning("Connection was reset: %s", e)
+                return
+            except BrokenPipeError as e:
+                LOG.warning("Broken pipe: %s", e)
+                return
             if not raw_message:
                 return
             try:


### PR DESCRIPTION
The reader will already be dead and thus will keep re-rasing the ConnectionResetError which will be added on top of the previous traceback in python until it crosses any environmental memory cap. Return instead to give true chance for the status to be received and for other coroutines to make further progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling for reset or unexpectedly closed client connections.
  * Ensured callbacks terminate cleanly instead of retrying after disconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->