### PR TITLE
exec-test: honor keep_tmp during cleanup

### DIFF
--- a/avocado/plugins/runners/exec_test.py
+++ b/avocado/plugins/runners/exec_test.py
@@ -65,7 +65,7 @@ class ExecTestRunner(BaseRunner):
         workdir = runnable.kwargs.get("AVOCADO_TEST_WORKDIR")
         if (
             workdir is not None
-            and runnable.config.get("run.keep_tmp") is not None
+            and not runnable.config.get("run.keep_tmp")
             and os.path.exists(workdir)
         ):
             shutil.rmtree(workdir)


### PR DESCRIPTION
Fix the exec-test runner cleanup logic so it preserves  `AVOCADO_TEST_WORKDIR` when `run.keep_tmp` is enabled.

Previously, the cleanup condition checked whether `run.keep_tmp` was not `None`. Since the option is normally set to either `False` or `True`, the workdir was still removed even when users requested temporary files to be kept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary work directories are now properly removed when temporary-file retention is disabled, improving cleanup after test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->