### PR TITLE
utils/nvme: Enhanced get_ns_status to support ns topology fallback

### DIFF
--- a/avocado/utils/nvme.py
+++ b/avocado/utils/nvme.py
@@ -21,7 +21,6 @@
 Nvme utilities
 """
 
-
 import json
 import logging
 import os
@@ -650,26 +649,83 @@ def create_namespaces(controller_name, ns_count, shared_ns=False):
         create_one_ns(ns_id, controller_name, ns_size, shared_ns=shared_ns)
 
 
+def _iter_topology_paths(json_data, ns_id):
+    """
+    Yields (name, state, ana_state) for each path matching the namespace ID.
+
+    Handles both targeted query format (where Name and State reside directly
+    on Path) and whole-system query format (where Name and State are nested
+    under Controller).
+
+    :param json_data: Parsed JSON topology data (list)
+    :param ns_id: Target namespace ID (int)
+    """
+    if not isinstance(json_data, list):
+        return
+
+    for entry in json_data:
+        for subsystem in entry.get("Subsystems", []):
+            for namespace in subsystem.get("Namespaces", []):
+                if namespace.get("NSID") != ns_id:
+                    continue
+                for path in namespace.get("Paths", []):
+                    ana_state = path.get("ANAState")
+                    controllers = path.get("Controller", [])
+                    if controllers:
+                        for ctrl in controllers:
+                            yield ctrl.get("Name"), ctrl.get("State"), ana_state
+                    else:
+                        yield path.get("Name"), path.get("State"), ana_state
+
+
 def get_ns_status(controller_name, ns_id):
     """
-    Returns the status of namespaces on the specified controller
+    Returns the status of namespaces on the specified controller.
 
-    :param controller_name: name of the controller like nvme0
-    :param ns_id: ID of namespace for which we need the status
+    Tries ``nvme show-topology /dev/<controller_name>`` first; on error
+    or no match falls back to ``nvme show-topology -o json``
+    (whole-system), locating via ``NSID`` and ``Controller.Name``
+    (multi-path safe, e.g. ``nvme0``/``nvme3`` serving ``nvme3n1``).
 
-    :rtype: list
+    :param controller_name: name of the controller, e.g. ``nvme0``
+    :param ns_id: NSID of the namespace whose status is required (int)
+
+    :rtype: list  -- ``[State, ANAState]`` for the matching path, or ``[]``
     """
     stat = []
+
     cmd = f"nvme show-topology /dev/{controller_name} -o json"
     data = process.run(cmd, ignore_status=True, sudo=True, shell=True).stdout_text
-    json_data = json.loads(data)
-    for data in json_data:
-        for subsystem in data["Subsystems"]:
-            for namespace in subsystem["Namespaces"]:
-                nsid = namespace["NSID"]
-                for paths in namespace["Paths"]:
-                    if nsid == ns_id and paths["Name"] == controller_name:
-                        stat.extend([paths["State"], paths["ANAState"]])
+    try:
+        json_data = json.loads(data)
+    except json.JSONDecodeError:
+        json_data = None
+
+    for name, state, ana_state in _iter_topology_paths(json_data, ns_id):
+        if name == controller_name:
+            stat.extend([state, ana_state])
+    if stat:
+        return stat
+
+    LOGGER.debug(
+        "get_ns_status: primary show-topology for %s failed or returned no "
+        "match; retrying with whole-system show-topology",
+        controller_name,
+    )
+    cmd = "nvme show-topology -o json"
+    data = process.run(cmd, ignore_status=True, sudo=True, shell=True).stdout_text
+    try:
+        json_data = json.loads(data)
+    except json.JSONDecodeError:
+        LOGGER.warning(
+            "get_ns_status: could not parse whole-system show-topology output"
+        )
+        return stat
+
+    for name, state, ana_state in _iter_topology_paths(json_data, ns_id):
+        if name == controller_name:
+            stat.extend([state, ana_state])
+
     return stat
 
 

--- a/docs/source/releases/next.rst
+++ b/docs/source/releases/next.rst
@@ -23,6 +23,12 @@ Bug Fixes
 
 * The Podman spawner now resolves the default ``podman`` binary through
   ``PATH``, supporting installations outside ``/usr/bin``.
+* :func:`avocado.utils.nvme.get_ns_status` now handles nvme-cli builds
+  that reject a controller node argument to ``nvme show-topology``, and
+  correctly resolves namespace status for peer controllers in multi-path
+  subsystems (e.g. ``nvme0`` and ``nvme3`` both serving ``nvme3n1``).
+  A whole-system ``nvme show-topology -o json`` fallback is used when
+  the controller-addressed form fails or yields no match.
 
 Internal changes
 ================

--- a/selftests/check.py
+++ b/selftests/check.py
@@ -127,7 +127,7 @@ TEST_SIZE = {
     "job-api-check-tmp-directory-exists": 1,
     "nrunner-interface": 90,
     "nrunner-requirement": 28,
-    "unit": 1028,
+    "unit": 1046,
     "jobs": 11,
     "functional-parallel": 368,
     "functional-serial": 7,

--- a/selftests/unit/utils/nvme.py
+++ b/selftests/unit/utils/nvme.py
@@ -1,0 +1,381 @@
+import json
+import unittest
+import unittest.mock
+
+from avocado.utils import nvme, process
+
+# ---------------------------------------------------------------------------
+# JSON topology fixtures
+# ---------------------------------------------------------------------------
+
+# Targeted-controller schema: Name and State reside directly on Path.
+_TOPOLOGY_TARGETED = [
+    {
+        "Subsystems": [
+            {
+                "Namespaces": [
+                    {
+                        "NSID": 1,
+                        "Paths": [
+                            {
+                                "Name": "nvme0",
+                                "State": "live",
+                                "ANAState": "optimized",
+                                "Controller": [],
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+]
+
+# Whole-system schema: Name and State are nested under Controller[].
+_TOPOLOGY_WHOLE_SYSTEM = [
+    {
+        "Subsystems": [
+            {
+                "Namespaces": [
+                    {
+                        "NSID": 1,
+                        "Paths": [
+                            {
+                                "ANAState": "optimized",
+                                "Controller": [
+                                    {"Name": "nvme0", "State": "live"},
+                                    {"Name": "nvme3", "State": "live"},
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+]
+
+# Error payload returned by some nvme-cli builds for a targeted query.
+_ERROR_PAYLOAD = {"error": "Invalid device name"}
+
+
+def _make_run_result(stdout_text, exit_status=0):
+    """Return a minimal process.CmdResult mock for process.run()."""
+    result = process.CmdResult(command="nvme ...", stdout=stdout_text.encode())
+    result.exit_status = exit_status
+    return result
+
+
+# ===========================================================================
+# _iter_topology_paths() tests
+# ===========================================================================
+
+
+class IterTopologyPathsTest(unittest.TestCase):
+    """Tests for _iter_topology_paths() covering both JSON schemas."""
+
+    # --- Guard-clause: non-list input ---
+
+    def test_none_input_yields_nothing(self):
+        self.assertEqual(list(nvme._iter_topology_paths(None, 1)), [])
+
+    def test_dict_input_yields_nothing(self):
+        self.assertEqual(list(nvme._iter_topology_paths({}, 1)), [])
+
+    def test_empty_list_yields_nothing(self):
+        self.assertEqual(list(nvme._iter_topology_paths([], 1)), [])
+
+    # --- Targeted schema (Name/State on Path directly) ---
+
+    def test_targeted_schema_returns_name_state_ana_state(self):
+        results = list(nvme._iter_topology_paths(_TOPOLOGY_TARGETED, 1))
+        self.assertEqual(len(results), 1)
+        name, state, ana_state = results[0]
+        self.assertEqual(name, "nvme0")
+        self.assertEqual(state, "live")
+        self.assertEqual(ana_state, "optimized")
+
+    # --- Whole-system schema (Name/State under Controller[]) ---
+
+    def test_whole_system_schema_yields_one_tuple_per_controller(self):
+        results = list(nvme._iter_topology_paths(_TOPOLOGY_WHOLE_SYSTEM, 1))
+        self.assertEqual(len(results), 2)
+        names = [r[0] for r in results]
+        self.assertIn("nvme0", names)
+        self.assertIn("nvme3", names)
+        # ANAState from the Path is propagated to every Controller entry.
+        for _, _, ana_state in results:
+            self.assertEqual(ana_state, "optimized")
+
+    # --- NSID filter ---
+
+    def test_nsid_filter_skips_non_matching_namespaces(self):
+        """Only paths for the requested NSID are yielded."""
+        topology = [
+            {
+                "Subsystems": [
+                    {
+                        "Namespaces": [
+                            {
+                                "NSID": 1,
+                                "Paths": [
+                                    {
+                                        "Name": "nvme0",
+                                        "State": "live",
+                                        "ANAState": "optimized",
+                                        "Controller": [],
+                                    }
+                                ],
+                            },
+                            {
+                                "NSID": 2,
+                                "Paths": [
+                                    {
+                                        "Name": "nvme0",
+                                        "State": "dead",
+                                        "ANAState": "non-optimized",
+                                        "Controller": [],
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+        ]
+        results_ns1 = list(nvme._iter_topology_paths(topology, 1))
+        self.assertEqual(len(results_ns1), 1)
+        self.assertEqual(results_ns1[0][1], "live")
+
+        results_ns2 = list(nvme._iter_topology_paths(topology, 2))
+        self.assertEqual(len(results_ns2), 1)
+        self.assertEqual(results_ns2[0][1], "dead")
+
+    def test_unknown_nsid_yields_nothing(self):
+        results = list(nvme._iter_topology_paths(_TOPOLOGY_TARGETED, 99))
+        self.assertEqual(results, [])
+
+    # --- Missing keys produce None, not KeyError ---
+
+    def test_missing_name_state_keys_produce_none(self):
+        topology = [
+            {
+                "Subsystems": [
+                    {
+                        "Namespaces": [
+                            {
+                                "NSID": 1,
+                                "Paths": [{"Controller": []}],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        results = list(nvme._iter_topology_paths(topology, 1))
+        self.assertEqual(len(results), 1)
+        name, state, ana_state = results[0]
+        self.assertIsNone(name)
+        self.assertIsNone(state)
+        self.assertIsNone(ana_state)
+
+
+# ===========================================================================
+# get_ns_status() tests
+# ===========================================================================
+
+
+class GetNsStatusTest(unittest.TestCase):
+    """Tests for the two-stage get_ns_status() function."""
+
+    # --- Primary path succeeds (targeted schema) -------------------------
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_primary_targeted_schema_returns_state(self, mock_run):
+        """Primary path with targeted schema returns [State, ANAState],
+        no fallback."""
+        mock_run.return_value = _make_run_result(json.dumps(_TOPOLOGY_TARGETED))
+        result = nvme.get_ns_status("nvme0", 1)
+        self.assertEqual(result, ["live", "optimized"])
+        self.assertEqual(mock_run.call_count, 1)
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_primary_whole_system_schema_returns_state(self, mock_run):
+        """Primary path with Controller[] schema returns correct state."""
+        mock_run.return_value = _make_run_result(json.dumps(_TOPOLOGY_WHOLE_SYSTEM))
+        result = nvme.get_ns_status("nvme0", 1)
+        self.assertEqual(result, ["live", "optimized"])
+        self.assertEqual(mock_run.call_count, 1)
+
+    # --- Primary path returns error payload → fallback -------------------
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_error_payload_triggers_fallback(self, mock_run):
+        """
+        {"error": ...} is valid JSON but not a list, so _iter_topology_paths()
+        yields nothing; fallback must be invoked.
+        """
+        mock_run.side_effect = [
+            _make_run_result(json.dumps(_ERROR_PAYLOAD)),
+            _make_run_result(json.dumps(_TOPOLOGY_TARGETED)),
+        ]
+        result = nvme.get_ns_status("nvme0", 1)
+        self.assertEqual(result, ["live", "optimized"])
+        self.assertEqual(mock_run.call_count, 2)
+
+    # --- Primary path returns invalid JSON → fallback --------------------
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_primary_json_decode_error_triggers_fallback(self, mock_run):
+        mock_run.side_effect = [
+            _make_run_result("not json at all"),
+            _make_run_result(json.dumps(_TOPOLOGY_TARGETED)),
+        ]
+        result = nvme.get_ns_status("nvme0", 1)
+        self.assertEqual(result, ["live", "optimized"])
+        self.assertEqual(mock_run.call_count, 2)
+
+    # --- Primary has no match for controller name → fallback -------------
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_primary_controller_name_mismatch_triggers_fallback(self, mock_run):
+        """
+        Primary topology only contains 'nvme3'; querying for 'nvme0' finds no
+        match and must fall through to the whole-system fallback.
+        """
+        primary_wrong_ctrl = [
+            {
+                "Subsystems": [
+                    {
+                        "Namespaces": [
+                            {
+                                "NSID": 1,
+                                "Paths": [
+                                    {
+                                        "Name": "nvme3",
+                                        "State": "live",
+                                        "ANAState": "optimized",
+                                        "Controller": [],
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        fallback = [
+            {
+                "Subsystems": [
+                    {
+                        "Namespaces": [
+                            {
+                                "NSID": 1,
+                                "Paths": [
+                                    {
+                                        "Name": "nvme0",
+                                        "State": "live",
+                                        "ANAState": "inaccessible",
+                                        "Controller": [],
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        mock_run.side_effect = [
+            _make_run_result(json.dumps(primary_wrong_ctrl)),
+            _make_run_result(json.dumps(fallback)),
+        ]
+        result = nvme.get_ns_status("nvme0", 1)
+        self.assertEqual(result, ["live", "inaccessible"])
+        self.assertEqual(mock_run.call_count, 2)
+
+    # --- Multi-path: nvme0 + nvme3 share a namespace ---------------------
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_multipath_nvme3_found_via_whole_system_fallback(self, mock_run):
+        """
+        In a multi-path subsystem (nvme0 + nvme3 share NSID 1), querying for
+        nvme3 finds its entry in the whole-system fallback topology.
+        """
+        mock_run.side_effect = [
+            _make_run_result(json.dumps(_ERROR_PAYLOAD)),
+            _make_run_result(json.dumps(_TOPOLOGY_WHOLE_SYSTEM)),
+        ]
+        result = nvme.get_ns_status("nvme3", 1)
+        self.assertEqual(result, ["live", "optimized"])
+        self.assertEqual(mock_run.call_count, 2)
+
+    # --- Both paths fail → empty list ------------------------------------
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_both_paths_invalid_json_returns_empty_list(self, mock_run):
+        """If both primary and fallback return unparsable output,
+        [] is returned."""
+        mock_run.side_effect = [
+            _make_run_result("bad"),
+            _make_run_result("also bad"),
+        ]
+        result = nvme.get_ns_status("nvme0", 1)
+        self.assertEqual(result, [])
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_nsid_absent_in_fallback_returns_empty_list(self, mock_run):
+        """Fallback topology has no matching NSID → empty list returned."""
+        no_match = [
+            {
+                "Subsystems": [
+                    {
+                        "Namespaces": [
+                            {
+                                "NSID": 99,
+                                "Paths": [
+                                    {
+                                        "Name": "nvme0",
+                                        "State": "live",
+                                        "ANAState": "optimized",
+                                        "Controller": [],
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        mock_run.side_effect = [
+            _make_run_result("bad json"),
+            _make_run_result(json.dumps(no_match)),
+        ]
+        result = nvme.get_ns_status("nvme0", 1)
+        self.assertEqual(result, [])
+
+    # --- Command construction checks -------------------------------------
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_primary_command_targets_controller_device(self, mock_run):
+        """Primary command must include /dev/<controller_name>."""
+        mock_run.return_value = _make_run_result(json.dumps(_TOPOLOGY_TARGETED))
+        nvme.get_ns_status("nvme0", 1)
+        primary_cmd = mock_run.call_args_list[0][0][0]
+        self.assertIn("/dev/nvme0", primary_cmd)
+        self.assertIn("show-topology", primary_cmd)
+
+    @unittest.mock.patch("avocado.utils.nvme.process.run")
+    def test_fallback_command_omits_device_path(self, mock_run):
+        """Fallback (whole-system) command must not include /dev/."""
+        mock_run.side_effect = [
+            _make_run_result("invalid"),
+            _make_run_result(json.dumps(_TOPOLOGY_TARGETED)),
+        ]
+        nvme.get_ns_status("nvme0", 1)
+        fallback_cmd = mock_run.call_args_list[1][0][0]
+        self.assertNotIn("/dev/", fallback_cmd)
+        self.assertIn("show-topology", fallback_cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The 'nvme show-topology /dev/<controller>' form fails on some nvme-cli builds, returning {"error": "Invalid device name"} instead of a valid JSON topology. Additionally, in multi-path subsystems where two controllers (e.g. nvme0 and nvme3) share a namespace (e.g. nvme3n1), the namespace block device is named after only one of the controllers, making a namespace name constructed from controller_name unreliable.

Enhance get_ns_status with a two-stage approach:

Primary path (unchanged behaviour):
  nvme show-topology /dev/<controller_name> -o json
  Parses the original JSON structure where paths["Name"] matches
  the controller name. Returns immediately on success.

Fallback path (new):
  nvme show-topology -o json  (whole-system, no device argument)
  Triggered when the primary path returns an error payload (dict
  instead of list), raises JSONDecodeError, or yields no match.
  Locates the correct path by matching NSID and Controller.Name
  inside the Paths[].Controller[] array, which is unambiguous
  across multi-controller subsystems and avoids any namespace
  device name construction.

Both paths return [State, ANAState] preserving the existing API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NVMe namespace status detection for multipath configurations, including peer controllers and nested topology data.
  - Added a whole-system topology fallback when controller-specific queries fail or return no matching namespace.
  - Improved handling of malformed, incomplete, or unavailable topology data, returning an empty result when fallback data is invalid.
  - Added support for NVMe CLI versions that reject controller-addressed topology queries.

- **Documentation**
  - Updated release notes to document the improved NVMe namespace status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->