### PR TITLE
Allow for flexible default podman binary path

### DIFF
--- a/avocado/plugins/spawners/podman.py
+++ b/avocado/plugins/spawners/podman.py
@@ -32,9 +32,9 @@ class PodmanSpawnerInit(Init):
     def initialize(self):
         section = "spawner.podman"
 
-        help_msg = "Path to the podman binary"
+        help_msg = "Path or name of the podman binary"
         settings.register_option(
-            section=section, key="bin", help_msg=help_msg, default="/usr/bin/podman"
+            section=section, key="bin", help_msg=help_msg, default="podman"
         )
 
         this_distro = distro.detect()

--- a/docs/source/releases/next.rst
+++ b/docs/source/releases/next.rst
@@ -21,7 +21,8 @@ Utility Modules
 Bug Fixes
 =========
 
-*
+* The Podman spawner now resolves the default ``podman`` binary through
+  ``PATH``, supporting installations outside ``/usr/bin``.
 
 Internal changes
 ================


### PR DESCRIPTION
GitHub changed the Ubuntu 22.04 runner from the distro's Podman 3.4.4 at /usr/bin/podman to a static Podman 5.8.4 bundle installed at /usr/local/bin/podman. The upgrade first appeared in the 20260810 Ubuntu 22.04 runner release and the runner-image change explicitly describes the new location. However, avocado still defaults to /usr/bin/podman and thus breaks in multiple CI workflows. Let's allow for the path to be distro and distro version independent and allow it to resolve in the standard way by not using an absolute path to the binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Podman integration by allowing the executable to be specified by binary name or full path.
  * The default `podman` command is now discovered through the system `PATH`, supporting installations outside `/usr/bin`.

* **Documentation**
  * Added release notes documenting the improved Podman executable resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->