### PR TITLE
feat: add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .settings
 .coverage
 .idea/*
+.venv
 coverage.xml
 xunit.xml
 tmp/*


### PR DESCRIPTION
The `.venv` directory is for Python virtual environments and should be added to `.gitignore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude local Python virtual environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->