### PR TITLE
Reduce races from a few flaky unit tests

### DIFF
--- a/selftests/functional/job_timeout.py
+++ b/selftests/functional/job_timeout.py
@@ -139,9 +139,10 @@ class JobTimeOutTest(TestCaseTmpDir):
             )
 
     def test_sleep_short_timeout(self):
+        # Keep passtest queued so the short job timeout cannot interrupt its setup.
         cmd_line = (
             f"{AVOCADO} run --job-results-dir {self.tmpdir.name} "
-            f"--disable-sysinfo "
+            f"--disable-sysinfo --max-parallel-tasks=1 "
             f"--job-timeout=1 {self.script_long.path} "
             f"examples/tests/passtest.py"
         )

--- a/selftests/functional/utils/wait.py
+++ b/selftests/functional/utils/wait.py
@@ -41,13 +41,14 @@ class WaitForFunctionalTest(TestCaseTmpDir):
         filepath = os.path.join(self.tmpdir.name, "nonexistent.txt")
 
         # Wait for a file that will never be created
-        start = time.time()
+        start = time.monotonic()
         result = wait.wait_for(lambda: os.path.exists(filepath), timeout=0.5, step=0.1)
-        elapsed = time.time() - start
+        elapsed = time.monotonic() - start
 
         self.assertIsNone(result)
         self.assertGreaterEqual(elapsed, 0.5)
-        self.assertLess(elapsed, 0.7)
+        # Allow scheduling delays on busy CI hosts
+        self.assertLess(elapsed, 1.5)
 
 
 if __name__ == "__main__":

--- a/selftests/unit/utils/wait.py
+++ b/selftests/unit/utils/wait.py
@@ -217,13 +217,22 @@ class WaitForTest(unittest.TestCase):
         self.assertTrue(result)
 
     def test_timing_precision(self):
-        """Test wait_for timeout is reasonably accurate."""
+        """Test wait_for timeout is accurate with a controlled clock."""
         func = mock.Mock(return_value=False)
         timeout_val = 1.0
-        start = time.time()
-        wait.wait_for(func, timeout=timeout_val, step=0.1)
-        elapsed = time.time() - start
-        # Should be close to timeout (within 20% tolerance for system variance)
+        with mock.patch("avocado.utils.wait.time") as clock:
+            clock.monotonic.return_value = 0.0
+
+            def sleep(seconds):
+                clock.monotonic.return_value += seconds
+
+            clock.sleep.side_effect = sleep
+            start = clock.monotonic()
+            result = wait.wait_for(func, timeout=timeout_val, step=0.1)
+            elapsed = clock.monotonic() - start
+
+        self.assertIsNone(result)
+        # Allow polling overshoot and floating-point rounding
         self.assertGreaterEqual(elapsed, timeout_val)
         self.assertLess(elapsed, timeout_val * 1.2)
 


### PR DESCRIPTION
Apply three targeted changes in avocado:
- use a simulated clock, removing scheduler variability in a flaky unit test for the wait utility
- measure monotonic time and allow one second of scheduling overhead in a functional test for the wait utility
- run sequentially, preventing the deadline from interrupting the passing test’s startup in job timeout functional test

The last of the three is indicated by 9 = 8 | 1 status meaning both the job was interrupted and a test failed or errored (passtest ERROR). If we run in serial mode the deadline interrupts while passtest is still queued and is thus subsequently skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved timeout test reliability under parallel execution and busy CI conditions.
  - Made timing-related tests deterministic by using a controlled monotonic clock.
  - Added verification that timeout waits return correctly without exceeding the permitted delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->