### PR TITLE
Fix UnboundLocalError in _catch_test_status when ThreadPool creation...

### DIFF
--- a/avocado/core/test.py
+++ b/avocado/core/test.py
@@ -661,6 +661,7 @@ class Test(unittest.TestCase, TestData):
             asyncio.set_event_loop(asyncio.new_event_loop())
             method()
 
+        pool = None
         try:
             pool = multiprocessing.pool.ThreadPool(1)
             res = pool.apply_async(set_new_event_loop_for_method, [method])
@@ -701,7 +702,8 @@ class Test(unittest.TestCase, TestData):
             for e_line in tb_info:
                 self.log.error(e_line)
         finally:
-            pool.terminate()
+            if pool is not None:
+                pool.terminate()
 
     def run_avocado(self):
         """


### PR DESCRIPTION
Initialize pool to None and only terminate it if it was created, so a
failure during ThreadPool setup is not masked by UnboundLocalError in
the finally block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution cleanup to prevent errors when the thread pool cannot be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->